### PR TITLE
Add Codex runtime support for repository skills, orchestration, and PR authoring

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,76 @@
+# Codex Skill Architecture
+
+## Purpose
+
+This directory is the canonical Codex runtime surface for repository-local skills.
+
+Codex-supported repository locations in this repo are:
+
+- `.agents/skills/<skill-name>/SKILL.md` for reusable workflow skills
+- `.codex/agents/*.toml` for subagent definitions
+- `.codex/prompts/*.md` for prompt entrypoints and lightweight workflow launchers
+
+The legacy GitHub Copilot ecosystem under `.github/skills` and `.github/agents` remains as historical source material during migration. New Codex-native runtime behavior should be authored in `.agents/skills` and consumed from `.codex/agents`.
+
+## Layering
+
+Design skills in layers so behavior is authored once and reused everywhere:
+
+1. Foundation skills
+   - Policy order
+   - Atomic plan contract
+   - Acceptance criteria tracking
+   - Evidence conventions
+   - Canonical-location audits
+
+2. Integration skills
+   - PR base resolution
+   - PR context artifact rules
+   - Feature-promotion lifecycle
+   - Remediation handoff
+   - Host-surface adapters
+
+3. Language routing and orchestration-state skills
+   - Change-budget routers
+   - Checkpoint and resume contracts
+
+4. Workflow skills
+   - `atomic-executor`
+   - `atomic-planner`
+   - `feature-review`
+
+5. Specialist support skills
+   - `commit-message-conventions`
+
+6. Subagents
+   - Keep `.codex/agents/*.toml` concise.
+   - Reference workflow and shared skills by name instead of embedding long duplicated instructions.
+
+## Anti-Duplication Rules
+
+1. If multiple workflows need the same rule, extract it into one shared skill.
+2. Workflow skills should name the shared skills they depend on rather than restating those blocks.
+3. Environment-specific repo automation should live in `repo-automation-adapter`, not in each workflow skill.
+4. Canonical paths should be defined in exactly one skill; other skills should reference that skill instead of repeating the path.
+5. If Codex already ships a suitable system skill, prefer a thin repo-local compatibility wrapper instead of re-implementing the same scaffolding.
+6. If an agent persona grows reusable decision rules or formatting rules, move those rules into a shared skill and keep the agent as a thin wrapper.
+
+## Migration Rules
+
+When migrating a Copilot artifact:
+
+1. If it defines reusable repository guidance, migrate it to `.agents/skills/<name>/SKILL.md`.
+2. If it defines a reusable agent persona or bounded delegation role, migrate it to `.codex/agents/<name>.toml`.
+3. If it is mainly a launch prompt or an orchestration shortcut, migrate it to `.codex/prompts/<name>.md`.
+4. Preserve stable names where possible so downstream handoffs remain readable and consistent.
+5. If a Copilot workflow relied on `drmCopilotExtension.*` commands or another host-specific surface, move that translation logic into `repo-automation-adapter` and keep the business workflow skill host-agnostic.
+
+## Future Migrations
+
+Use the system `$skill-creator` skill when scaffolding a new Codex skill, then apply the repository rules in this file:
+
+- place the runtime skill under `.agents/skills`
+- keep frontmatter minimal
+- make the description explicit about triggers
+- reference existing shared skills before creating a new one
+- add a new shared skill only when the behavior cannot be expressed as a composition of existing skills

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -38,6 +38,7 @@ Design skills in layers so behavior is authored once and reused everywhere:
    - `atomic-executor`
    - `atomic-planner`
    - `feature-review`
+   - `orchestrator-workflow`
 
 5. Specialist support skills
    - `commit-message-conventions`
@@ -54,6 +55,7 @@ Design skills in layers so behavior is authored once and reused everywhere:
 4. Canonical paths should be defined in exactly one skill; other skills should reference that skill instead of repeating the path.
 5. If Codex already ships a suitable system skill, prefer a thin repo-local compatibility wrapper instead of re-implementing the same scaffolding.
 6. If an agent persona grows reusable decision rules or formatting rules, move those rules into a shared skill and keep the agent as a thin wrapper.
+7. If a top-level workflow routes between multiple existing skills or subagents, capture that routing once in a shared workflow skill and keep the prompt or agent as a launcher.
 
 ## Migration Rules
 

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -42,6 +42,7 @@ Design skills in layers so behavior is authored once and reused everywhere:
 
 5. Specialist support skills
    - `commit-message-conventions`
+   - `pr-authoring`
 
 6. Subagents
    - Keep `.codex/agents/*.toml` concise.
@@ -51,7 +52,7 @@ Design skills in layers so behavior is authored once and reused everywhere:
 
 1. If multiple workflows need the same rule, extract it into one shared skill.
 2. Workflow skills should name the shared skills they depend on rather than restating those blocks.
-3. Environment-specific repo automation should live in `repo-automation-adapter`, not in each workflow skill.
+3. Environment-specific repo automation and its MCP dependency binding should live in `repo-automation-adapter`, not in each workflow skill.
 4. Canonical paths should be defined in exactly one skill; other skills should reference that skill instead of repeating the path.
 5. If Codex already ships a suitable system skill, prefer a thin repo-local compatibility wrapper instead of re-implementing the same scaffolding.
 6. If an agent persona grows reusable decision rules or formatting rules, move those rules into a shared skill and keep the agent as a thin wrapper.
@@ -65,7 +66,14 @@ When migrating a Copilot artifact:
 2. If it defines a reusable agent persona or bounded delegation role, migrate it to `.codex/agents/<name>.toml`.
 3. If it is mainly a launch prompt or an orchestration shortcut, migrate it to `.codex/prompts/<name>.md`.
 4. Preserve stable names where possible so downstream handoffs remain readable and consistent.
-5. If a Copilot workflow relied on `drmCopilotExtension.*` commands or another host-specific surface, move that translation logic into `repo-automation-adapter` and keep the business workflow skill host-agnostic.
+5. If a Copilot workflow relied on `drmCopilotExtension.*` commands or another host-specific surface, move that translation logic into `repo-automation-adapter`, target semantic MCP tools on server `drmCopilotExtension` when available, and keep the business workflow skill host-agnostic.
+
+## External Tool Bindings
+
+When a repository skill owns an external MCP dependency:
+
+- declare that dependency once in `agents/openai.yaml` beside the owning skill
+- keep downstream workflow skills dependent on the adapter skill, not on duplicated MCP binding metadata
 
 ## Future Migrations
 

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -29,6 +29,7 @@ Repository-local Codex skills live under `.agents/skills/<skill-name>/SKILL.md`.
   - `atomic-planner`
   - `atomic-executor`
   - `feature-review`
+  - `orchestrator-workflow`
 
 - Specialist support
   - `commit-message-conventions`
@@ -43,3 +44,4 @@ Repository-local Codex skills live under `.agents/skills/<skill-name>/SKILL.md`.
 3. Put host-specific repo automation rules in `repo-automation-adapter`.
 4. Keep names stable when migrating from the legacy Copilot ecosystem.
 5. When an agent needs reusable rules, extract them into a shared skill and keep the agent as a thin wrapper.
+6. Put top-level route selection and checkpoint rules in a shared workflow skill rather than duplicating them across prompts or agent personas.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -33,6 +33,7 @@ Repository-local Codex skills live under `.agents/skills/<skill-name>/SKILL.md`.
 
 - Specialist support
   - `commit-message-conventions`
+  - `pr-authoring`
 
 - Meta
   - `make-skill-template`
@@ -41,7 +42,8 @@ Repository-local Codex skills live under `.agents/skills/<skill-name>/SKILL.md`.
 
 1. Put shared rules in one skill only.
 2. Have workflow skills reference shared skills instead of copying their text.
-3. Put host-specific repo automation rules in `repo-automation-adapter`.
+3. Put host-specific repo automation rules and their MCP dependency binding in `repo-automation-adapter`.
 4. Keep names stable when migrating from the legacy Copilot ecosystem.
 5. When an agent needs reusable rules, extract them into a shared skill and keep the agent as a thin wrapper.
 6. Put top-level route selection and checkpoint rules in a shared workflow skill rather than duplicating them across prompts or agent personas.
+7. When a skill depends on an external MCP server, declare it in that skill's `agents/openai.yaml` instead of repeating the binding in each caller.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,45 @@
+# Codex Repository Skills
+
+Repository-local Codex skills live under `.agents/skills/<skill-name>/SKILL.md`.
+
+## Skill Groups
+
+- Foundation
+  - `policy-compliance-order`
+  - `atomic-plan-contract`
+  - `acceptance-criteria-tracking`
+  - `evidence-and-timestamp-conventions`
+  - `skill-canonical-location-audit`
+
+- Integration
+  - `repo-automation-adapter`
+  - `pr-base-branch-merge-base`
+  - `pr-context-artifacts`
+  - `feature-promotion-lifecycle`
+  - `policy-audit-template-usage`
+  - `remediation-handoff-atomic-planner`
+
+- Language routing and state
+  - `csharp-change-budget-router`
+  - `csharp-orchestration-state-machine`
+  - `powershell-change-budget-router`
+  - `powershell-orchestration-state-machine`
+
+- Workflow
+  - `atomic-planner`
+  - `atomic-executor`
+  - `feature-review`
+
+- Specialist support
+  - `commit-message-conventions`
+
+- Meta
+  - `make-skill-template`
+
+## Authoring Rules
+
+1. Put shared rules in one skill only.
+2. Have workflow skills reference shared skills instead of copying their text.
+3. Put host-specific repo automation rules in `repo-automation-adapter`.
+4. Keep names stable when migrating from the legacy Copilot ecosystem.
+5. When an agent needs reusable rules, extract them into a shared skill and keep the agent as a thin wrapper.

