### PR TITLE
Harden Outlook sender and recipient resolution for Exchange fallback paths

### DIFF
--- a/UtilitiesCS.Test/OutlookObjects/Recipient/RecipientStaticSenderResolverTests.cs
+++ b/UtilitiesCS.Test/OutlookObjects/Recipient/RecipientStaticSenderResolverTests.cs
@@ -1,0 +1,347 @@
+using System;
+using FluentAssertions;
+using Microsoft.Office.Interop.Outlook;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using InteropMailItem = Microsoft.Office.Interop.Outlook.MailItem;
+
+namespace UtilitiesCS.Test.OutlookObjects.Recipient
+{
+    /// <summary>
+    /// Tests for the robust Exchange directory resolution paths in GetRecipientInfo,
+    /// GetSenderName, and GetSenderAddress. These cover the Exchange user lookup, COM-safe
+    /// fallback chains, and Exchange DN address handling that were absent in the previous
+    /// rudimentary implementations.
+    /// </summary>
+    [TestClass]
+    public class RecipientStaticSenderResolverTests
+    {
+        private const string SmtpAddressProperty =
+            "http://schemas.microsoft.com/mapi/proptag/0x39FE001E";
+
+        // ── GetRecipientInfo ──────────────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetRecipientInfo_WithExchangeUser_ReturnsExchangeNameAndSmtpAddress()
+        {
+            // Arrange: Exchange recipient whose raw Address is empty (Exchange DN not exposed),
+            // but whose Exchange directory entry carries both the display name and primary SMTP.
+            var exchangeUser = new Mock<ExchangeUser>();
+            exchangeUser.SetupGet(x => x.FirstName).Returns("Ada");
+            exchangeUser.SetupGet(x => x.LastName).Returns("Lovelace");
+            exchangeUser.SetupGet(x => x.PrimarySmtpAddress).Returns("ada@exchange.example.com");
+
+            var propertyAccessor = new Mock<PropertyAccessor>();
+            propertyAccessor
+                .Setup(x => x.GetProperty(SmtpAddressProperty))
+                .Returns((object)"ada@exchange.example.com");
+
+            var addressEntry = new Mock<AddressEntry>();
+            addressEntry
+                .SetupGet(x => x.AddressEntryUserType)
+                .Returns(OlAddressEntryUserType.olExchangeUserAddressEntry);
+            addressEntry.Setup(x => x.GetExchangeUser()).Returns(exchangeUser.Object);
+
+            var recipient = new Mock<Microsoft.Office.Interop.Outlook.Recipient>();
+            recipient.SetupGet(x => x.Name).Returns("Ada Display Name");
+            recipient.SetupGet(x => x.Address).Returns(string.Empty);
+            recipient.SetupGet(x => x.AddressEntry).Returns(addressEntry.Object);
+            recipient.SetupGet(x => x.PropertyAccessor).Returns(propertyAccessor.Object);
+
+            // Act
+            var (name, address) = RecipientStatic.GetRecipientInfo(recipient.Object);
+
+            // Assert: Exchange directory values take precedence over the raw recipient properties.
+            name.Should().Be("Ada Lovelace");
+            address.Should().Be("ada@exchange.example.com");
+        }
+
+        [TestMethod]
+        public void GetRecipientInfo_WithNonExchangeRecipient_ReturnsNameAndAddress()
+        {
+            // Arrange: standard SMTP recipient — no Exchange directory involved.
+            var propertyAccessor = new Mock<PropertyAccessor>();
+            propertyAccessor
+                .Setup(x => x.GetProperty(SmtpAddressProperty))
+                .Returns((object)"grace@example.com");
+
+            var addressEntry = new Mock<AddressEntry>();
+            addressEntry
+                .SetupGet(x => x.AddressEntryUserType)
+                .Returns(OlAddressEntryUserType.olSmtpAddressEntry);
+
+            var recipient = new Mock<Microsoft.Office.Interop.Outlook.Recipient>();
+            recipient.SetupGet(x => x.Name).Returns("Grace Hopper");
+            recipient.SetupGet(x => x.Address).Returns("grace@example.com");
+            recipient.SetupGet(x => x.AddressEntry).Returns(addressEntry.Object);
+            recipient.SetupGet(x => x.PropertyAccessor).Returns(propertyAccessor.Object);
+
+            // Act
+            var (name, address) = RecipientStatic.GetRecipientInfo(recipient.Object);
+
+            // Assert
+            name.Should().Be("Grace Hopper");
+            address.Should().Be("grace@example.com");
+        }
+
+        // ── GetSenderName (MailItem) ──────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetSenderName_ForMailItemWithNullSender_ReturnsSenderName()
+        {
+            // Arrange: Sender AddressEntry not available; fall back to the stored SenderName.
+            var mail = new Mock<InteropMailItem>();
+            mail.SetupGet(x => x.Sender).Returns((AddressEntry)null);
+            mail.SetupGet(x => x.SenderName).Returns("Ada Lovelace");
+
+            // Act
+            var result = mail.Object.GetSenderName();
+
+            // Assert
+            result.Should().Be("Ada Lovelace");
+        }
+
+        [TestMethod]
+        public void GetSenderName_ForMailItemWithExchangeUser_ReturnsExchangeDirectoryName()
+        {
+            // Arrange: Exchange sender whose SenderName differs from the directory first/last pair.
+            // The Exchange directory name is the authoritative source and must take precedence.
+            var exchUser = new Mock<ExchangeUser>();
+            exchUser.SetupGet(x => x.FirstName).Returns("Ada");
+            exchUser.SetupGet(x => x.LastName).Returns("Lovelace");
+
+            var sender = new Mock<AddressEntry>();
+            sender
+                .SetupGet(x => x.AddressEntryUserType)
+                .Returns(OlAddressEntryUserType.olExchangeUserAddressEntry);
+            sender.Setup(x => x.GetExchangeUser()).Returns(exchUser.Object);
+
+            var mail = new Mock<InteropMailItem>();
+            mail.SetupGet(x => x.Sender).Returns(sender.Object);
+            mail.SetupGet(x => x.SenderName).Returns("ada.lovelace@example.com");
+
+            // Act
+            var result = mail.Object.GetSenderName();
+
+            // Assert: directory name preferred over the mail-item SenderName field.
+            result.Should().Be("Ada Lovelace");
+        }
+
+        [TestMethod]
+        public void GetSenderName_ForMailItemWhenGetExchangeUserReturnsNull_FallsBackToAddressEntryName()
+        {
+            // Arrange: Exchange user type but GetExchangeUser returns null; fall back to
+            // AddressEntry.Name which is more reliable than the mail-item SenderName field.
+            var sender = new Mock<AddressEntry>();
+            sender
+                .SetupGet(x => x.AddressEntryUserType)
+                .Returns(OlAddressEntryUserType.olExchangeUserAddressEntry);
+            sender.Setup(x => x.GetExchangeUser()).Returns((ExchangeUser)null);
+            sender.SetupGet(x => x.Name).Returns("Ada from AddressEntry");
+
+            var mail = new Mock<InteropMailItem>();
+            mail.SetupGet(x => x.Sender).Returns(sender.Object);
+            mail.SetupGet(x => x.SenderName).Returns("Ada from SenderName");
+
+            // Act
+            var result = mail.Object.GetSenderName();
+
+            // Assert: AddressEntry.Name preferred over SenderName when ExchangeUser is unavailable.
+            result.Should().Be("Ada from AddressEntry");
+        }
+
+        [TestMethod]
+        public void GetSenderName_ForMailItemWhenExchangeLookupThrows_FallsBackToAddressEntryName()
+        {
+            // Arrange: Exchange directory lookup throws a COM exception; the method must not
+            // propagate the exception and must return AddressEntry.Name instead.
+            var sender = new Mock<AddressEntry>();
+            sender
+                .SetupGet(x => x.AddressEntryUserType)
+                .Returns(OlAddressEntryUserType.olExchangeUserAddressEntry);
+            sender
+                .Setup(x => x.GetExchangeUser())
+                .Throws(new InvalidOperationException("COM call failed"));
+            sender.SetupGet(x => x.Name).Returns("Ada Lovelace");
+
+            var mail = new Mock<InteropMailItem>();
+            mail.SetupGet(x => x.Sender).Returns(sender.Object);
+            mail.SetupGet(x => x.SenderName).Returns("Ada Lovelace");
+
+            // Act — must not throw
+            var result = mail.Object.GetSenderName();
+
+            // Assert
+            result.Should().Be("Ada Lovelace");
+        }
+
+        // ── GetSenderAddress (MailItem) ────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetSenderAddress_ForMailItemWithNullSender_ReturnsSenderEmailAddress()
+        {
+            // Arrange
+            var mail = new Mock<InteropMailItem>();
+            mail.SetupGet(x => x.Sender).Returns((AddressEntry)null);
+            mail.SetupGet(x => x.SenderEmailAddress).Returns("ada@example.com");
+
+            // Act
+            var result = mail.Object.GetSenderAddress();
+
+            // Assert
+            result.Should().Be("ada@example.com");
+        }
+
+        [TestMethod]
+        public void GetSenderAddress_ForMailItemWithExchangeUser_ReturnsPrimarySmtpAddress()
+        {
+            // Arrange: Exchange sender with a valid primary SMTP in the directory.
+            // The raw SenderEmailAddress may be an Exchange DN and must not be returned.
+            var exchUser = new Mock<ExchangeUser>();
+            exchUser.SetupGet(x => x.PrimarySmtpAddress).Returns("ada@exchange.example.com");
+
+            var sender = new Mock<AddressEntry>();
+            sender
+                .SetupGet(x => x.AddressEntryUserType)
+                .Returns(OlAddressEntryUserType.olExchangeUserAddressEntry);
+            sender.Setup(x => x.GetExchangeUser()).Returns(exchUser.Object);
+
+            var mail = new Mock<InteropMailItem>();
+            mail.SetupGet(x => x.Sender).Returns(sender.Object);
+            mail.SetupGet(x => x.SenderEmailAddress).Returns("/o=ExchangeLabs/dn=Ada");
+
+            // Act
+            var result = mail.Object.GetSenderAddress();
+
+            // Assert: primary SMTP from Exchange directory takes precedence over the raw field.
+            result.Should().Be("ada@exchange.example.com");
+        }
+
+        [TestMethod]
+        public void GetSenderAddress_ForMailItemWhenGetExchangeUserReturnsNull_FallsBackToSenderEmailAddress()
+        {
+            // Arrange: Exchange user type but no user object accessible; SenderEmailAddress
+            // contains a valid SMTP address that should be used.
+            var sender = new Mock<AddressEntry>();
+            sender
+                .SetupGet(x => x.AddressEntryUserType)
+                .Returns(OlAddressEntryUserType.olExchangeUserAddressEntry);
+            sender.Setup(x => x.GetExchangeUser()).Returns((ExchangeUser)null);
+
+            var mail = new Mock<InteropMailItem>();
+            mail.SetupGet(x => x.Sender).Returns(sender.Object);
+            mail.SetupGet(x => x.SenderEmailAddress).Returns("ada@example.com");
+
+            // Act
+            var result = mail.Object.GetSenderAddress();
+
+            // Assert
+            result.Should().Be("ada@example.com");
+        }
+
+        [TestMethod]
+        public void GetSenderAddress_ForMailItemWhenSenderEmailAddressEmpty_UsesPropertyAccessorFallback()
+        {
+            // Arrange: neither Exchange user nor SenderEmailAddress provides an SMTP address;
+            // the PropertyAccessor carries the SMTP via the MAPI PR_SMTP_ADDRESS property.
+            var propertyAccessor = new Mock<PropertyAccessor>();
+            propertyAccessor
+                .Setup(x => x.GetProperty(SmtpAddressProperty))
+                .Returns((object)"ada@example.com");
+
+            var sender = new Mock<AddressEntry>();
+            sender
+                .SetupGet(x => x.AddressEntryUserType)
+                .Returns(OlAddressEntryUserType.olSmtpAddressEntry);
+            sender.SetupGet(x => x.Address).Returns(string.Empty);
+            sender.SetupGet(x => x.PropertyAccessor).Returns(propertyAccessor.Object);
+
+            var mail = new Mock<InteropMailItem>();
+            mail.SetupGet(x => x.Sender).Returns(sender.Object);
+            mail.SetupGet(x => x.SenderEmailAddress).Returns(string.Empty);
+
+            // Act
+            var result = mail.Object.GetSenderAddress();
+
+            // Assert: MAPI property accessor used as fallback when direct addresses are absent.
+            result.Should().Be("ada@example.com");
+        }
+
+        [TestMethod]
+        public void GetSenderAddress_ForMailItemWhenAllFallbacksFail_ReturnsEmptyString()
+        {
+            // Arrange: no address is available from any source; final fallback must be "".
+            var propertyAccessor = new Mock<PropertyAccessor>();
+            propertyAccessor
+                .Setup(x => x.GetProperty(SmtpAddressProperty))
+                .Throws(new InvalidOperationException("property not found"));
+
+            var sender = new Mock<AddressEntry>();
+            sender
+                .SetupGet(x => x.AddressEntryUserType)
+                .Returns(OlAddressEntryUserType.olSmtpAddressEntry);
+            sender.SetupGet(x => x.Address).Returns(string.Empty);
+            sender.SetupGet(x => x.PropertyAccessor).Returns(propertyAccessor.Object);
+
+            var mail = new Mock<InteropMailItem>();
+            mail.SetupGet(x => x.Sender).Returns(sender.Object);
+            mail.SetupGet(x => x.SenderEmailAddress).Returns(string.Empty);
+            mail.SetupGet(x => x.SenderName).Returns(string.Empty);
+
+            // Act
+            var result = mail.Object.GetSenderAddress();
+
+            // Assert
+            result.Should().BeEmpty();
+        }
+
+        // ── GetSenderAddress (MeetingItem) ─────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetSenderAddress_ForMeetingItemWithValidSmtpAddress_ReturnsSmtpAddress()
+        {
+            // Arrange: meeting sender with a normal SMTP address.
+            var meeting = new Mock<MeetingItem>();
+            meeting.SetupGet(x => x.SenderEmailAddress).Returns("ada@example.com");
+
+            // Act
+            var result = meeting.Object.GetSenderAddress();
+
+            // Assert
+            result.Should().Be("ada@example.com");
+        }
+
+        [TestMethod]
+        public void GetSenderAddress_ForMeetingItemWithExchangeDnAddress_FallsBackToSenderName()
+        {
+            // Arrange: Exchange DN address stored in SenderEmailAddress cannot be used
+            // as SMTP without a session reference; the method must fall back to SenderName.
+            var meeting = new Mock<MeetingItem>();
+            meeting
+                .SetupGet(x => x.SenderEmailAddress)
+                .Returns("/o=ExchangeLabs/ou=Exchange Administrative Group/cn=Ada Lovelace");
+            meeting.SetupGet(x => x.SenderName).Returns("Ada Lovelace");
+
+            // Act
+            var result = meeting.Object.GetSenderAddress();
+
+            // Assert
+            result.Should().Be("Ada Lovelace");
+        }
+
+        [TestMethod]
+        public void GetSenderAddress_ForMeetingItemWithEmptyAddress_FallsBackToSenderName()
+        {
+            // Arrange: empty SenderEmailAddress (e.g. externally organised meeting).
+            var meeting = new Mock<MeetingItem>();
+            meeting.SetupGet(x => x.SenderEmailAddress).Returns(string.Empty);
+            meeting.SetupGet(x => x.SenderName).Returns("Ada Lovelace");
+
+            // Act
+            var result = meeting.Object.GetSenderAddress();
+
+            // Assert
+            result.Should().Be("Ada Lovelace");
+        }
+    }
+}

