### PR TITLE
(fix(junk-potential)): persist selected folder to JunkPotential

### DIFF
--- a/TaskMaster.Test/AppGlobals/AppOlObjectsTests.cs
+++ b/TaskMaster.Test/AppGlobals/AppOlObjectsTests.cs
@@ -81,5 +81,48 @@ namespace TaskMaster.Test.AppGlobals
             result.Should().BeNull();
             mockRepository.VerifyAll();
         }
+
+        [TestMethod]
+        public void ReadJunkPotentialSetting_ReturnsJunkPotentialValue()
+        {
+            // Arrange
+            var original = Properties.Settings.Default.JunkPotential;
+            var expected = "Inbox\\Junk Suspects SB";
+            Properties.Settings.Default.JunkPotential = expected;
+
+            try
+            {
+                // Act
+                var result = AppOlObjects.ReadJunkPotentialSetting();
+
+                // Assert
+                result.Should().Be(expected);
+            }
+            finally
+            {
+                Properties.Settings.Default.JunkPotential = original;
+            }
+        }
+
+        [TestMethod]
+        public void WriteJunkPotentialSetting_UpdatesJunkPotentialValue()
+        {
+            // Arrange
+            var original = Properties.Settings.Default.JunkPotential;
+            var expected = "Inbox\\Junk Suspects SB";
+
+            try
+            {
+                // Act
+                AppOlObjects.WriteJunkPotentialSetting(expected);
+
+                // Assert
+                Properties.Settings.Default.JunkPotential.Should().Be(expected);
+            }
+            finally
+            {
+                Properties.Settings.Default.JunkPotential = original;
+            }
+        }
     }
 }

--- a/TaskMaster/AppGlobals/AppOlObjects.cs
+++ b/TaskMaster/AppGlobals/AppOlObjects.cs
@@ -173,10 +173,12 @@ namespace TaskMaster
 
         private Folder _junkPotential;
         public Folder JunkPotential => Initializer.GetOrLoad(ref _junkPotential, LoadJunkPotential);
+        internal static string ReadJunkPotentialSetting() => Properties.Settings.Default.JunkPotential;
+        internal static void WriteJunkPotentialSetting(string relativePath) => Properties.Settings.Default.JunkPotential = relativePath;
         internal Folder LoadJunkPotential()
         {
             var root = new FolderTree(Root).Roots.FirstOrDefault();
-            var folderPath = Properties.Settings.Default.JunkPotential;
+            var folderPath = ReadJunkPotentialSetting();
             if (folderPath.IsNullOrEmpty()) { return null; }
             var sequence = new Queue<string>(folderPath.Split('\\'));
 
@@ -188,7 +190,7 @@ namespace TaskMaster
                 folder = NamespaceMAPI.PickFolder() as Folder;
                 if (folder is null) { return null; }
                 var wrapper = new FolderWrapper(folder, Root);
-                Properties.Settings.Default.OlJunkPotential = wrapper.RelativePath;
+                WriteJunkPotentialSetting(wrapper.RelativePath);
                 Properties.Settings.Default.Save();
             }
             return folder;

--- a/TaskMaster/Properties/Settings.settings
+++ b/TaskMaster/Properties/Settings.settings
@@ -155,9 +155,6 @@
     <Setting Name="EventsHooked" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
-    <Setting Name="OlJunkPotential" Type="System.String" Scope="User">
-      <Value Profile="(Default)">Junk Suspects SB</Value>
-    </Setting>
     <Setting Name="OlJunkCertain" Type="System.String" Scope="User">
       <Value Profile="(Default)">Junk E-Mail SB</Value>
     </Setting>

--- a/TaskMaster/app.config
+++ b/TaskMaster/app.config
@@ -363,9 +363,6 @@
       <setting name="EventsHooked" serializeAs="String">
         <value>True</value>
       </setting>
-      <setting name="OlJunkPotential" serializeAs="String">
-        <value>Junk Suspects SB</value>
-      </setting>
       <setting name="OlJunkCertain" serializeAs="String">
         <value>Junk E-Mail SB</value>
       </setting>

--- a/change-plan.md
+++ b/change-plan.md
@@ -3,6 +3,9 @@
 ## Objective
 Restore solution build after the recent NuGet package upgrades by identifying and fixing the current compile errors with minimal code changes.
 
+## Current Task
+Redirect legacy `OlJunkPotential` setting usage to `JunkPotential` so the add-in loads and saves the same folder path setting.
+
 ## Assumptions
 - The current solution build failures are caused by API or behavioral changes introduced by upgraded packages.
 - The goal is to get the solution building again without unrelated refactoring.
@@ -17,10 +20,13 @@ Restore solution build after the recent NuGet package upgrades by identifying an
 ## Status
 - [x] Plan created
 - [x] Build errors captured
-- [ ] Fixes applied
-- [ ] Solution build passes
-- [ ] Relevant tests run
+- [x] Fixes applied
+- [x] Solution build passes
+- [x] Relevant tests run
 
 ## Current Findings
 - Current workspace repro after unloading projects shows the active build failures are limited to MSTest v4 removing `ExpectedException` in `UtilitiesCS.Test`.
 - The affected files are `UtilitiesCS.Test/EmailIntelligence/Bayesian/BayesianClassifierSharedTests.cs` and `UtilitiesCS.Test/NewtonsoftHelpers/FilePathHelperConverterTests.cs`.
+- `TaskMaster/AppGlobals/AppOlObjects.cs` loads `JunkPotential` but persists the manually selected folder to legacy `OlJunkPotential`, which can cause the prompt to reappear on next startup.
+- `TaskMaster/Properties/Settings.settings` and `TaskMaster/app.config` no longer define `OlJunkPotential`; the only remaining source hit is the generated `TaskMaster/Properties/Settings.Designer.cs` accessor, which requires regeneration of the settings designer rather than a manual edit.
+- Validation results for this task: both solution build commands passed and the focused `AppOlObjects` regression tests passed. The repo-required `dotnet format TaskMaster.sln` command still fails in this environment during MSBuild workspace initialization before formatting begins.


### PR DESCRIPTION
- route junk-potential setting reads and writes through the current JunkPotential key in AppOlObjects
- add regression tests covering junk-potential setting reads and updates
- remove legacy OlJunkPotential setting entries and record validation status in the change plan