--- a/.agents/skills/acceptance-criteria-tracking/SKILL.md
+++ b/.agents/skills/acceptance-criteria-tracking/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: acceptance-criteria-tracking
+description: 'Track and check off acceptance criteria in requirement source files such as issue.md, spec.md, and user-story.md as work is delivered. Use when executing plans, reviewing features, or validating delivery.'
+---
+
+# Acceptance Criteria Tracking
+
+Shared protocol for identifying, tracking, and checking off acceptance criteria in their authoritative source files.
+
+## When to Use This Skill
+
+Use this skill when:
+- executing an atomic plan that satisfies acceptance criteria,
+- reviewing a feature branch and validating delivered behavior,
+- reconciling task completion with requirement documents.
+
+## AC Source Resolution
+
+Resolve authoritative acceptance-criteria sources from the persisted work-mode marker in `issue.md`:
+
+| Work Mode | AC Source File(s) |
+|---|---|
+| `minor-audit` | `issue.md` only |
+| `full-feature` | `spec.md` and `user-story.md` |
+| `full-bug` | `spec.md` only |
+| legacy `full` | normalize to `full-feature` |
+| missing / malformed | fail closed to `full-feature` |
+
+When multiple source files apply, track checkboxes in each applicable file independently.
+
+## Check-Off Rules
+
+1. Only mark an AC item complete after implementation and verification.
+2. Check off each item individually.
+3. Preserve the criterion text exactly; change only `- [ ]` to `- [x]`.
+4. Leave unmet items unchecked and document the gap elsewhere.
+5. Do not invent or add new acceptance criteria.
+
+## Completion Summary
+
+At the end of plan execution or feature review, report:
+
+```text
+### Acceptance Criteria Status
+- Source: <file path(s)>
+- Total AC items: <N>
+- Checked off (delivered): <M>
+- Remaining (unchecked): <N - M>
+- Items remaining: <list of unchecked criterion texts, if any>
+```

--- a/.agents/skills/atomic-executor/SKILL.md
+++ b/.agents/skills/atomic-executor/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: atomic-executor
+description: 'Execute an atomic-planner plan exactly as written. Use when a plan with [P#-T#] tasks already exists and Codex must carry it out task-by-task without replanning.'
+---
+
+# Atomic Executor
+
+Execution-only workflow skill for running an approved atomic plan.
+
+## Required Shared Skills
+
+Always apply:
+- `policy-compliance-order`
+- `atomic-plan-contract`
+- `acceptance-criteria-tracking`
+
+## Role
+
+- Execute the plan of record exactly as written.
+- Preserve phase headings, task IDs, checkbox state, and task order.
+- Verify each task before checking it off.
+- Do not create or revise the plan after execution starts.
+
+## Preflight Rules
+
+Before executing the first unchecked task:
+
+1. Read repository policy in the order defined by `policy-compliance-order`.
+2. Validate the plan format and Phase 0 / QA requirements using `atomic-plan-contract`.
+3. If the plan is incomplete, non-atomic, or conflicts with repo policy, stop at preflight and produce a precise plan delta.
+
+Blocking is allowed only during preflight.
+
+## Execution Rules
+
+For each task:
+
+1. Announce the exact task ID being executed.
+2. Perform only the micro-actions needed for that task.
+3. Verify the task acceptance criteria before marking it complete.
+4. Check off the plan file on disk immediately after verification passes.
+5. Check off satisfied acceptance criteria in the authoritative requirement source file per `acceptance-criteria-tracking`.
+
+## Non-Negotiable Constraints
+
+- Do not invent new phases or tasks.
+- Do not reorder tasks.
+- Do not substitute an in-session todo list for the plan file.
+- Do not claim success without verification.
+- After execution starts, do not stop mid-plan for replanning.
+
+## Resume Rule
+
+On resume:
+- reload the plan of record,
+- find the next unchecked task,
+- continue from there without replanning.

--- a/.agents/skills/atomic-plan-contract/SKILL.md
+++ b/.agents/skills/atomic-plan-contract/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: atomic-plan-contract
+description: 'Atomic plan format and QA contract shared by planning and execution skills. Use when generating, validating, or executing plans with Phase 0, baseline evidence, and final QA loops.'
+---
+
+# Atomic Plan Contract
+
+Shared rules for atomic plan formatting, Phase 0 requirements, baseline evidence, and final QA loops.
+
+## Canonical Plan Format
+
+- Phase headings must be `### Phase N — <Title>`.
+- Tasks must start with `- [ ] [P#-T#]` or `- [x] [P#-T#]`.
+- Task IDs must match the phase number and be sequential within the phase.
+
+## Phase 0 Requirements
+
+Phase 0 must:
+- read repository policy in the order defined by `policy-compliance-order`,
+- capture baseline toolchain state for each language touched,
+- write baseline artifacts using the conventions in `evidence-and-timestamp-conventions`.
+
+Baseline command-step artifacts must include:
+- `Timestamp:`
+- `Command:`
+- `EXIT_CODE:`
+- `Output Summary:`
+
+## Final QA Loop
+
+For plans that change code or tests, the final QA phase must run the applicable toolchain loop in order:
+
+1. Formatting
+2. Linting
+3. Type checking when applicable
+4. Testing
+
+If any step fails or changes files, restart from step 1 until the final pass is clean.
+
+## Minor-Audit Gate
+
+`minor-audit` plans must include:
+- baseline evidence tasks,
+- targeted verification evidence tasks,
+- end-state evidence tasks.
+
+They must not depend on `spec.md` or `user-story.md` when those documents are intentionally absent.
+
+## Expect-Fail Tasks
+
+Any regression-test task expected to fail before a later fix must:
+- include the exact `[expect-fail]` tag in the task title,
+- identify the exact command to run,
+- record auditable evidence in the canonical regression-testing location.
+
+## Preflight Signals
+
+Use these exact signals for executor preflight validation:
+- `PREFLIGHT: ALL CLEAR`
+- `PREFLIGHT: REVISIONS REQUIRED`

--- a/.agents/skills/atomic-planner/SKILL.md
+++ b/.agents/skills/atomic-planner/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: atomic-planner
+description: 'Generate deterministic phased implementation plans with atomic [P#-T#] checkbox tasks. Use when Codex needs to turn a goal, issue, or remediation input into an executor-ready plan.'
+---
+
+# Atomic Planner
+
+Planning-only workflow skill for generating executor-ready plans.
+
+## Required Shared Skills
+
+Always apply:
+- `policy-compliance-order`
+- `atomic-plan-contract`
+
+## Role
+
+- Produce a phased plan that an executor can run without replanning.
+- Write or update plan files only when explicitly asked or when a calling workflow provides the authoritative target path.
+- Do not implement the plan.
+
+## Plan Requirements
+
+Use `atomic-plan-contract` as the source of truth for:
+- phase and task formatting,
+- Phase 0 requirements,
+- baseline evidence tasks,
+- final QA requirements,
+- preflight validation loop behavior.
+
+Each task must be:
+- atomic,
+- binary in completion,
+- independently verifiable,
+- free of placeholder text.
+
+## Mandatory Preflight Loop
+
+Before a plan is finalized:
+
+1. Hand the current plan to `atomic-executor` in preflight-validation-only mode.
+2. If preflight returns `PREFLIGHT: REVISIONS REQUIRED`, revise the same file.
+3. Repeat until preflight returns `PREFLIGHT: ALL CLEAR`.
+
+Do not finalize a plan before preflight clears it.
+
+## Write Scope
+
+Allowed writes:
+- create or update the plan file,
+- normalize an existing plan template into executor-compatible structure.
+
+Forbidden writes:
+- source code,
+- tests,
+- configuration outside the plan file,
+- workflow execution artifacts.
+
+## Determinism Gates
+
+Reject and revise any plan that contains:
+- bucket tasks,
+- vague acceptance criteria,
+- placeholder tokens,
+- mixed discovery and implementation in one task,
+- multi-outcome tasks that should be split.

--- a/.agents/skills/commit-message-conventions/SKILL.md
+++ b/.agents/skills/commit-message-conventions/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: commit-message-conventions
+description: Generate a single high-signal conventional commit message from staged Git changes or an explicit commit-context artifact. Use when Codex or a subagent must classify dominant change intent, choose a precise commit type and optional scope, and emit an audit-quality message that is immediately usable with `git commit`.
+---
+
+# Commit Message Conventions
+
+Shared commit-message workflow for repository agents and prompts.
+
+## Inputs And Scope
+
+- Treat staged changes as the primary source of truth.
+- Accept an explicitly provided commit-context file or pasted commit context when one is supplied.
+- Ignore unstaged changes unless they are explicitly included in the provided context.
+- If there are no staged changes and no provided context artifact, stop and report that there is no in-scope commit content to summarize.
+
+## Context Gathering Order
+
+1. Use the supplied commit-context artifact first when one is present.
+2. Otherwise inspect the local staged state with non-destructive Git commands such as:
+   - `git status --short`
+   - `git diff --cached --stat`
+   - `git diff --cached`
+   - `git diff --cached --name-only`
+3. Do not infer intent from unstaged files or unrelated commit history.
+
+## Commit Classification Rules
+
+- Follow Conventional Commits semantics.
+- Choose exactly one primary type from:
+  - `feat`
+  - `fix`
+  - `docs`
+  - `test`
+  - `refactor`
+  - `ci`
+  - `chore`
+- Use the dominant intent of the staged changes.
+- Prefer `docs`, `test`, or `fix` over `chore` when classification is ambiguous.
+- Add a scope only when it materially improves clarity.
+- Keep scopes concrete and subsystem-oriented. Avoid vague scopes such as `misc`, `general`, or `updates`.
+
+## Commit Message Format
+
+- Output exactly one fenced code block with the language tag `text`.
+- The code block must contain only the commit message.
+- Use this preferred structure inside the code block:
+
+```text
+(type(optional-scope)): concise imperative summary
+
+- Bullet describing meaningful change #1
+- Bullet describing meaningful change #2
+- Bullet describing meaningful change #3 only when justified
+
+Refs: #<issue>, #<issue>
+```
+
+Header rules:
+- Use imperative mood.
+- Prefer 72 characters or fewer.
+- Do not end the header with a period.
+- Avoid filler words such as `various`, `some`, or `updates`.
+
+Body rules:
+- Use bullets only when they add real signal.
+- Make each bullet add information beyond the header.
+- Avoid implementation trivia unless it materially affects understanding.
+
+Reference rules:
+- Include a `Refs:` footer only when issue or PR references are explicitly present or clearly implied by the provided context.
+- Do not invent issue or PR references.
+
+## Interpretation Rules
+
+1. Identify the primary architectural or behavioral intent first.
+2. Treat incidental formatting or mechanical edits as secondary unless they dominate the staged diff.
+3. Keep the commit to one coherent narrative.
+4. Distinguish clearly between planning, documentation, investigation, and implementation.
+5. Do not imply a fix was implemented when the staged changes only document or plan the work.
+
+## Hard Prohibitions
+
+- No emojis
+- No commentary outside the required fenced code block
+- No Markdown inside the commit body beyond plain-text hyphen bullets
+- No references to `this commit`
+- No speculation about unstaged work
+- No multiple alternative commit messages
+
+## Quality Bar
+
+- The message must be immediately usable with `git commit`.
+- Optimize for clarity, traceability, and long-term audit value.
+- If multiple plausible narratives exist, choose the one that best reflects the dominant staged intent.