--- a/UtilitiesCS.Test/OutlookObjects/Recipient/RecipientStaticTests.cs
+++ b/UtilitiesCS.Test/OutlookObjects/Recipient/RecipientStaticTests.cs
@@ -121,6 +121,14 @@ namespace UtilitiesCS.Test.OutlookObjects.Recipient
             resolvedRecipient.SetupGet(x => x.Name).Returns("Ada Lovelace");
             resolvedRecipient.SetupGet(x => x.Address).Returns("ada@example.com");
 
+            // GetRecipientInfo now delegates to GetRecipientName/GetRecipientAddress, which
+            // access AddressEntry; use an SMTP entry type so the Exchange path is not taken.
+            var resolvedAddressEntry = new Mock<AddressEntry>();
+            resolvedAddressEntry
+                .SetupGet(x => x.AddressEntryUserType)
+                .Returns(OlAddressEntryUserType.olSmtpAddressEntry);
+            resolvedRecipient.SetupGet(x => x.AddressEntry).Returns(resolvedAddressEntry.Object);
+
             // Act
             var result = mail.Object.GetSenderInfo(nameSpace.Object);
 

--- a/UtilitiesCS.Test/UtilitiesCS.Test.csproj
+++ b/UtilitiesCS.Test/UtilitiesCS.Test.csproj
@@ -284,6 +284,7 @@
     <Compile Include="OutlookObjects\MailItem\MailItemHelperCoreTests.cs" />
     <Compile Include="OutlookObjects\Recipient\RecipientInfoTests.cs" />
     <Compile Include="OutlookObjects\Recipient\RecipientStaticTests.cs" />
