### PR TITLE
(fix(koverage)): normalize Cobertura coverage output

### DIFF
--- a/scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1
+++ b/scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1
@@ -3,21 +3,37 @@ Set-StrictMode -Version Latest
 function Get-KoverageProjectAllowlist {
     [CmdletBinding()]
     [OutputType([System.Array])]
-    param()
-
-    @(
-        'QuickFiler', 'QuickFiler.Test',
-        'SVGControl', 'SVGControl.Test',
-        'Tags', 'Tags.Test',
-        'TaskMaster', 'TaskMaster.Test',
-        'TaskTree',
-        'TaskVisualization', 'TaskVisualization.Test',
-        'TaskVisualizer',
-        'ToDoModel', 'ToDoModel.Test',
-        'UtilitiesCS', 'UtilitiesCS.Test',
-        'UtilitiesSwordfish', 'UtilitiesSwordfish.Test',
-        'VBFunctions', 'VBFunctions.Test'
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
     )
+
+    $projectFiles = Get-ChildItem -Path $RepoRoot -Recurse -File -Include '*.csproj', '*.vbproj', '*.fsproj' |
+        Where-Object {
+            $_.FullName -notmatch '\\bin\\' -and
+            $_.FullName -notmatch '\\obj\\' -and
+            $_.FullName -notmatch '\\packages\\'
+        }
+
+    $projectNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+    foreach ($projectFile in $projectFiles) {
+        $projectContent = Get-Content -Path $projectFile.FullName -Raw -Encoding UTF8
+        $assemblyNameMatch = [regex]::Match(
+            $projectContent,
+            '<AssemblyName>\s*(?<name>[^<]+?)\s*</AssemblyName>',
+            [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+        )
+
+        if ($assemblyNameMatch.Success) {
+            $null = $projectNames.Add($assemblyNameMatch.Groups['name'].Value.Trim())
+            continue
+        }
+
+        $null = $projectNames.Add([System.IO.Path]::GetFileNameWithoutExtension($projectFile.Name))
+    }
+
+    $projectNames | Sort-Object
 }
 
 function ConvertTo-KoverageRelativePath {
@@ -104,6 +120,154 @@ function Get-CoberturaCoverageSummary {
     }
 }
 
+function Get-CoberturaLineConditionCoverageParts {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Xml.XmlElement]$LineNode
+    )
+
+    if ($LineNode.HasAttribute('condition-coverage') -and $LineNode.'condition-coverage' -match '\(([0-9]+)/([0-9]+)\)') {
+        return [pscustomobject]@{
+            Covered = [int]$Matches[1]
+            Total   = [int]$Matches[2]
+        }
+    }
+
+    return [pscustomobject]@{
+        Covered = 0
+        Total   = 0
+    }
+}
+
+function Merge-CoberturaClassesByFilename {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [xml]$XmlDocument
+    )
+
+    foreach ($packageNode in $XmlDocument.SelectNodes('//package')) {
+        $classesNode = $packageNode.SelectSingleNode('./classes')
+        if (-not $classesNode) {
+            continue
+        }
+
+        $filenameGroups = @{}
+        foreach ($classNode in @($classesNode.SelectNodes('./class[@filename]'))) {
+            if (-not $filenameGroups.Contains($classNode.filename)) {
+                $filenameGroups[$classNode.filename] = [System.Collections.ArrayList]::new()
+            }
+
+            [void]$filenameGroups[$classNode.filename].Add($classNode)
+        }
+
+        foreach ($filename in $filenameGroups.Keys) {
+            $group = @($filenameGroups[$filename])
+            if ($group.Count -le 1) {
+                continue
+            }
+
+            $primaryNode = $group | Where-Object { $_.name -notmatch '<' } | Select-Object -First 1
+            if (-not $primaryNode) {
+                $primaryNode = $group[0]
+            }
+
+            $mergedClassNode = $primaryNode.CloneNode($true)
+
+            $methodsNode = $mergedClassNode.SelectSingleNode('./methods')
+            if (-not $methodsNode) {
+                $methodsNode = $XmlDocument.CreateElement('methods')
+                [void]$mergedClassNode.AppendChild($methodsNode)
+            }
+
+            $linesNode = $mergedClassNode.SelectSingleNode('./lines')
+            if ($linesNode) {
+                $linesNode.RemoveAll()
+            }
+            else {
+                $linesNode = $XmlDocument.CreateElement('lines')
+                [void]$mergedClassNode.AppendChild($linesNode)
+            }
+
+            $lineMap = @{}
+            foreach ($classNode in $group) {
+                foreach ($lineNode in @($classNode.SelectNodes('./lines/line'))) {
+                    $lineNumber = [int]$lineNode.number
+                    $candidateCoverage = Get-CoberturaLineConditionCoverageParts -LineNode $lineNode
+
+                    if (-not $lineMap.Contains($lineNumber)) {
+                        $lineMap[$lineNumber] = [pscustomobject]@{
+                            Node     = $lineNode.CloneNode($true)
+                            Covered  = $candidateCoverage.Covered
+                            Total    = $candidateCoverage.Total
+                        }
+                        continue
+                    }
+
+                    $existing = $lineMap[$lineNumber]
+                    $existingNode = $existing.Node
+                    $existingNode.SetAttribute('hits', [string]([math]::Max([int]$existingNode.GetAttribute('hits'), [int]$lineNode.GetAttribute('hits'))))
+
+                    if ($existingNode.GetAttribute('branch') -ne 'True' -and $lineNode.GetAttribute('branch') -eq 'True') {
+                        $existingNode.SetAttribute('branch', 'True')
+                    }
+
+                    if (
+                        $candidateCoverage.Total -gt $existing.Total -or
+                        ($candidateCoverage.Total -eq $existing.Total -and $candidateCoverage.Covered -gt $existing.Covered)
+                    ) {
+                        $existing.Covered = $candidateCoverage.Covered
+                        $existing.Total = $candidateCoverage.Total
+
+                        if ($lineNode.HasAttribute('condition-coverage')) {
+                            $existingNode.SetAttribute('condition-coverage', $lineNode.GetAttribute('condition-coverage'))
+                        }
+                        elseif ($existingNode.HasAttribute('condition-coverage')) {
+                            $existingNode.RemoveAttribute('condition-coverage')
+                        }
+
+                        foreach ($conditionChild in @($existingNode.SelectNodes('./conditions'))) {
+                            [void]$existingNode.RemoveChild($conditionChild)
+                        }
+
+                        foreach ($conditionChild in @($lineNode.SelectNodes('./conditions'))) {
+                            [void]$existingNode.AppendChild($conditionChild.CloneNode($true))
+                        }
+                    }
+                }
+            }
+
+            $sortedLineNumbers = $lineMap.Keys | Sort-Object
+            foreach ($lineNumber in $sortedLineNumbers) {
+                [void]$linesNode.AppendChild($lineMap[$lineNumber].Node)
+            }
+
+            $classSummaryXml = [xml]"<coverage><packages><package><classes /></package></packages></coverage>"
+            $classSummaryClasses = $classSummaryXml.SelectSingleNode('//classes')
+            [void]$classSummaryClasses.AppendChild($classSummaryXml.ImportNode($mergedClassNode, $true))
+            $classSummary = Get-CoberturaCoverageSummary -XmlDocument $classSummaryXml
+
+            $mergedClassNode.SetAttribute('line-rate', $classSummary.LineRate)
+            $mergedClassNode.SetAttribute('branch-rate', $classSummary.BranchRate)
+            $mergedClassNode.SetAttribute('complexity', [string](
+                ($group | ForEach-Object {
+                    if ($_.complexity) { [double]$_.complexity } else { 0d }
+                } | Measure-Object -Sum).Sum
+            ))
+
+            [void]$classesNode.ReplaceChild($mergedClassNode, $primaryNode)
+
+            foreach ($classNode in $group) {
+                if ($classNode -ne $primaryNode) {
+                    [void]$classesNode.RemoveChild($classNode)
+                }
+            }
+        }
+    }
+}
+
 function ConvertTo-KoverageCoberturaXml {
     [CmdletBinding()]
     [OutputType([string])]
@@ -138,6 +302,8 @@ function ConvertTo-KoverageCoberturaXml {
         $classNode.filename = ConvertTo-KoverageRelativePath -Path $classNode.filename -RepoRoot $RepoRoot -PathSeparator $PathSeparator
     }
 
+    Merge-CoberturaClassesByFilename -XmlDocument $xml
+
     if (-not $xml.SelectSingleNode('//sources')) {
         $sourcesNode = $xml.CreateElement('sources')
         $sourceNode = $xml.CreateElement('source')
@@ -150,12 +316,12 @@ function ConvertTo-KoverageCoberturaXml {
     }
 
     $coverageSummary = Get-CoberturaCoverageSummary -XmlDocument $xml
-    $xml.coverage.'line-rate' = $coverageSummary.LineRate
-    $xml.coverage.'branch-rate' = $coverageSummary.BranchRate
-    $xml.coverage.'lines-covered' = $coverageSummary.LinesCovered
-    $xml.coverage.'lines-valid' = $coverageSummary.LinesValid
-    $xml.coverage.'branches-covered' = $coverageSummary.BranchesCovered
-    $xml.coverage.'branches-valid' = $coverageSummary.BranchesValid
+    $xml.coverage.SetAttribute('line-rate', $coverageSummary.LineRate)
+    $xml.coverage.SetAttribute('branch-rate', $coverageSummary.BranchRate)
+    $xml.coverage.SetAttribute('lines-covered', $coverageSummary.LinesCovered)
+    $xml.coverage.SetAttribute('lines-valid', $coverageSummary.LinesValid)
+    $xml.coverage.SetAttribute('branches-covered', $coverageSummary.BranchesCovered)
+    $xml.coverage.SetAttribute('branches-valid', $coverageSummary.BranchesValid)
 
     $stringWriter = [System.IO.StringWriter]::new()
     $xmlWriter = [System.Xml.XmlTextWriter]::new($stringWriter)

--- a/tests/scripts/vscode/Invoke-MSTestWithCoverage.Helpers.Tests.ps1
+++ b/tests/scripts/vscode/Invoke-MSTestWithCoverage.Helpers.Tests.ps1
@@ -34,4 +34,48 @@ Describe 'ConvertTo-KoverageCoberturaXml' {
         $classNode.filename | Should -Not -Match '/'
         $sourceNode.InnerText | Should -Be '.'
     }
+
+    It 'merges duplicate class entries that point to the same source file' {
+        $inputXml = @'
+<?xml version="1.0" encoding="utf-8"?>
+<coverage line-rate="0" branch-rate="0" lines-covered="0" lines-valid="0" branches-covered="0" branches-valid="0">
+  <packages>
+    <package name="UtilitiesCS" line-rate="0" branch-rate="0" complexity="1">
+      <classes>
+        <class name="UtilitiesCS.MeetingItemHelper" filename="C:\repo\UtilitiesCS\OutlookObjects\AppointmentItem\MeetingItemHelper.cs" line-rate="0.5" branch-rate="0" complexity="2">
+          <methods />
+          <lines>
+            <line number="10" hits="1" branch="False" />
+            <line number="11" hits="0" branch="False" />
+          </lines>
+        </class>
+        <class name="UtilitiesCS.MeetingItemHelper.&lt;&gt;c" filename="C:\repo\UtilitiesCS\OutlookObjects\AppointmentItem\MeetingItemHelper.cs" line-rate="1" branch-rate="1" complexity="3">
+          <methods />
+          <lines>
+            <line number="11" hits="1" branch="False" />
+            <line number="12" hits="1" branch="True" condition-coverage="50% (1/2)">
+              <conditions>
+                <condition number="0" type="jump" coverage="50%" />
+              </conditions>
+            </line>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>
+'@
+
+        [xml]$resultXml = ConvertTo-KoverageCoberturaXml -XmlContent $inputXml -RepoRoot 'C:\repo' -PathSeparator '\'
+        $classNodes = @($resultXml.SelectNodes('//class[@filename="UtilitiesCS\OutlookObjects\AppointmentItem\MeetingItemHelper.cs"]'))
+        $line11 = $resultXml.SelectSingleNode('//class[@filename="UtilitiesCS\OutlookObjects\AppointmentItem\MeetingItemHelper.cs"]/lines/line[@number="11"]')
+        $line12 = $resultXml.SelectSingleNode('//class[@filename="UtilitiesCS\OutlookObjects\AppointmentItem\MeetingItemHelper.cs"]/lines/line[@number="12"]')
+
+        $classNodes.Count | Should -Be 1
+        $classNodes[0].name | Should -Be 'UtilitiesCS.MeetingItemHelper'
+        $classNodes[0].complexity | Should -Be '5'
+        $line11.hits | Should -Be '1'
+        $line12.branch | Should -Be 'True'
+        $line12.'condition-coverage' | Should -Be '50% (1/2)'
+    }
 }


### PR DESCRIPTION
- derive the Koverage project allowlist from repository project files instead of a hard-coded list
- merge duplicate Cobertura class entries that share a source filename so line and branch coverage are aggregated correctly
- add coverage-helper tests that verify duplicate class consolidation and preserved condition coverage