--- a/.agents/skills/csharp-change-budget-router/SKILL.md
+++ b/.agents/skills/csharp-change-budget-router/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: csharp-change-budget-router
+description: 'Budget-first routing contract for C# work. Use when a C# request must be classified as small path or large path before planning or implementation.'
+---
+
+# C# Change Budget Router
+
+Canonical routing rules for deciding whether C# work can stay on a direct path or must escalate to orchestration.
+
+## Routing Rules
+
+1. Estimate the number of production C# files likely to change.
+2. Route:
+   - `1-3` production files plus corresponding tests -> small path
+   - more than `3` production files or more than `3` test files -> large path
+
+## Small-Path Requirements
+
+Even for small path, the workflow must still:
+- follow `feature-promotion-lifecycle`,
+- use `repo-automation-adapter` for any host-specific repo automation,
+- create a `minor-audit` plan through `atomic-planner`,
+- require `atomic-executor` preflight,
+- execute Phase 0 before branching into implementation,
+- run reduced audit and QA at the end.
+
+Direct implementation does not replace the orchestration lifecycle.
+
+## Direct-Mode Rejection Rule
+
+If direct implementation is requested for work estimated above the small-path budget:
+- stop before implementation,
+- route the work to the orchestrated C# workflow.

--- a/.agents/skills/csharp-orchestration-state-machine/SKILL.md
+++ b/.agents/skills/csharp-orchestration-state-machine/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: csharp-orchestration-state-machine
+description: Checkpoint schema and resume protocol for long-running C# orchestration workflows.
+---
+
+# C# Orchestration State Machine
+
+Canonical checkpoint and resume behavior for multi-step C# orchestration workflows.
+
+## Canonical Checkpoint Location
+
+- `artifacts/orchestration/csharp-orchestrator-state.json`
+
+## Required Fields
+
+- `objective`
+- `change_budget_estimate`
+- `path_selected`
+- `promotion-type`
+- `short-name`
+- `relativeFile`
+- `long-name`
+- `issue-num`
+- `feature-folder`
+- `work-mode`
+- `plan-path`
+- `completed_steps`
+- `next_step`
+- `last_updated`
+
+For short-path runs, also persist:
+- `small_path_qc_summary`
+- `small_path_audit_artifacts`
+- `bootstrap_mode`
+- `phase0_execution_summary`
+- `resume_after_manual_bootstrap`
+
+## Resume Rules
+
+1. Read the checkpoint if it exists.
+2. If incomplete, resume from `next_step`.
+3. If missing or complete, start from intake.
+4. If the user explicitly requests a restart, reset the checkpoint and start over.

--- a/.agents/skills/evidence-and-timestamp-conventions/SKILL.md
+++ b/.agents/skills/evidence-and-timestamp-conventions/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: evidence-and-timestamp-conventions
+description: 'Evidence storage and timestamp naming conventions. Use when storing baseline, regression, remediation, or QA evidence artifacts with deterministic timestamps.'
+---
+
+# Evidence and Timestamp Conventions
+
+Reusable conventions for evidence storage and timestamped artifacts.
+
+## Timestamp Format
+
+Use `yyyy-MM-ddTHH-mm` for audit, remediation, and evidence artifacts.
+
+## Canonical Evidence Locations
+
+- Baseline evidence: `evidence/baseline/`
+- Regression-testing evidence: `evidence/regression-testing/`
+- Other evidence: `evidence/other/`
+- QA-gate evidence: `evidence/qa-gates/`
+- Issue-update mirrors: `evidence/issue-updates/`
+- Remediation baselines: `evidence/remediation-baseline/`
+
+## Evidence Artifact Schema
+
+Machine-checkable evidence artifacts should include:
+- `Timestamp: <ISO-8601>`
+- `Command: <exact command>`
+- `EXIT_CODE: <int>`
+- `Output Summary: <short outcome summary>`
+
+## Negative Evidence Claims
+
+If you claim evidence is missing, also record:
+- `SearchScope:`
+- `SearchPatterns:`
+- `SearchResult:`
+
+## Issue Update Mirrors
+
+When a workflow updates or proposes text for a GitHub issue, create a local mirror artifact at:
+- `<FEATURE>/evidence/issue-updates/issue-<N>.<timestamp>.md`

--- a/.agents/skills/feature-promotion-lifecycle/SKILL.md
+++ b/.agents/skills/feature-promotion-lifecycle/SKILL.md
@@ -7,10 +7,11 @@ description: 'Deterministic promotion workflow from potential item to issue, bra
 
 Canonical variable model and promotion sequence for initializing active feature delivery.
 
-## Required Shared Skill
+## Required Shared Skills
 
 Always use:
 - `repo-automation-adapter`
+- `evidence-and-timestamp-conventions`
 
 ## Canonical Variables
 
@@ -32,6 +33,22 @@ Always use:
 5. Resolve and persist the canonical `plan-path`.
 6. Delegate planning to `atomic-planner`.
 7. Require `atomic-executor` preflight before execution.
+
+## Canonical Branch Name
+
+- `${promotion-type}/${short-name}-${issue-num}`
+
+If the branch already exists, reuse it instead of inventing an alternate branch name.
+
+## Plan Path Resolution
+
+The canonical active plan path must use the timestamped form `plan.<timestamp>.md`.
+
+Resolve `${plan-path}` in this order:
+
+1. If one or more `plan*.md` files already exist under `${feature-folder}`, reuse the earliest existing timestamped `plan.<timestamp>.md`.
+2. If no timestamped plan exists but a legacy `plan.md` exists, treat that as a migration defect to be corrected; do not keep both `plan.md` and a new timestamped plan as competing active-plan candidates.
+3. If no plan file exists, create exactly one new `plan.<timestamp>.md` using the timestamp format from `evidence-and-timestamp-conventions` and persist that path as `${plan-path}`.
 
 ## Codex Execution Rule
 

--- a/.agents/skills/feature-promotion-lifecycle/SKILL.md
+++ b/.agents/skills/feature-promotion-lifecycle/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: feature-promotion-lifecycle
+description: 'Deterministic promotion workflow from potential item to issue, branch, and active feature folder. Use when orchestration must initialize delivery state in Codex without duplicating host-specific automation logic.'
+---
+
+# Feature Promotion Lifecycle
+
+Canonical variable model and promotion sequence for initializing active feature delivery.
+
+## Required Shared Skill
+
+Always use:
+- `repo-automation-adapter`
+
+## Canonical Variables
+
+- `${promotion-type}`: `feature` or `bug`
+- `${short-name}`: lowercase hyphenated slug
+- `${relativeFile}`: workspace-relative path to the potential entry
+- `${long-name}`: `${relativeFile}` filename without `.md`
+- `${issue-num}`: promoted GitHub issue number
+- `${feature-folder}`: active feature folder path
+- `${plan-path}`: canonical plan file path
+- `${work-mode}`: `minor-audit`, `full-feature`, or `full-bug`
+
+## Workflow
+
+1. Create the potential entry.
+2. Promote the potential entry to an issue.
+3. Create the branch.
+4. Create the active feature folder.
+5. Resolve and persist the canonical `plan-path`.
+6. Delegate planning to `atomic-planner`.
+7. Require `atomic-executor` preflight before execution.
+
+## Codex Execution Rule
+
+Do not encode host-specific implementation details here.
+
+For each lifecycle step:
+- use `repo-automation-adapter` to choose the direct repo automation path,
+- use a deterministic local fallback only when explicitly supported,
+- otherwise stop and report the missing automation dependency.
+
+## Mode-Aware Expectations
+
+- `minor-audit`: `issue.md` is authoritative and `spec.md` / `user-story.md` are intentionally absent
+- `full-feature`: `issue.md`, `spec.md`, and `user-story.md` are expected
+- `full-bug`: `issue.md` and `spec.md` are expected

--- a/.agents/skills/feature-review/SKILL.md
+++ b/.agents/skills/feature-review/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: feature-review
+description: 'Review a feature branch relative to a base branch and write audit artifacts into the active feature folder. Use when Codex must produce policy, code, and feature audits and trigger remediation planning when needed.'
+---
+
+# Feature Review
+
+Workflow skill for PR-style feature review in Codex.
+
+## Required Shared Skills
+
+Always apply:
+- `policy-compliance-order`
+- `evidence-and-timestamp-conventions`
+- `policy-audit-template-usage`
+- `pr-context-artifacts`
+- `acceptance-criteria-tracking`
+- `remediation-handoff-atomic-planner`
+
+Use as needed:
+- `pr-base-branch-merge-base`
+- `repo-automation-adapter`
+
+## Role
+
+- Review the feature branch relative to the correct base.
+- Produce audit-grade artifacts, not code fixes.
+- Prefer deterministic evidence from PR-context artifacts and exact diff anchors.
+- Trigger remediation planning when blockers or unmet acceptance criteria exist.
+
+## Required Outputs
+
+Write timestamped artifacts into the active feature folder:
+- `policy-audit.<timestamp>.md`
+- `code-review.<timestamp>.md`
+- `feature-audit.<timestamp>.md`
+- `remediation-inputs.<timestamp>.md` when remediation is required
+- `remediation-plan.<timestamp>.md` when remediation is required
+
+## Review Flow
+
+1. Resolve the base branch.
+   - Use the supplied base when present.
+   - If ambiguous, use `pr-base-branch-merge-base`.
+2. Load PR context from the canonical artifacts defined by `pr-context-artifacts`.
+3. If PR context is missing or stale, refresh it through `repo-automation-adapter`.
+4. Determine the active feature folder deterministically from the scoping docs and PR context.
+5. Create the policy audit, code review, and feature audit.
+6. Check off passing acceptance criteria in the authoritative requirement sources per `acceptance-criteria-tracking`.
+7. If remediation is required, create remediation inputs first and then hand off plan creation using `remediation-handoff-atomic-planner`.
+
+## Review Constraints
+
+- Do not silently fix code during review.
+- Prefer check-only commands.
+- If a tool cannot be run, mark the related section as unverified or partial with a concrete reason.
+- Do not claim completion until every required artifact exists on disk.