+    <Compile Include="OutlookObjects\Recipient\RecipientStaticSenderResolverTests.cs" />
     <Compile Include="OutlookObjects\MailItem\MailResolutionTests.cs" />
     <Compile Include="OutlookObjects\Store\StoreWrapperTests.cs" />
     <Compile Include="OutlookObjects\Store\StoreWrapperViewerTests.cs" />

--- a/UtilitiesCS/OutlookObjects/Recipient/RecipientStatic.cs
+++ b/UtilitiesCS/OutlookObjects/Recipient/RecipientStatic.cs
@@ -60,87 +60,131 @@ namespace UtilitiesCS
 
         public static string GetSenderName(this MailItem olMail)
         {
-            var name = olMail.SenderName;
-            return name;
-            //AddressEntry sender = olMail.Sender;
-            //string senderName = "";
+            AddressEntry sender = olMail.Sender;
+            if (sender is null)
+            {
+                return olMail.SenderName ?? string.Empty;
+            }
 
-            //if (sender?.AddressEntryUserType == OlAddressEntryUserType.olExchangeUserAddressEntry || sender?.AddressEntryUserType == OlAddressEntryUserType.olExchangeRemoteUserAddressEntry)
-            //{
-            //    ExchangeUser exchUser = sender.GetExchangeUser();
-            //    if (exchUser != null)
-            //    {
-            //        senderName = $"{exchUser.FirstName} {exchUser.LastName}";
-            //    }
-            //    else
-            //    {
-            //        senderName = sender.Name;
-            //    }
-            //}
-            //else
-            //{
-            //    senderName = olMail.SenderName;
-            //}
-            //return senderName;
+            // Prefer the Exchange directory name (first + last) over the mail-item SenderName
+            // field, which can be stale or formatted differently from the directory entry.
+            try
+            {
+                if (
+                    sender.AddressEntryUserType == OlAddressEntryUserType.olExchangeUserAddressEntry
+                    || sender.AddressEntryUserType
+                        == OlAddressEntryUserType.olExchangeRemoteUserAddressEntry
+                )
+                {
+                    ExchangeUser exchUser = sender.GetExchangeUser();
+                    if (exchUser != null)
+                    {
+                        return $"{exchUser.FirstName} {exchUser.LastName}";
+                    }
+                }
+            }
+            catch (System.Exception ex)
+            {
+                logger.Warn(
+                    "GetSenderName (MailItem): Exchange directory lookup failed; falling back to display name.",
+                    ex
+                );
+            }
+
+            // AddressEntry.Name is more current than the stored SenderName field.
+            return !sender.Name.IsNullOrEmpty() ? sender.Name : olMail.SenderName ?? string.Empty;
         }
 
         public static string GetSenderName(this MeetingItem olMeeting)
         {
-            return olMeeting.SenderName;
+            return olMeeting.SenderName ?? string.Empty;
         }
 
         public static string GetSenderAddress(this MeetingItem olMeeting)
         {
-            return olMeeting.SenderEmailAddress;
+            var address = olMeeting.SenderEmailAddress ?? string.Empty;
+
+            // Exchange DN addresses (X500 format) cannot be resolved to a usable SMTP address
+            // without a session reference; fall back to the display name in those cases.
+            if (address.IsNullOrEmpty() || address.StartsWith("/o=ExchangeLabs"))
+            {
+                var name = olMeeting.SenderName ?? string.Empty;
+                return name.StartsWith("/o=ExchangeLabs") ? string.Empty : name;
+            }
+
+            return address;
         }
 
         public static string GetSenderAddress(this MailItem olMail)
         {
-            return olMail.SenderEmailAddress;
-            //AddressEntry sender = olMail.Sender;
-            //string senderAddress = "";
+            AddressEntry sender = olMail.Sender;
+            if (sender is null)
+            {
+                return olMail.SenderEmailAddress ?? string.Empty;
+            }
 
-            //if (sender?.AddressEntryUserType == OlAddressEntryUserType.olExchangeUserAddressEntry || sender?.AddressEntryUserType == OlAddressEntryUserType.olExchangeRemoteUserAddressEntry)
-            //{
-            //    ExchangeUser exchUser = sender.GetExchangeUser();
-            //    if (exchUser != null)
-            //    {
-            //        senderAddress = exchUser.PrimarySmtpAddress;
-            //    }
-            //    else
-            //    {
-            //        senderAddress = sender.Address;
-            //    }
-            //}
-            //else
-            //{
-            //    senderAddress = olMail.SenderEmailAddress;
-            //}
-            //if (senderAddress.IsNullOrEmpty())
-            //{
-            //    var olPA = sender.PropertyAccessor;
-            //    try
-            //    {
-            //        senderAddress = olPA.GetProperty(PR_SMTP_ADDRESS) as string;
-            //        if (senderAddress.IsNullOrEmpty())
-            //            throw new InvalidOperationException("Sender address is null or empty");
-            //    }
-            //    catch
-            //    {
-            //        try
-            //        {
-            //            senderAddress = olMail.SenderName;
-            //            if (senderAddress.IsNullOrEmpty() || senderAddress.StartsWith("/o=ExchangeLabs"))
-            //                throw new InvalidOperationException("Sender address and name are null or empty");
-            //        }
-            //        catch
-            //        {
-            //            senderAddress = "";
-            //        }
-            //    }
-            //}
+            // Prefer the Exchange directory primary SMTP over the mail-item field, which
+            // may contain a stale or X500 Exchange DN address.
+            string address = null;
+            try
+            {
+                if (
+                    sender.AddressEntryUserType == OlAddressEntryUserType.olExchangeUserAddressEntry
+                    || sender.AddressEntryUserType
+                        == OlAddressEntryUserType.olExchangeRemoteUserAddressEntry
+                )
+                {
+                    ExchangeUser exchUser = sender.GetExchangeUser();
+                    if (exchUser != null)
+                    {
+                        address = exchUser.PrimarySmtpAddress;
+                    }
+                }
+            }
+            catch (System.Exception ex)
+            {
+                logger.Warn(
+                    "GetSenderAddress (MailItem): Exchange directory lookup failed; falling back.",
+                    ex
+                );
+            }
 
-            //return senderAddress;
+            // Fall back to the mail-item address fields when Exchange lookup yields nothing.
+            if (address.IsNullOrEmpty())
+            {
+                address = !olMail.SenderEmailAddress.IsNullOrEmpty()
+                    ? olMail.SenderEmailAddress
+                    : sender.Address;
+            }
+
+            // Last resort: query the MAPI property accessor, then use SenderName if still empty.
+            if (address.IsNullOrEmpty())
+            {
+                var olPA = sender.PropertyAccessor;
+                try
+                {
+                    address = (string)olPA.GetProperty(PR_SMTP_ADDRESS);
+                    if (address.IsNullOrEmpty())
+                        throw new InvalidOperationException("SMTP address is null or empty");
+                }
+                catch
+                {
+                    try
+                    {
+                        address = olMail.SenderName;
+                        if (address.IsNullOrEmpty() || address.StartsWith("/o=ExchangeLabs"))
+                            throw new InvalidOperationException(
+                                "Sender address and name are null, empty, or malformed"
+                            );
+                    }
+                    catch (System.Exception)
+                    {
+                        address = string.Empty;
+                    }
+                }
+            }
+
+            return address ?? string.Empty;
         }
 
         public static IRecipientInfo GetSenderInfo(this MeetingItem olMeeting)
