### PR TITLE
Make TaskMaster COM entry points synchronous in `AddInUtilities`

### DIFF
--- a/TaskMaster/AddInUtilities.cs
+++ b/TaskMaster/AddInUtilities.cs
@@ -11,8 +11,8 @@ namespace TaskMaster
     public interface IAddInUtilities
     {
         void MaximizeQuickFilerWindow();
-        Task LaunchQuickFilerAsync();
-        Task LaunchSortEmailAsync();
+        void LaunchQuickFiler();
+        void LaunchSortEmail();
         void LaunchFlagAsTask();
     }
 
@@ -39,12 +39,19 @@ namespace TaskMaster
             }
         }
 
-        public async Task LaunchQuickFilerAsync()
+        public void LaunchQuickFiler()
         {
             if (_globals is not null)
             {
-                await _ribbonController.LoadQuickFilerAsync();
-                //_ = _ribbonController.LoadQuickFilerAsync();
+                _ = _ribbonController.LoadQuickFilerAsync();
+            }
+        }
+
+        public void LaunchSortEmail()
+        {
+            if (_globals is not null)
+            {
+                _ = _ribbonController.SortEmailAsync();
             }
         }
 
@@ -53,22 +60,6 @@ namespace TaskMaster
             if (_globals is not null)
             {
                 _ribbonController.FlagAsTask();
-            }
-        }
-
-        public void LaunchSortEmail()
-        {
-            if (_globals is not null)
-            {
-                _ribbonController.SortEmail();
-            }
-        }
-
-        public async Task LaunchSortEmailAsync()
-        {
-            if (_globals is not null)
-            {
-                await _ribbonController.SortEmailAsync();
             }
         }
     }


### PR DESCRIPTION
Make TaskMaster COM entry points synchronous in `AddInUtilities`

## Summary

- Remove async behavior from COM-facing entry points in `TaskMaster/AddInUtilities.cs`.
- Keep the branch scoped to a single targeted C# file with a small net diff (`8` additions, `17` deletions).
- Address the branch’s stated fix from the commit subject: `fixed com entry points so that they are not async`.
- No test, tooling, documentation, or template changes are recorded in this PR context.

## Why

- This PR corrects COM entry-point behavior by removing async usage at that boundary in `TaskMaster/AddInUtilities.cs`.

## What Changed

- **Core behavior / architecture**
  - Updated `TaskMaster/AddInUtilities.cs` to make the affected COM entry points non-async.
  - Kept the change narrowly scoped to one file in the `TaskMaster` project.

- **Tooling / automation / CI / DevEx**
  - No tooling, automation, or CI changes are recorded in this PR context.

- **Tests**
  - No test file changes are recorded in this PR context.

- **Docs / templates / agents**
  - No documentation, template, or agent changes are recorded in this PR context.

## Architecture / How It Fits Together

- The only changed integration point in this branch is `TaskMaster/AddInUtilities.cs`.
- This PR adjusts the COM-facing entry-point boundary in that file so the affected entry points are synchronous rather than async.
- No other projects, helper libraries, or test assemblies are included in the recorded change range.