--- a/.agents/skills/make-skill-template/SKILL.md
+++ b/.agents/skills/make-skill-template/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: make-skill-template
+description: 'Create or scaffold a new repository skill for Codex. Use when asked to create a new skill or migrate a Copilot skill into the Codex runtime tree.'
+---
+
+# Make Skill Template
+
+Repository compatibility wrapper for Codex skill scaffolding.
+
+## Canonical Rule
+
+Use the built-in `$skill-creator` system skill first, then apply repository-specific conventions from `.agents/README.md`.
+
+## Required Repository Conventions
+
+When creating a new repository skill:
+- place it under `.agents/skills/<skill-name>/SKILL.md`,
+- keep frontmatter minimal with `name` and `description`,
+- write a trigger-rich description,
+- prefer composing existing shared skills before inventing a new shared rule,
+- centralize host-specific repo automation in `repo-automation-adapter`.
+
+## Migration Rule
+
+When the source is a GitHub Copilot skill:
+- preserve the stable skill name when practical,
+- move reusable behavior into the new Codex skill,
+- remove Copilot-only tool assumptions from the runtime instructions,
+- keep the skill body focused and defer repeated rules to existing shared skills.

--- a/.agents/skills/orchestrator-workflow/SKILL.md
+++ b/.agents/skills/orchestrator-workflow/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: orchestrator-workflow
+description: 'Coordinate a feature or bug request from intake through promotion, planning, execution, validation, and review by selecting the correct small or large path and delegating to migrated Codex specialists when available.'
+---
+
+# Orchestrator Workflow
+
+Top-level delivery orchestration workflow for Codex.
+
+## Required Shared Skills
+
+Always apply:
+- `policy-compliance-order`
+- `feature-promotion-lifecycle`
+- `repo-automation-adapter`
+- `atomic-plan-contract`
+- `acceptance-criteria-tracking`
+
+Use as needed:
+- `csharp-change-budget-router`
+- `powershell-change-budget-router`
+- `feature-review`
+- `pr-base-branch-merge-base`
+- `pr-context-artifacts`
+
+## Role
+
+- Coordinate the mission from intake through completion.
+- Prefer migrated Codex subagents when they exist.
+- Current preferred migrated subagents:
+  - `atomic-planner`
+  - `atomic-executor`
+  - `feature-reviewer`
+- If a specialist step has no migrated Codex subagent yet, perform that step directly while still following the governing shared skills.
+
+## Checkpoint Contract
+
+Canonical checkpoint path:
+- `artifacts/orchestration/orchestrator-state.json`
+
+Persist and reuse these fields exactly:
+- `objective`
+- `change_budget_estimate`
+- `path_selected`
+- `promotion-type`
+- `short-name`
+- `relativeFile`
+- `long-name`
+- `issue-num`
+- `feature-folder`
+- `work-mode`
+- `plan-path`
+- `completed_steps`
+- `next_step`
+- `last_updated`
+
+For small-path runs, also persist:
+- `bootstrap_mode`
+- `phase0_execution_summary`
+- `small_path_qc_summary`
+- `small_path_audit_artifacts`
+- `resume_after_manual_bootstrap`
+
+## Resume Rules
+
+1. Read the checkpoint first when it exists.
+2. If the recorded mission is incomplete, resume from `next_step`.
+3. Restart only when the user explicitly requests restart.
+4. Do not recompute persisted variables when valid stored values already exist.
+
+## Routing Rules
+
+1. Estimate the likely touched production files and test files first.
+2. Determine the dominant implementation language.
+3. If the scope is primarily C#, use `csharp-change-budget-router`.
+4. If the scope is primarily PowerShell, use `powershell-change-budget-router`.
+5. If the scope is mixed-language, ambiguous, or unsupported by an existing change-budget router, fail closed to the large path.
+6. Treat any request outside the applicable small-path budget as large path.
+
+## Small Path
+
+Use the small path only when the applicable language router clears it.
+
+Required behavior:
+
+1. Set `${work-mode}` to `minor-audit`.
+2. Use `feature-promotion-lifecycle` as the source of truth for lifecycle variables, branch naming, and `${plan-path}` resolution.
+3. Route all promotion, issue, and feature-folder automation through `repo-automation-adapter`.
+4. Enforce minor-audit folder integrity:
+   - `${feature-folder}/issue.md` must exist
+   - `${feature-folder}/spec.md` must be absent
+   - `${feature-folder}/user-story.md` must be absent
+5. Spawn `atomic-planner` to create or revise the minimal plan at `${plan-path}`.
+   - Include the directive `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`
+   - Require the same `${plan-path}` to be updated in place
+   - Do not continue until the planner reports `PREFLIGHT: ALL CLEAR`
+6. Spawn `atomic-executor` to execute Phase 0 only.
+7. If the request is manual bootstrap, persist the resume checkpoint and stop after Phase 0.
+8. Otherwise continue with constrained implementation:
+   - prefer a migrated language specialist when one exists
+   - if no migrated specialist exists yet, execute the constrained implementation directly while staying within the approved plan and applicable repo policy
+9. Validate the delivered work against `${feature-folder}/issue.md` and persist plan or acceptance-criteria checkoffs before review.
+   - prefer `atomic-executor` for validation and checklist updates
+10. Run reduced audit:
+   - prefer `feature-reviewer`
+   - otherwise execute the `feature-review` workflow directly in minor-audit mode
+11. If review triggers remediation, create remediation inputs, delegate planning to `atomic-planner`, execute the remediation plan, and re-run reduced review until the gate is clean.
+
+## Large Path
+
+Use the large path for any request that exceeds or bypasses the small-path router.
+
+Required behavior:
+
+1. Set `${work-mode}` to:
+   - `full-feature` for feature work
+   - `full-bug` for bug work
+2. Use `feature-promotion-lifecycle` as the source of truth for lifecycle variables, branch naming, and `${plan-path}` resolution.
+3. Route all promotion, issue, and feature-folder automation through `repo-automation-adapter`.
+4. Complete the requirements-authoring steps before planning:
+   - fill the potential entry details
+   - create or refresh research artifacts
+   - complete `spec.md` and `user-story.md` when the selected work mode requires them
+5. Prefer dedicated migrated specialists for those authoring steps when they exist.
+6. When those specialists are not yet migrated, perform the authoring steps directly without changing template headings.
+7. Spawn `atomic-planner` to finalize `${plan-path}` and require `PREFLIGHT: ALL CLEAR`.
+8. Spawn `atomic-executor` to execute the approved plan.
+9. Spawn `feature-reviewer` for post-implementation review when available.
+10. If review triggers remediation, loop through remediation planning, remediation execution, and re-review until the gate is clean.
+
+## Completion Gates
+
+Do not claim mission completion until all of the following are true:
+
+- the selected path completed end to end
+- the checkpoint is updated with the final state
+- `${feature-folder}` and `${plan-path}` are known when lifecycle setup was required
+- required review artifacts exist on disk
+- small path has Phase 0 evidence plus reduced audit artifacts
+- large path has policy, code, and feature audit artifacts
+
+## Hard Constraints
+
+- Do not stop after one delegation when required downstream steps remain.
+- Do not call `drmCopilotExtension.*` directly from this workflow.
+- Do not bypass `repo-automation-adapter` for host-specific lifecycle steps.
+- Do not create replacement audit artifacts yourself when `feature-reviewer` is available to own that workflow.
+- Do not claim completion without reporting the checkpoint path and the created or updated artifact paths.

--- a/.agents/skills/policy-audit-template-usage/SKILL.md
+++ b/.agents/skills/policy-audit-template-usage/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: policy-audit-template-usage
+description: 'Policy audit artifact rules. Use when creating policy-audit.<timestamp>.md files from repository templates or minimal fallbacks.'
+---
+
+# Policy Audit Template Usage
+
+Shared rules for creating policy audit artifacts.
+
+## Template Source
+
+- Preferred template: `docs/features/templates/policy_audit/policy-audit.yyyy-MM-ddTHH-mm.md`
+- If missing, search the repository for `policy-audit.yyyy-MM-ddTHH-mm.md`.
+- If still missing, create a minimal policy audit artifact marked blocked and record the missing template.
+
+## Required Steps
+
+1. Copy the template to the target location using an ISO-style timestamp.
+2. Replace placeholders with real values.
+3. Remove template instructions from the final artifact.
+4. Mark each section `PASS`, `FAIL`, or `N/A` using the template convention.

--- a/.agents/skills/policy-compliance-order/SKILL.md
+++ b/.agents/skills/policy-compliance-order/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: policy-compliance-order
+description: 'Repository policy reading order and hard constraints. Use when an agent or skill must apply repository policy without duplicating the same preamble everywhere.'
+---
+
+# Policy Compliance Order
+
+Shared policy-compliance instructions for repository workflows.
+
+## Required Reading Order
+
+1. `.github/copilot-instructions.md`
+2. `.github/instructions/general-code-change.instructions.md`
+3. `.github/instructions/general-unit-test.instructions.md`
+4. Relevant language or domain policies based on files in scope
+
+## Hard Constraints
+
+- Do not modify policy documents under `.github/instructions/` unless explicitly asked.
+- Do not create secrets or `.env` files unless explicitly requested.
+- Prefer repository-defined commands when available.
+- If information is missing, proceed with best-effort assumptions and document them.