@@ -524,41 +568,9 @@ namespace UtilitiesCS
 
         internal static (string Name, string Address) GetRecipientInfo(Recipient recipient)
         {
-            string name,
-                address;
-            name = recipient.Name;
-            address = recipient.Address;
-            //try
-            //{
-            //    if (recipient.AddressEntry.AddressEntryUserType == OlAddressEntryUserType.olExchangeUserAddressEntry || recipient.AddressEntry.AddressEntryUserType == OlAddressEntryUserType.olExchangeRemoteUserAddressEntry)
-            //    {
-            //        ExchangeUser exchUser = recipient.AddressEntry.GetExchangeUser();
-            //        if (exchUser != null)
-            //        {
-            //            var firstNameExch = exchUser.FirstName;
-            //            address = exchUser.PrimarySmtpAddress;
-            //            var rx = new Regex(@"^(.+)@([^@]+)$");
-            //            name = $"{exchUser.FirstName} {exchUser.LastName}";
-            //        }
-            //        else
-            //        {
-            //            name = recipient.Name;
-            //            address = recipient.Address;
-            //        }
-            //    }
-            //    else
-            //    {
-            //        name = recipient.Name;
-            //        address = recipient.Address;
-            //    }
-            //}
-            //catch (System.Exception)
-            //{
-            //    name = recipient.Name;
-            //    address = recipient.Address;
-            //}
-
-            return (name, address);
+            // Delegate to the robust helpers so Exchange directory lookup and PropertyAccessor
+            // fallbacks are applied consistently — matching the GetInfo / GetRecipients paths.
+            return (GetRecipientName(recipient), GetRecipientAddress(recipient));
         }
 
         private static string GetRecipientName(Recipient olRecipient)