--- a/.agents/skills/powershell-change-budget-router/SKILL.md
+++ b/.agents/skills/powershell-change-budget-router/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: powershell-change-budget-router
+description: 'Budget-first routing contract for PowerShell work. Use when a PowerShell request must be classified as small path or large path before planning or implementation.'
+---
+
+# PowerShell Change Budget Router
+
+Canonical routing rules for deciding whether PowerShell work can stay on a direct path or must escalate to orchestration.
+
+## Routing Rules
+
+1. Estimate the number of production PowerShell files likely to change.
+2. Route:
+   - `1-2` production files plus corresponding tests -> small path
+   - more than `2` production files -> large path
+
+## Small-Path Requirements
+
+Even for small path, the workflow must still:
+- follow `feature-promotion-lifecycle`,
+- use `repo-automation-adapter` for any host-specific repo automation,
+- create a `minor-audit` plan through `atomic-planner`,
+- require `atomic-executor` preflight,
+- execute Phase 0 before branching into implementation,
+- run reduced audit and QA at the end.
+
+Direct implementation does not replace the orchestration lifecycle.
+
+## Direct-Mode Rejection Rule
+
+If direct implementation is requested for work estimated above the small-path budget:
+- stop before implementation,
+- route the work to the orchestrated PowerShell workflow.

--- a/.agents/skills/powershell-orchestration-state-machine/SKILL.md
+++ b/.agents/skills/powershell-orchestration-state-machine/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: powershell-orchestration-state-machine
+description: Checkpoint schema and resume protocol for long-running PowerShell orchestration workflows.
+---
+
+# PowerShell Orchestration State Machine
+
+Canonical checkpoint and resume behavior for multi-step PowerShell orchestration workflows.
+
+## Canonical Checkpoint Location
+
+- `artifacts/orchestration/powershell-orchestrator-state.json`
+
+## Required Fields
+
+- `objective`
+- `change_budget_estimate`
+- `path_selected`
+- `promotion-type`
+- `short-name`
+- `relativeFile`
+- `long-name`
+- `issue-num`
+- `feature-folder`
+- `work-mode`
+- `plan-path`
+- `completed_steps`
+- `next_step`
+- `last_updated`
+
+For short-path runs, also persist:
+- `small_path_qc_summary`
+- `small_path_audit_artifacts`
+- `bootstrap_mode`
+- `phase0_execution_summary`
+- `resume_after_manual_bootstrap`
+
+## Resume Rules
+
+1. Read the checkpoint if it exists.
+2. If incomplete, resume from `next_step`.
+3. If missing or complete, start from intake.
+4. If the user explicitly requests a restart, reset the checkpoint and start over.

--- a/.agents/skills/pr-authoring/SKILL.md
+++ b/.agents/skills/pr-authoring/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: pr-authoring
+description: 'Write a GitHub-ready pull request body from the canonical PR-context bundle and its enumerated additional context files. Use when Codex or a subagent must produce an evidence-based PR description with strict verification and auto-close rules.'
+---
+
+# PR Authoring
+
+Shared workflow for producing a GitHub-ready pull request body.
+
+## Required Shared Skill
+
+Always use:
+- `pr-context-artifacts`
+
+## Role
+
+- Generate a PR body that is feature-first, accurate, and review-ready.
+- Base every claim on the canonical PR-context bundle and the explicitly enumerated additional context files listed inside that bundle.
+- Keep GitHub issue and PR references precise and non-hallucinatory.
+
+## Allowed Sources
+
+Use only:
+- the canonical PR-context summary and appendix defined by `pr-context-artifacts`
+- files explicitly listed under `Additional context files` inside that context bundle
+- optional user directives supplied with the request
+
+Do not cite or summarize any other repository file.
+
+## Context Priority
+
+Prioritize evidence in this order:
+
+1. `PR Intent`
+2. enumerated `Additional context files`
+3. embedded feature-doc excerpts such as root cause, constraints, proposed fix, acceptance criteria, story statement, problem, or why
+4. comparison range, commits, changed files, and diff statistics
+5. referenced issues and PRs
+6. issues to autoclose
+
+## Core Objectives
+
+1. Accuracy: every statement must be supported by the allowed sources.
+2. Signal: emphasize why and semantic intent, not just changed-file inventory.
+3. GitHub correctness: auto-close syntax must be valid and must not invent issue numbers.
+
+## Required Output Shape
+
+Output exactly one fenced code block using the language tag `markdown`.
+
+Inside that code block, include only the PR body with exactly this section order:
+
+- `Suggested title: ...`
+- `## Summary`
+- `## Why`
+- `## What Changed`
+- `## Architecture / How It Fits Together`
+- `## Verification`
+- `### Completed`
+- `### Recommended`
+- `## Backward Compatibility / Migration Notes`
+- `## Risks and Mitigations`
+- `## Review Guide`
+- `## Follow-ups`
+- `## GitHub Auto-close`
+- `## Related issues / PRs`
+
+## Section Rules
+
+### Suggested title
+
+- one line only
+- lead with the primary outcome, not secondary tooling or docs work
+
+### Summary
+
+- 3 to 7 bullets
+- first bullet must state the primary change
+
+### Why
+
+- use feature-doc excerpts and PR Intent as the main source of motivation
+- if explicit excerpts are missing, infer conservatively from commits and file themes
+
+### What Changed
+
+Group bullets by theme:
+- core behavior or architecture
+- tooling, automation, CI, or developer experience
+- tests
+- docs, templates, or agents
+
+### Verification
+
+- `Completed` may include only evidence-backed verification
+- if verification is not proven, state: `Not verified in this PR (no tool outputs recorded in the PR-context summary).`
+- `Recommended` must include concrete repo-appropriate commands
+
+### GitHub Auto-close
+
+This section must contain only bullets of the form:
+- `Closes #NNN`
+
+Source of truth in order:
+1. verified or pending issues to autoclose
+2. `PR Intent` author-asserted autoclose issues
+
+If GitHub validation is unavailable or no approved source provides issue numbers, include one bullet:
+- `None (...)`
+
+Never use `Related:` in this section.
+
+### Related issues / PRs
+
+- non-closed issues: `Related issue: #NNN`
+- PRs in range: `Related PR: #NNN`
+
+## Hard Prohibitions
+
+- Do not invent issue or PR numbers.
+- Do not treat PR numbers as issues.
+- Do not claim verification unless the context proves it.
+- Do not cite sources outside the allowed-source list.
+- Do not output commentary outside the single fenced Markdown block.

--- a/.agents/skills/pr-base-branch-merge-base/SKILL.md
+++ b/.agents/skills/pr-base-branch-merge-base/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: pr-base-branch-merge-base
+description: 'Resolve the correct PR base branch using merge-base ancestry. Use when review or PR-context workflows need a deterministic base branch instead of a guessed default.'
+---
+
+# PR Base Branch (Merge-Base)
+
+Deterministic branch-selection rules for review and PR-context workflows.
+
+## Selection Contract
+
+The base branch must be resolved from git ancestry, not guessed.
+
+Definition:
+- choose the candidate branch whose merge-base with `HEAD` has the most recent commit timestamp
+
+## Deterministic Procedure
+
+1. Enumerate candidate branches from local and remotes, excluding `HEAD` and detached refs.
+2. For each candidate `B`, compute `M = git merge-base HEAD B`.
+3. Compute `merge_base_epoch(B)` from `git show -s --format=%ct M`.
+4. Select the branch with the highest `merge_base_epoch(B)`.
+5. Tie-break in this order:
+   - `development`
+   - `main`
+   - `master`
+   - lexical ascending branch name
+
+## Guardrails
+
+- Do not default to `main` unless merge-base resolution fails for all candidates.
+- Persist and reuse the selected base within the same review or orchestration run.

--- a/.agents/skills/pr-context-artifacts/SKILL.md
+++ b/.agents/skills/pr-context-artifacts/SKILL.md
@@ -16,9 +16,10 @@ Canonical locations and refresh rules for PR context artifacts.
 
 If artifacts are missing or stale relative to the current branch state:
 
-1. Use `repo-automation-adapter` to attempt the repository's canonical collector.
-2. If no direct Codex-facing collector is available and the workflow only needs diff-scoped review evidence, use a deterministic git-based fallback.
-3. Record the provenance of any fallback-generated evidence in the review artifact.
+1. Use `repo-automation-adapter` and prefer MCP server `drmCopilotExtension` tool `collect_pr_context`.
+2. If the caller already resolved a base branch, pass that base explicitly to the canonical collector.
+3. If the MCP collector is unavailable and the workflow only needs diff-scoped review evidence, use a deterministic git-based fallback.
+4. Record the provenance of any fallback-generated evidence in the review artifact.
 
 ## Consumer Rule
 

--- a/.agents/skills/pr-context-artifacts/SKILL.md
+++ b/.agents/skills/pr-context-artifacts/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: pr-context-artifacts
+description: 'PR context artifact locations and refresh rules. Use when generating, refreshing, or consuming pr_context summary and appendix artifacts in Codex.'
+---
+
+# PR Context Artifacts
+
+Canonical locations and refresh rules for PR context artifacts.
+
+## Canonical Locations
+
+- Summary: `artifacts/pr_context.summary.txt`
+- Appendix: `artifacts/pr_context.appendix.txt`
+
+## Refresh Rule
+
+If artifacts are missing or stale relative to the current branch state:
+
+1. Use `repo-automation-adapter` to attempt the repository's canonical collector.
+2. If no direct Codex-facing collector is available and the workflow only needs diff-scoped review evidence, use a deterministic git-based fallback.
+3. Record the provenance of any fallback-generated evidence in the review artifact.
+
+## Consumer Rule
+
+Use the summary as the primary review source and the appendix as the secondary diff anchor.

--- a/.agents/skills/remediation-handoff-atomic-planner/SKILL.md
+++ b/.agents/skills/remediation-handoff-atomic-planner/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: remediation-handoff-atomic-planner
+description: 'Reusable remediation trigger and atomic-planner handoff steps. Use when audits or validation workflows require remediation inputs and a delegated remediation plan.'
+---
+
+# Remediation Handoff To Atomic Planner
+
+Shared remediation workflow for agents that must create remediation inputs and delegate plan creation.
+
+## Trigger Conditions
+
+Trigger remediation when any of these are true:
+- audit artifacts contain `FAIL` or meaningful `PARTIAL` findings,
+- toolchain checks fail,
+- required acceptance criteria are unmet.
+
+## Required Inputs
+
+Create `remediation-inputs.<timestamp>.md` with:
+- enumerated fixes,
+- exact file paths and expected behavior,
+- verification commands,
+- a clear do-not-do list.
+
+## Handoff
+
+1. Create the remediation plan target file.
+2. Delegate plan creation to `atomic-planner`.
+3. Treat remediation inputs as the primary requirements source.
+4. Preserve the authoritative target plan path across revisions.

--- a/.agents/skills/repo-automation-adapter/SKILL.md
+++ b/.agents/skills/repo-automation-adapter/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: repo-automation-adapter
+description: 'Centralize host-surface and repo-automation differences for Codex. Use when a migrated workflow previously depended on GitHub Copilot or VS Code extension commands and needs a single Codex-compatible execution or fallback rule.'
+---
+
+# Repo Automation Adapter
+
+Use this skill to keep host-specific workflow translation in one place.
+
+## When to Use This Skill
+
+Use this skill when:
+- a migrated skill previously depended on `drmCopilotExtension.*` commands,
+- a workflow needs PR-context collection, issue promotion, or feature-folder creation,
+- the same fallback behavior would otherwise be repeated across multiple skills.
+
+## Canonical Rule
+
+Do not encode host-specific execution details in multiple workflow skills. Put them here and have the calling skills reference this skill.
+
+## Codex Capability Model
+
+Codex in this repo can reliably use:
+- repository files,
+- shell commands,
+- git,
+- local scripts that already exist in the repository,
+- configured MCP tools when available.
+
+Codex in this repo should not assume direct access to:
+- `vscode/runCommand`,
+- `drmCopilotExtension.*` command execution,
+- GitHub issue or PR mutation unless an explicit connector or script is available.
+
+## Execution Order
+
+For any host-specific workflow step:
+
+1. Prefer a repo-native script, CLI, or MCP tool that Codex can invoke directly.
+2. If no direct adapter exists, determine whether a deterministic git/filesystem fallback is sufficient.
+3. If a deterministic fallback is sufficient, use it and record that the result is a fallback artifact rather than a canonical tool-produced artifact.
+4. If no direct adapter or safe fallback exists, stop and report the missing automation dependency instead of inventing behavior.
+
+## Current Adapter Guidance
+
+### PR context collection
+
+- Preferred: use the repository's direct PR-context collector if one becomes available to Codex.
+- Current fallback: use deterministic git commands to reconstruct equivalent context when review workflows only need base/head, merge-base, commits, and changed files.
+- When using fallback, record the provenance in the generated review artifact.
+
+### Feature promotion and active feature folder creation
+
+- Preferred: use a direct repository script, CLI, MCP tool, or future Codex-facing adapter.
+- Current rule: if no such adapter exists, treat the step as unavailable in Codex and surface a precise dependency gap.
+- Do not synthesize GitHub issue state or feature-folder scaffolding unless the user explicitly requests a best-effort local-only fallback.
+
+## Output Requirements
+
+When this skill is used, the calling workflow should report:
+- which operation required host adaptation,
+- which direct adapter or fallback path was selected,
+- whether the result is canonical or fallback-only,
+- what dependency is missing when the step is blocked.

--- a/.agents/skills/repo-automation-adapter/SKILL.md
+++ b/.agents/skills/repo-automation-adapter/SKILL.md
@@ -18,6 +18,15 @@ Use this skill when:
 
 Do not encode host-specific execution details in multiple workflow skills. Put them here and have the calling skills reference this skill.
 
+## Published Codex Automation Surface
+
+The canonical Codex automation dependency for this repo is the published MCP server:
+- `drmCopilotExtension`
+
+Downstream Codex skills should depend on the MCP server name `drmCopilotExtension`, not on raw VS Code command IDs.
+
+Declare that dependency once on this skill via `agents/openai.yaml`.
+
 ## Codex Capability Model
 
 Codex in this repo can reliably use:
@@ -32,28 +41,80 @@ Codex in this repo should not assume direct access to:
 - `drmCopilotExtension.*` command execution,
 - GitHub issue or PR mutation unless an explicit connector or script is available.
 
+## Published MCP Tool Surface
+
+Prefer these semantic MCP tools when the server is configured:
+
+- `collect_commit_context`
+- `collect_pr_context`
+- `push_down_copilot_customizations`
+- `new_potential_bug_entry`
+- `new_potential_entry`
+- `potential_to_issue`
+- `new_active_feature_folder`
+- `resolve_execute_hard_lock_prompt`
+
+Legacy VS Code command IDs remain historical source material only:
+
+- `drmCopilotExtension.collectCommitContext`
+- `drmCopilotExtension.collectPrContext`
+- `drmCopilotExtension.pushDownCopilotCustomizations`
+- `drmCopilotExtension.newPotentialBugEntry`
+- `drmCopilotExtension.newPotentialEntry`
+- `drmCopilotExtension.potentialToIssue`
+- `drmCopilotExtension.newActiveFeatureFolder`
+- `drmCopilotExtension.resolveExecuteHardLockPrompt`
+
+## Adapter Preconditions
+
+Before treating the MCP path as available, assume these prerequisites:
+
+- the Codex client is configured with MCP server name `drmCopilotExtension`
+- the published extension or bridge is installed and built
+- an open workspace folder exists for workspace-targeted operations
+- `python` is on `PATH`
+- `pwsh` is preferred, with Windows PowerShell fallback when applicable
+
 ## Execution Order
 
 For any host-specific workflow step:
 
-1. Prefer a repo-native script, CLI, or MCP tool that Codex can invoke directly.
-2. If no direct adapter exists, determine whether a deterministic git/filesystem fallback is sufficient.
+1. Prefer the published `drmCopilotExtension` MCP tool when it covers the requested operation.
+2. If the MCP server is unavailable, determine whether a deterministic git or filesystem fallback is sufficient.
 3. If a deterministic fallback is sufficient, use it and record that the result is a fallback artifact rather than a canonical tool-produced artifact.
-4. If no direct adapter or safe fallback exists, stop and report the missing automation dependency instead of inventing behavior.
+4. If no MCP path or safe fallback exists, stop and report the missing automation dependency instead of inventing behavior.
 
 ## Current Adapter Guidance
 
 ### PR context collection
 
-- Preferred: use the repository's direct PR-context collector if one becomes available to Codex.
+- Preferred: call tool `collect_pr_context` on MCP server `drmCopilotExtension`.
+- When the caller already resolved a base branch, pass that base explicitly.
 - Current fallback: use deterministic git commands to reconstruct equivalent context when review workflows only need base/head, merge-base, commits, and changed files.
 - When using fallback, record the provenance in the generated review artifact.
 
+### Commit context collection
+
+- Preferred: call tool `collect_commit_context` on MCP server `drmCopilotExtension`.
+- If the MCP server is unavailable and the workflow only needs staged-diff summary, use non-destructive git inspection as fallback and record that provenance.
+
 ### Feature promotion and active feature folder creation
 
-- Preferred: use a direct repository script, CLI, MCP tool, or future Codex-facing adapter.
-- Current rule: if no such adapter exists, treat the step as unavailable in Codex and surface a precise dependency gap.
+- Preferred MCP tools:
+  - `new_potential_entry`
+  - `new_potential_bug_entry`
+  - `potential_to_issue`
+  - `new_active_feature_folder`
+- Current rule: use the MCP tools as the canonical path.
+- If the MCP server is unavailable, surface a precise dependency gap unless the caller explicitly requests a best-effort local-only fallback.
 - Do not synthesize GitHub issue state or feature-folder scaffolding unless the user explicitly requests a best-effort local-only fallback.
+
+### Customization publishing and hard-lock resolution
+
+- Preferred MCP tools:
+  - `push_down_copilot_customizations`
+  - `resolve_execute_hard_lock_prompt`
+- If the MCP server is unavailable, stop unless the caller explicitly provides an approved alternate path.
 
 ## Output Requirements
 

--- a/.agents/skills/repo-automation-adapter/agents/openai.yaml
+++ b/.agents/skills/repo-automation-adapter/agents/openai.yaml
@@ -1,0 +1,5 @@
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "drmCopilotExtension"
+      description: "Published drm-copilot stdio MCP bridge for repository automation"

--- a/.agents/skills/skill-canonical-location-audit/SKILL.md
+++ b/.agents/skills/skill-canonical-location-audit/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: skill-canonical-location-audit
+description: 'Audit skills for canonical-location duplication. Use when adding or changing skills that define canonical paths, folders, or file names.'
+---
+
+# Skill Canonical-Location Audit
+
+Audit skills to ensure canonical locations are defined in exactly one place.
+
+## Scope
+
+- Applies to repository skills under `.agents/skills/**/SKILL.md`
+- Focuses on canonical paths, folders, and file names
+
+## Workflow
+
+1. Inventory explicit canonical-location statements.
+2. Group them by the item they describe.
+3. Detect duplicates.
+4. Recommend one skill as the single source of truth for each duplicated item.
+
+## Notes
+
+- Indirect references to another skill do not count as duplication.
+- Only explicit canonical definitions count.

--- a/.codex/agents/commit-steward.toml
+++ b/.codex/agents/commit-steward.toml
@@ -1,0 +1,20 @@
+name = "commit-steward"
+description = "Generate a high-signal conventional commit message for the current repository based on staged changes only."
+
+developer_instructions = """
+You are a commit-message specialist.
+
+Use the following repo-local skill as the canonical workflow source:
+- commit-message-conventions
+
+Core behavior:
+- Generate an audit-quality Git commit message for the current repository.
+- Use an explicitly supplied commit-context artifact when one is provided.
+- Otherwise inspect the local staged state directly with non-destructive Git commands.
+- Do not create the commit. Do not stage, unstage, or modify files.
+- Treat the shared skill as the source of truth for commit classification, formatting, interpretation, and prohibitions.
+
+Final response contract:
+- Output exactly one fenced `text` code block containing only the commit message.
+- Do not include commentary, alternatives, or explanations outside the code block.
+"""