### PR DESCRIPTION
Harden Outlook sender and recipient resolution for Exchange fallback paths

## Summary

- Harden `UtilitiesCS/OutlookObjects/Recipient/RecipientStatic.cs` so sender and recipient resolution uses Exchange-aware fallback logic instead of relying only on stored Outlook fields.
- Route `GetRecipientInfo` through the shared recipient helper paths so Exchange directory and MAPI SMTP lookup behavior stays consistent with the broader recipient-resolution flow.
- Improve `MailItem` and `MeetingItem` sender handling for null senders, Exchange user lookups, Exchange DN values, and empty-address fallback scenarios.
- Add focused MSTest coverage in `UtilitiesCS.Test/OutlookObjects/Recipient/RecipientStaticSenderResolverTests.cs` and update existing recipient tests to match the new helper behavior.
- Register the new test file in `UtilitiesCS.Test/UtilitiesCS.Test.csproj`.

## Why

- The branch and commit intent indicate a correctness fix for recipient-name resolution in Outlook interop code.
- The changed-file set is concentrated in `RecipientStatic.cs` and matching recipient-focused tests, which supports a targeted fix rather than a broader refactor.
- No feature-doc excerpts or PR Intent details were provided in the allowed context, so the motivation that can be stated confidently is limited to making sender/recipient resolution more robust across Exchange and fallback cases.