--- a/.codex/agents/orchestrator.toml
+++ b/.codex/agents/orchestrator.toml
@@ -1,0 +1,29 @@
+name = "orchestrator"
+description = "Route a request through the correct small or large delivery path and persist until the mission is complete."
+
+developer_instructions = """
+You are an orchestration-only agent.
+
+Use the following repo-local skill as the canonical workflow source:
+- orchestrator-workflow
+
+Primary role:
+- Receive a delivery objective and route it through the correct orchestration path.
+- Coordinate planning, execution, validation, and review until the mission is complete.
+- Prefer delegation to currently migrated Codex subagents:
+  - `atomic-planner`
+  - `atomic-executor`
+  - `feature-reviewer`
+
+Core behavior:
+- Estimate change budget first and select the route deterministically.
+- Maintain and resume from the canonical orchestration checkpoint.
+- Use `feature-promotion-lifecycle` and `repo-automation-adapter` instead of hard-coding host-specific commands.
+- If a needed specialist has not been migrated yet, perform that step directly under the governing shared skills rather than depending on unmigrated Copilot agents.
+- Do not stop after partial setup while required downstream steps remain.
+
+Final response contract:
+- Report the selected route, branch, key captured variables, checkpoint path, and created or updated artifact paths.
+- For small path, also report the approved `plan-path`, final preflight signal, and whether execution stopped for manual bootstrap.
+- Do not claim completion unless the checkpoint and required orchestration artifacts are on disk.
+"""

--- a/.codex/agents/pr-author.toml
+++ b/.codex/agents/pr-author.toml
@@ -1,0 +1,26 @@
+name = "pr-author"
+description = "Write a GitHub-ready pull request body from the canonical PR-context bundle and its enumerated additional context files."
+
+developer_instructions = """
+You are a PR-authoring specialist.
+
+Use the following repo-local skills as the canonical workflow source:
+- pr-authoring
+- pr-context-artifacts
+
+Primary role:
+- Generate a GitHub-ready pull request body from the canonical PR-context bundle.
+- Use only the canonical PR-context bundle, its enumerated additional context files, and explicit user directives.
+- Keep verification, issue references, and auto-close bullets evidence-based.
+
+Core behavior:
+- Treat `pr-context-artifacts` as the source of truth for PR-context locations and refresh rules.
+- If the PR-context bundle is missing or stale, refresh it through the canonical mechanism before continuing.
+- Do not cite or summarize files outside the allowed-source list.
+- Do not invent issue or PR references.
+
+Final response contract:
+- Output exactly one fenced `markdown` code block containing only the PR body.
+- Use the exact section order defined by the shared skill.
+- Do not include commentary, alternatives, or explanation outside the code block.
+"""

--- a/.codex/prompts/generate-commit-message-repo.md
+++ b/.codex/prompts/generate-commit-message-repo.md
@@ -1,0 +1,11 @@
+---
+description: Generate a conventional commit message for the current repository by spawning commit-steward
+---
+
+Spawn `commit-steward` to generate a single audit-quality conventional commit message for the current repository.
+
+Use an explicitly supplied commit-context artifact as the primary input when one is provided.
+If no explicit commit-context artifact is provided, prefer `artifacts/commit_context.txt` when that file exists in the workspace.
+If no commit-context artifact is available, have `commit-steward` inspect staged changes directly and scope the message to staged changes only.
+
+Return exactly one fenced `text` code block containing only the commit message.

--- a/.codex/prompts/generate-pr.md
+++ b/.codex/prompts/generate-pr.md
@@ -1,0 +1,15 @@
+---
+description: Generate a GitHub-ready PR body from the canonical PR-context bundle by spawning pr-author
+argument-hint: Optional notes or PR intent edits to apply while writing the PR body
+---
+
+Spawn `pr-author` to generate a GitHub-ready pull request body.
+
+Use only:
+- the canonical PR-context bundle
+- the additional context files enumerated inside that bundle
+- any explicit user directives supplied with this prompt invocation
+
+If the PR-context bundle is missing or stale, refresh it using the canonical mechanism before generating the PR body.
+
+Return exactly one fenced `markdown` code block containing only the pull request message.

--- a/.codex/prompts/orchestrate-work.md
+++ b/.codex/prompts/orchestrate-work.md
@@ -1,0 +1,22 @@
+---
+description: Route a request through budget-based orchestration and persist until the selected delivery path is complete
+argument-hint: Provide objective, likely files, feature-or-bug hint, constraints, and whether small-path execution should stop after Phase 0 for manual bootstrap
+---
+
+Spawn `orchestrator` to coordinate the current request from intake through completion.
+
+Inputs to provide or infer:
+- request summary and expected outcome
+- likely affected production and test files, when known
+- initial classification hint: `feature` or `bug`, when known
+- constraints, preserved APIs, or forbidden changes
+- whether small-path execution should stop after Phase 0 for manual bootstrap
+
+Required behavior:
+- estimate change budget first and choose the correct small or large path
+- maintain and resume from the canonical orchestration checkpoint
+- use migrated Codex subagents when available
+- route host-specific lifecycle automation through the shared adapter rules
+- continue until planning, execution, validation, and review are complete for the selected path, unless the request explicitly requires a manual-bootstrap pause
+
+On completion, report the selected route, branch, key variables, `plan-path` when applicable, checkpoint path, created or updated artifact paths, and final readiness summary.

--- a/change-plan.md
+++ b/change-plan.md
@@ -2,48 +2,54 @@
 
 ## Objective
 
-Continue the Codex runtime migration by restoring the repository change-plan document and migrating the GitHub Copilot `commit-steward` behavior into the layered Codex runtime surface.
+Continue the Codex runtime migration by moving the GitHub Copilot `orchestrator` workflow into the layered Codex runtime surface while preserving the existing separation between shared workflow skills, thin subagents, and prompt launchers.
 
 ## Current Migration Scope
 
-- Keep repository-local reusable skills under `.agents/skills/`
+- Keep repository-local reusable workflow rules under `.agents/skills/`
 - Keep Codex subagent definitions under `.codex/agents/`
-- Migrate bounded agent personas from `.github/agents/` into `.codex/agents/`
+- Keep prompt launchers under `.codex/prompts/`
+- Migrate Copilot workflow personas into shared Codex skills plus thin Codex agents
 
 ## This Increment
 
-1. Restore `change-plan.md` as the repository plan of record for the Codex migration.
-2. Split `commit-steward` into:
-   - a reusable shared skill for commit-message conventions
-   - a thin Codex-native subagent definition that delegates to that skill
-   - a thin Codex prompt launcher that spawns the subagent
-3. Preserve the original purpose:
-   - generate high-signal conventional commit messages
-   - scope analysis to staged changes only
-   - avoid speculative or noisy commit summaries
-4. Adapt the behavior to Codex-native execution:
-   - use the local workspace and git staging state directly
-   - allow an explicitly provided context file when available
-   - keep the agent output strict and copy-ready
+1. Migrate `.github/agents/orchestrator.agent.md` into:
+   - a reusable shared orchestration workflow skill
+   - a thin Codex-native `orchestrator` subagent that delegates to that skill
+2. Migrate `.github/prompts/orchestrate-work.prompt.md` into a Codex prompt launcher that spawns the new subagent.
+3. Preserve the original orchestration intent:
+   - estimate change budget first
+   - choose the correct small or large path
+   - persist orchestration state and resume deterministically
+   - continue through planning, execution, validation, and review until the selected path is complete
+4. Adapt the workflow to the current Codex runtime:
+   - route host-specific repo automation through `repo-automation-adapter`
+   - reuse the existing `feature-promotion-lifecycle`, `atomic-planner`, `atomic-executor`, `feature-review`, and language budget-router skills
+   - prefer currently migrated Codex subagents and keep direct-execution fallback only for steps whose specialist persona has not yet been migrated
+5. Normalize any new canonical lifecycle rules into the existing shared skills rather than duplicating them in the new orchestrator files.
 
 ## Design Rules
 
-1. Put reusable commit-message rules in one shared skill instead of duplicating them across agents or prompts.
+1. Put reusable orchestration rules in one shared skill instead of duplicating them across agents or prompts.
 2. Keep `.codex/agents/*.toml` concise and focused on bounded role behavior.
-3. Preserve stable naming where practical, but prefer Codex-friendly file names and agent names.
-4. Prefer direct staged git inspection over Copilot-specific context assumptions when running inside Codex.
+3. Preserve stable external names where practical:
+   - agent name `orchestrator`
+   - prompt name `orchestrate-work`
+4. Keep canonical variable and lifecycle rules in existing shared skills when those rules already have a natural owner.
+5. Do not hard-code `drmCopilotExtension.*` command execution in the new agent or prompt.
 
 ## Deliverables
 
 - `change-plan.md`
-- `.agents/skills/commit-message-conventions/SKILL.md`
-- `.codex/agents/commit-steward.toml`
-- `.codex/prompts/generate-commit-message-repo.md`
+- `.agents/skills/orchestrator-workflow/SKILL.md`
+- `.codex/agents/orchestrator.toml`
+- `.codex/prompts/orchestrate-work.md`
+- updates to shared skill docs and any existing shared lifecycle skill that now owns canonical orchestration details
 
 ## Verification
 
 - Confirm the new shared skill exists with valid Codex frontmatter.
 - Confirm the new agent file exists and parses as TOML.
 - Confirm the new prompt exists with valid Codex prompt frontmatter.
-- Confirm the skill and agent together preserve the staged-only commit-message scope.
-- Confirm the repository change-plan file exists again at the repo root.
+- Confirm the orchestrator skill references the existing shared lifecycle and routing skills instead of restating their rules.
+- Confirm canonical `plan-path` rules live in one shared skill only.