## What Changed

- Core behavior / architecture
  - Updated `RecipientStatic.cs` to restore and harden Exchange-aware resolution paths for `GetSenderName`, `GetSenderAddress`, and `GetRecipientInfo`.
  - Added fallback behavior for null senders, Exchange directory lookup failures, property-accessor SMTP resolution, and Exchange DN values on meeting items.
- Tests
  - Added `RecipientStaticSenderResolverTests.cs` with focused coverage for Exchange user resolution, null sender fallbacks, COM-failure fallback behavior, and meeting-item address handling.
  - Adjusted `RecipientStaticTests.cs` so the existing sender-info test uses an SMTP `AddressEntry` and remains aligned with the new helper delegation path.
  - Included the new test file in `UtilitiesCS.Test.csproj`.
- Tooling / automation / CI / DevEx
  - No tooling, CI, or automation changes are recorded in the allowed context.
- Docs / templates / agents
  - No documentation, template, or agent changes are recorded in the allowed context.

## Architecture / How It Fits Together

- `RecipientStatic.cs` remains the central Outlook interop helper for sender and recipient identity extraction.
- `MailItem` and `MeetingItem` extension methods now prefer Exchange-aware data when available, then fall back through stored Outlook fields and MAPI property access when Exchange data is unavailable or unusable.
- `GetRecipientInfo` now delegates to the shared recipient helper methods rather than returning raw `Recipient.Name` and `Recipient.Address`, which aligns recipient info resolution with the same fallback logic used elsewhere in the recipient pipeline.
- The new MSTest coverage exercises these resolution branches directly, while the updated existing test validates the revised delegation path.