--- a/change-plan.md
+++ b/change-plan.md
@@ -1,0 +1,49 @@
+# Change Plan
+
+## Objective
+
+Continue the Codex runtime migration by restoring the repository change-plan document and migrating the GitHub Copilot `commit-steward` behavior into the layered Codex runtime surface.
+
+## Current Migration Scope
+
+- Keep repository-local reusable skills under `.agents/skills/`
+- Keep Codex subagent definitions under `.codex/agents/`
+- Migrate bounded agent personas from `.github/agents/` into `.codex/agents/`
+
+## This Increment
+
+1. Restore `change-plan.md` as the repository plan of record for the Codex migration.
+2. Split `commit-steward` into:
+   - a reusable shared skill for commit-message conventions
+   - a thin Codex-native subagent definition that delegates to that skill
+   - a thin Codex prompt launcher that spawns the subagent
+3. Preserve the original purpose:
+   - generate high-signal conventional commit messages
+   - scope analysis to staged changes only
+   - avoid speculative or noisy commit summaries
+4. Adapt the behavior to Codex-native execution:
+   - use the local workspace and git staging state directly
+   - allow an explicitly provided context file when available
+   - keep the agent output strict and copy-ready
+
+## Design Rules
+
+1. Put reusable commit-message rules in one shared skill instead of duplicating them across agents or prompts.
+2. Keep `.codex/agents/*.toml` concise and focused on bounded role behavior.
+3. Preserve stable naming where practical, but prefer Codex-friendly file names and agent names.
+4. Prefer direct staged git inspection over Copilot-specific context assumptions when running inside Codex.
+
+## Deliverables
+
+- `change-plan.md`
+- `.agents/skills/commit-message-conventions/SKILL.md`
+- `.codex/agents/commit-steward.toml`
+- `.codex/prompts/generate-commit-message-repo.md`
+
+## Verification
+
+- Confirm the new shared skill exists with valid Codex frontmatter.
+- Confirm the new agent file exists and parses as TOML.
+- Confirm the new prompt exists with valid Codex prompt frontmatter.
+- Confirm the skill and agent together preserve the staged-only commit-message scope.
+- Confirm the repository change-plan file exists again at the repo root.

--- a/change-plan.md
+++ b/change-plan.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Continue the Codex runtime migration by moving the GitHub Copilot `orchestrator` workflow into the layered Codex runtime surface while preserving the existing separation between shared workflow skills, thin subagents, and prompt launchers.
+Align the TaskMaster Codex runtime with the published `drm-copilot` MCP bridge so repository automation now targets the semantic MCP server surface instead of treating those operations as mostly unavailable in Codex.
 
 ## Current Migration Scope
 
@@ -13,43 +13,31 @@ Continue the Codex runtime migration by moving the GitHub Copilot `orchestrator`
 
 ## This Increment
 
-1. Migrate `.github/agents/orchestrator.agent.md` into:
-   - a reusable shared orchestration workflow skill
-   - a thin Codex-native `orchestrator` subagent that delegates to that skill
-2. Migrate `.github/prompts/orchestrate-work.prompt.md` into a Codex prompt launcher that spawns the new subagent.
-3. Preserve the original orchestration intent:
-   - estimate change budget first
-   - choose the correct small or large path
-   - persist orchestration state and resume deterministically
-   - continue through planning, execution, validation, and review until the selected path is complete
-4. Adapt the workflow to the current Codex runtime:
-   - route host-specific repo automation through `repo-automation-adapter`
-   - reuse the existing `feature-promotion-lifecycle`, `atomic-planner`, `atomic-executor`, `feature-review`, and language budget-router skills
-   - prefer currently migrated Codex subagents and keep direct-execution fallback only for steps whose specialist persona has not yet been migrated
-5. Normalize any new canonical lifecycle rules into the existing shared skills rather than duplicating them in the new orchestrator files.
+1. Update `repo-automation-adapter` so the canonical Codex path is the published MCP server name `drmCopilotExtension`.
+2. Add MCP dependency metadata for the adapter skill so the owning skill declares the external tool surface once.
+3. Replace stale guidance that treated feature promotion and feature-folder initialization as unavailable in Codex when no repo-local script existed.
+4. Update PR-context refresh guidance so it prefers the published `collect_pr_context` MCP tool before falling back to git reconstruction.
+5. Update migration and authoring docs so future migrations target semantic MCP tools on `drmCopilotExtension`, not raw VS Code command IDs.
 
 ## Design Rules
 
-1. Put reusable orchestration rules in one shared skill instead of duplicating them across agents or prompts.
-2. Keep `.codex/agents/*.toml` concise and focused on bounded role behavior.
-3. Preserve stable external names where practical:
-   - agent name `orchestrator`
-   - prompt name `orchestrate-work`
-4. Keep canonical variable and lifecycle rules in existing shared skills when those rules already have a natural owner.
-5. Do not hard-code `drmCopilotExtension.*` command execution in the new agent or prompt.
+1. Keep host-surface translation in `repo-automation-adapter`; do not restate MCP tool names across workflow skills.
+2. Prefer semantic MCP tool names on server `drmCopilotExtension` over raw `drmCopilotExtension.*` VS Code command IDs.
+3. Declare the MCP dependency once on the owning adapter skill instead of duplicating tool bindings across every caller.
+4. Keep canonical PR-context artifact paths in `pr-context-artifacts`.
+5. Preserve deterministic fallback rules only where the MCP surface is unavailable and a safe local fallback is still acceptable.
 
 ## Deliverables
 
 - `change-plan.md`
-- `.agents/skills/orchestrator-workflow/SKILL.md`
-- `.codex/agents/orchestrator.toml`
-- `.codex/prompts/orchestrate-work.md`
-- updates to shared skill docs and any existing shared lifecycle skill that now owns canonical orchestration details
+- `.agents/skills/repo-automation-adapter/SKILL.md`
+- `.agents/skills/repo-automation-adapter/agents/openai.yaml`
+- `.agents/skills/pr-context-artifacts/SKILL.md`
+- updates to `.agents/README.md` and `.agents/skills/README.md`
 
 ## Verification
 
-- Confirm the new shared skill exists with valid Codex frontmatter.
-- Confirm the new agent file exists and parses as TOML.
-- Confirm the new prompt exists with valid Codex prompt frontmatter.
-- Confirm the orchestrator skill references the existing shared lifecycle and routing skills instead of restating their rules.
-- Confirm canonical `plan-path` rules live in one shared skill only.
+- Confirm the adapter skill references server name `drmCopilotExtension` and the published semantic tool names.
+- Confirm the new `agents/openai.yaml` exists under `repo-automation-adapter`.
+- Confirm `pr-context-artifacts` now prefers the MCP collector before git fallback.
+- Confirm migration and authoring docs instruct future Codex migrations to target semantic MCP tools rather than raw VS Code command IDs.


### PR DESCRIPTION
Add Codex runtime support for repository skills, orchestration, and PR authoring

## Summary
- Adds Codex runtime support for repository-local skills, orchestration, commit authoring, and PR authoring.
- Introduces 22 new skill definitions under `.agents/skills/`, covering planning, review, policy, orchestration, PR context, and authoring workflows.
- Adds Codex agent configurations for `commit-steward`, `orchestrator`, and `pr-author`, plus prompt templates for commit, PR, and orchestration flows.
- Adds `.agents` documentation and `change-plan.md` to describe and stage the new runtime assets.
- Keeps the recorded change set additive only: 32 new files, 1,532 insertions, and 0 deletions.

## Why
- The recorded commits describe three coordinated goals: add a repository skill runtime and commit steward, migrate the orchestrator workflow to the Codex runtime, and support PR authoring via the published MCP surface.
- The added files cluster into skill definitions, Codex agent configs, prompts, and planning artifacts, which indicates a coordinated Codex-first workflow rollout rather than an isolated change.
- No explicit PR Intent text or feature-doc excerpts were provided in the PR-context bundle, so the rationale above is inferred conservatively from the commit log and diff inventory.

## What Changed
- Core behavior / architecture: Added 22 skill definitions under `.agents/skills/`, including orchestrator, PR authoring, PR context, planning, review, policy, change-budget, and remediation workflows.
- Tooling / automation / developer experience: Added `.codex/agents/commit-steward.toml`, `.codex/agents/orchestrator.toml`, `.codex/agents/pr-author.toml`, plus `.codex/prompts/generate-commit-message-repo.md`, `.codex/prompts/generate-pr.md`, and `.codex/prompts/orchestrate-work.md`.
- Tests: No test files are listed in the recorded diff.
- Docs / templates / agents: Added `.agents/README.md`, `.agents/skills/README.md`, `change-plan.md`, and `.agents/skills/repo-automation-adapter/agents/openai.yaml`.

## Architecture / How It Fits Together
- `.agents/skills/` is the main catalog of reusable workflow contracts and operating guidance.
- `.codex/agents/*.toml` appears to define the named Codex entry points that consume those skills.
- `.codex/prompts/*.md` supplies prompt surfaces for orchestration, commit-message generation, and PR generation.
- `change-plan.md` anchors the rollout scope alongside the runtime artifacts.

## Verification
### Completed
- Not verified in this PR (no tool outputs recorded in the PR-context summary).

### Recommended
- `git log --oneline origin/development..feature/codex-skills`
- `git diff --stat origin/development...feature/codex-skills`
- `git diff origin/development...feature/codex-skills -- .agents .codex change-plan.md`

## Backward Compatibility / Migration Notes
- The recorded diff is additive only: 32 new files were added, with 1,532 insertions and 0 deletions.
- No explicit backward-compatibility guarantees or migration steps are documented in the PR-context bundle.
- Any workflow migration expectations beyond the added assets are not described in the current bundle.

## Risks and Mitigations
- Risk: This PR adds 32 new runtime, prompt, and skill assets, so drift between `.agents/skills/`, `.codex/agents/`, and `.codex/prompts/` is a plausible review concern.
- Mitigation: The change is fully additive and grouped into clearly separated directories, which limits direct disruption to existing files in the recorded diff.
- Risk: The PR-context bundle contains no verification evidence and no CI status for `43e286ae4889d403bccffe8a473fb0980961c91d`.
- Mitigation: Run the recommended diff review and repository validation before merge.

## Review Guide
- Review the three commits in order to follow the implementation arc from skill runtime, to orchestrator migration, to PR authoring support.
- Inspect `.agents/skills/` first, with extra attention to `orchestrator-workflow`, `pr-authoring`, and `pr-context-artifacts`.
- Then review `.codex/agents/` and `.codex/prompts/` to confirm the runtime entry points line up with the new skill set.
- Finish with `.agents/README.md`, `.agents/skills/README.md`, and `change-plan.md` to confirm the documented scope matches the added assets.

## Follow-ups
- Attach tool outputs or CI evidence before merge, since none are recorded in the PR-context summary.
- Confirm whether any issue should be linked or auto-closed; the current bundle records none.
- If workflow migration details exist outside this bundle, add them in a future PR update or follow-up artifact.

## GitHub Auto-close
- None (no verified or author-asserted auto-close issues in the PR-context bundle)

## Related issues / PRs
- None recorded in the PR-context bundle.