## Verification

### Completed

- Not verified in this PR (no tool outputs recorded in `artifacts/pr_context.summary.txt`).

### Recommended

- Run the repository's standard C# formatting step for the branch.
- Run the repository's standard analyzer/build validation for the branch.
- Run the repository's nullable/type-safety build validation for the branch.
- Run the MSTest suite covering `UtilitiesCS.Test`, including the new sender resolver tests.

## Backward Compatibility / Migration Notes

- No public API renames, moved files, or deleted files are recorded in the allowed context.
- This PR changes runtime resolution behavior in `RecipientStatic.cs`; callers should receive more robust sender/recipient names and addresses in Exchange-related and fallback scenarios.
- No migration steps are indicated by the allowed context.

## Risks and Mitigations

- Risk: Fallback precedence changes could alter returned sender or recipient values for existing Outlook message shapes.
  - Mitigation: The PR adds focused tests for Exchange-user, null-sender, property-accessor, and Exchange-DN scenarios.
- Risk: Outlook interop calls can fail unpredictably at runtime when Exchange directory access is unavailable.
  - Mitigation: The updated logic adds explicit fallback paths instead of relying on a single Outlook field.
- Risk: Meeting-item sender handling may still vary across Outlook environments not represented in the current test cases.
  - Mitigation: The new tests cover the main empty-address and Exchange-DN fallback cases introduced by this change.

## Review Guide

- Review `UtilitiesCS/OutlookObjects/Recipient/RecipientStatic.cs` first to understand the fallback order for sender and recipient resolution.
- Review the `MailItem` sender name/address changes next, focusing on Exchange-aware behavior and null/exception fallbacks.
- Review the `MeetingItem` sender-address handling for Exchange DN and empty-address cases.
- Review the `GetRecipientInfo` delegation change to confirm it now aligns with the shared recipient helper path.
- Review `UtilitiesCS.Test/OutlookObjects/Recipient/RecipientStaticSenderResolverTests.cs` for scenario coverage and expected behavior.
- Review the small update in `UtilitiesCS.Test/OutlookObjects/Recipient/RecipientStaticTests.cs` to confirm the existing test setup still matches the new path.
- Review `UtilitiesCS.Test/UtilitiesCS.Test.csproj` last; it only wires the new test file into the test project.

## Follow-ups

- Add canonical verification evidence to the PR context before merge if format/build/test results are collected later.
- Expand Outlook interop coverage further if additional sender or recipient edge cases are discovered outside the scenarios covered in this change.

## GitHub Auto-close

- None (no verified closing issues listed; fill “Author-asserted autoclose issues” in PR Intent to enable auto-close)

## Related issues / PRs

- None