### PR TITLE
(fix(outlook-recipient)): prevent background COM recipient crashes

### DIFF
--- a/UtilitiesCS.Test/OutlookObjects/MailItem/MailItemHelperCoreTests.cs
+++ b/UtilitiesCS.Test/OutlookObjects/MailItem/MailItemHelperCoreTests.cs
@@ -1,10 +1,15 @@
 using System;
+using System.Collections;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Office.Interop.Outlook;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using UtilitiesCS.EmailIntelligence;
 using InteropMailItem = Microsoft.Office.Interop.Outlook.MailItem;
 using OutlookFolder = Microsoft.Office.Interop.Outlook.Folder;
 
@@ -109,6 +114,103 @@ namespace UtilitiesCS.Test.OutlookObjects.MailItem
             MailItemHelper.CompressPlainText(string.Empty, string.Empty).Should().NotBeNull();
         }
 
+        [TestMethod]
+        public async Task FromMailItemAsync_MaterializesTokenizationDependenciesBeforeBackgroundTokenAccess()
+        {
+            var mailItem = new Mock<InteropMailItem>();
+            var archiveRoot = new Mock<OutlookFolder>();
+            var inbox = new Mock<OutlookFolder>();
+            var globals = CreateGlobals(archiveRoot.Object, inbox.Object, "\\Archive");
+            var sender = CreateSenderMock("Ada Sender", "ada@example.com");
+            var toRecipient = CreateRecipientMock(
+                "To User",
+                "to@example.com",
+                (int)OlMailRecipientType.olTo
+            );
+            var ccRecipient = CreateRecipientMock(
+                "Cc User",
+                "cc@example.com",
+                (int)OlMailRecipientType.olCC
+            );
+            var recipients = CreateRecipientsMock(toRecipient.Object, ccRecipient.Object);
+            var attachments = CreateAttachmentsMock();
+
+            var subjectReads = 0;
+            var bodyReads = 0;
+            var htmlBodyReads = 0;
+            var senderReads = 0;
+            var recipientsReads = 0;
+            var attachmentsReads = 0;
+
+            mailItem.SetupGet(x => x.Subject).Callback(() => subjectReads++).Returns("Subject");
+            mailItem.SetupGet(x => x.Body).Callback(() => bodyReads++).Returns("Body");
+            mailItem
+                .SetupGet(x => x.HTMLBody)
+                .Callback(() => htmlBodyReads++)
+                .Returns("<html><body>Body</body></html>");
+            mailItem.SetupGet(x => x.SenderName).Returns("Ada Sender");
+            mailItem.SetupGet(x => x.SenderEmailAddress).Returns("ada@example.com");
+            mailItem.SetupGet(x => x.EntryID).Returns("entry-1");
+            mailItem.SetupGet(x => x.Sender).Callback(() => senderReads++).Returns(sender.Object);
+            mailItem
+                .SetupGet(x => x.Recipients)
+                .Callback(() => recipientsReads++)
+                .Returns(recipients.Object);
+            mailItem
+                .SetupGet(x => x.Attachments)
+                .Callback(() => attachmentsReads++)
+                .Returns(attachments.Object);
+
+            var helper = await MailItemHelper.FromMailItemAsync(
+                mailItem.Object,
+                globals.Object,
+                CancellationToken.None,
+                loadAll: false
+            );
+
+            subjectReads.Should().BeGreaterThan(0);
+            bodyReads.Should().BeGreaterThan(0);
+            htmlBodyReads.Should().BeGreaterThan(0);
+            senderReads.Should().BeGreaterThan(0);
+            recipientsReads.Should().BeGreaterThan(0);
+            attachmentsReads.Should().BeGreaterThan(0);
+
+            var subjectReadsAfterMaterialization = subjectReads;
+            var bodyReadsAfterMaterialization = bodyReads;
+            var htmlBodyReadsAfterMaterialization = htmlBodyReads;
+            var senderReadsAfterMaterialization = senderReads;
+            var recipientsReadsAfterMaterialization = recipientsReads;
+            var attachmentsReadsAfterMaterialization = attachmentsReads;
+
+            var tokenizer = new Mock<IEmailTokenizer>();
+            tokenizer
+                .Setup(x => x.Tokenize(It.IsAny<IItemInfo>()))
+                .Returns(
+                    (IItemInfo info) =>
+                    {
+                        _ = info.Subject;
+                        _ = info.Body;
+                        _ = info.HTMLBody;
+                        _ = info.Sender;
+                        _ = info.ToRecipients;
+                        _ = info.CcRecipients;
+                        _ = info.AttachmentsInfo;
+                        return new[] { "token" };
+                    }
+                );
+            SetField(helper, "_tokenizer", tokenizer.Object);
+
+            var tokens = await Task.Run(() => helper.Tokens);
+
+            tokens.Should().Equal("token");
+            subjectReads.Should().Be(subjectReadsAfterMaterialization);
+            bodyReads.Should().Be(bodyReadsAfterMaterialization);
+            htmlBodyReads.Should().Be(htmlBodyReadsAfterMaterialization);
+            senderReads.Should().Be(senderReadsAfterMaterialization);
+            recipientsReads.Should().Be(recipientsReadsAfterMaterialization);
+            attachmentsReads.Should().Be(attachmentsReadsAfterMaterialization);
+        }
+
         private static Mock<IApplicationGlobals> CreateGlobals(
             OutlookFolder archiveRoot,
             OutlookFolder inbox,
@@ -119,10 +221,77 @@ namespace UtilitiesCS.Test.OutlookObjects.MailItem
             olObjects.SetupGet(x => x.ArchiveRoot).Returns(archiveRoot);
             olObjects.SetupGet(x => x.Inbox).Returns(inbox);
             olObjects.SetupGet(x => x.ArchiveRootPath).Returns(archiveRootPath);
+            olObjects.SetupGet(x => x.EmailPrefixToStrip).Returns(string.Empty);
 
             var globals = new Mock<IApplicationGlobals>();
             globals.SetupGet(x => x.Ol).Returns(olObjects.Object);
             return globals;
+        }
+
+        private static Mock<AddressEntry> CreateSenderMock(string name, string address)
+        {
+            var propertyAccessor = new Mock<PropertyAccessor>();
+            var sender = new Mock<AddressEntry>();
+
+            sender
+                .SetupGet(x => x.AddressEntryUserType)
+                .Returns(OlAddressEntryUserType.olSmtpAddressEntry);
+            sender.SetupGet(x => x.Name).Returns(name);
+            sender.SetupGet(x => x.Address).Returns(address);
+            sender.SetupGet(x => x.PropertyAccessor).Returns(propertyAccessor.Object);
+
+            return sender;
+        }
+
+        private static Mock<Microsoft.Office.Interop.Outlook.Recipient> CreateRecipientMock(
+            string name,
+            string address,
+            int type
+        )
+        {
+            var propertyAccessor = new Mock<PropertyAccessor>();
+            var addressEntry = new Mock<AddressEntry>();
+            var recipient = new Mock<Microsoft.Office.Interop.Outlook.Recipient>();
+
+            addressEntry
+                .SetupGet(x => x.AddressEntryUserType)
+                .Returns(OlAddressEntryUserType.olSmtpAddressEntry);
+            addressEntry.SetupGet(x => x.Name).Returns(name);
+            recipient.SetupGet(x => x.Name).Returns(name);
+            recipient.SetupGet(x => x.Address).Returns(address);
+            recipient.SetupGet(x => x.Type).Returns(type);
+            recipient.SetupGet(x => x.AddressEntry).Returns(addressEntry.Object);
+            recipient.SetupGet(x => x.PropertyAccessor).Returns(propertyAccessor.Object);
+
+            return recipient;
+        }
+
+        private static Mock<Recipients> CreateRecipientsMock(
+            params Microsoft.Office.Interop.Outlook.Recipient[] recipients
+        )
+        {
+            var recipientsMock = new Mock<Recipients>();
+            var recipientList = recipients.ToList();
+
+            recipientsMock.SetupGet(x => x.Count).Returns(recipientList.Count);
+            recipientsMock
+                .Setup(x => x.GetEnumerator())
+                .Returns(() => ((IEnumerable)recipientList).GetEnumerator());
+
+            return recipientsMock;
+        }
+
+        private static Mock<Attachments> CreateAttachmentsMock()
+        {
+            var attachments = new Mock<Attachments>();
+            var attachmentList = Array.Empty<Microsoft.Office.Interop.Outlook.Attachment>();
+
+            attachments.SetupGet(x => x.Count).Returns(0);
+            attachments
+                .Setup(x => x.GetEnumerator())
+                .Returns(() => ((IEnumerable)attachmentList).GetEnumerator());
+
+            return attachments;
         }
 
         private static MailItemHelper CreateHelper()

--- a/UtilitiesCS.Test/OutlookObjects/Recipient/RecipientStaticTests.cs
+++ b/UtilitiesCS.Test/OutlookObjects/Recipient/RecipientStaticTests.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using FluentAssertions;
 using Microsoft.Office.Interop.Outlook;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -398,6 +399,31 @@ namespace UtilitiesCS.Test.OutlookObjects.Recipient
         }
 
         [TestMethod]
+        public void GetInfo_WhenExchangeDirectoryAccessThrows_FallsBackToRecipientDisplayData()
+        {
+            // Arrange
+            var recipient = CreateRecipientMock(
+                name: "Ada Display",
+                address: "ada@example.com",
+                type: (int)OlMailRecipientType.olTo,
+                userType: OlAddressEntryUserType.olExchangeUserAddressEntry,
+                hasExchangeUser: true,
+                exchangeFirstNameThrows: true,
+                exchangePrimarySmtpAddressThrows: true
+            );
+
+            // Act
+            var result = recipient.Object.GetInfo();
+
+            // Assert
+            result.Name.Should().Be("Ada Display");
+            result.Address.Should().Be("ada@example.com");
+            result
+                .Html.Should()
+                .Be("Ada Display &lt;<a href=\"mailto:ada@example.com\">ada@example.com</a>&gt;");
+        }
+
+        [TestMethod]
         public void GetInfo_ForRecipientSequence_ProjectsEachRecipient()
         {
             // Arrange
@@ -533,7 +559,10 @@ namespace UtilitiesCS.Test.OutlookObjects.Recipient
             bool hasExchangeUser = false,
             string exchangeFirstName = "",
             string exchangeLastName = "",
-            string exchangePrimarySmtpAddress = ""
+            string exchangePrimarySmtpAddress = "",
+            bool exchangeFirstNameThrows = false,
+            bool exchangeLastNameThrows = false,
+            bool exchangePrimarySmtpAddressThrows = false
         )
         {
             var propertyAccessor = new Mock<PropertyAccessor>();
@@ -570,11 +599,42 @@ namespace UtilitiesCS.Test.OutlookObjects.Recipient
                 else
                 {
                     var exchangeUser = new Mock<ExchangeUser>();
-                    exchangeUser.SetupGet(x => x.FirstName).Returns(exchangeFirstName);
-                    exchangeUser.SetupGet(x => x.LastName).Returns(exchangeLastName);
-                    exchangeUser
-                        .SetupGet(x => x.PrimarySmtpAddress)
-                        .Returns(exchangePrimarySmtpAddress);
+
+                    if (exchangeFirstNameThrows)
+                    {
+                        exchangeUser
+                            .SetupGet(x => x.FirstName)
+                            .Throws(new COMException("Exchange first-name lookup failed."));
+                    }
+                    else
+                    {
+                        exchangeUser.SetupGet(x => x.FirstName).Returns(exchangeFirstName);
+                    }
+
+                    if (exchangeLastNameThrows)
+                    {
+                        exchangeUser
+                            .SetupGet(x => x.LastName)
+                            .Throws(new COMException("Exchange last-name lookup failed."));
+                    }
+                    else
+                    {
+                        exchangeUser.SetupGet(x => x.LastName).Returns(exchangeLastName);
+                    }
+
+                    if (exchangePrimarySmtpAddressThrows)
+                    {
+                        exchangeUser
+                            .SetupGet(x => x.PrimarySmtpAddress)
+                            .Throws(new COMException("Exchange SMTP lookup failed."));
+                    }
+                    else
+                    {
+                        exchangeUser
+                            .SetupGet(x => x.PrimarySmtpAddress)
+                            .Returns(exchangePrimarySmtpAddress);
+                    }
+
                     addressEntry.Setup(x => x.GetExchangeUser()).Returns(exchangeUser.Object);
                 }
             }

--- a/UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs
+++ b/UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs
@@ -323,7 +323,7 @@ namespace UtilitiesCS //QuickFiler
             }
         }
 
-        public static async Task<MailItemHelper> FromMailItemAsync(
+        public static Task<MailItemHelper> FromMailItemAsync(
             MailItem item,
             IApplicationGlobals appGlobals,
             CancellationToken token,
@@ -335,15 +335,12 @@ namespace UtilitiesCS //QuickFiler
             token.ThrowIfCancellationRequested();
             item.ThrowIfNull();
 
-            return await Task.Run(
-                () =>
-                {
-                    var info = new MailItemHelper(item, appGlobals);
-                    info.Sw = new SegmentStopWatch().Start();
-                    return info;
-                },
-                token
-            );
+            var info = new MailItemHelper(item, appGlobals);
+            info.Sw = new SegmentStopWatch().Start();
+            info.MaterializeTokenizationDependencies();
+
+            token.ThrowIfCancellationRequested();
+            return Task.FromResult(info);
         }
 
         public MailItem ResolveMail(Outlook.NameSpace olNs, bool strict = false)
@@ -389,6 +386,22 @@ namespace UtilitiesCS //QuickFiler
                 FolderName,
                 Globals,
                 ConversationID,
+            };
+        }
+
+        internal void MaterializeTokenizationDependencies()
+        {
+            // Force the COM-backed values that EmailTokenizer reads while we are
+            // still on the caller's Outlook thread instead of a later Task.Run path.
+            _ = new object[]
+            {
+                Subject,
+                Body,
+                HTMLBody,
+                Sender,
+                ToRecipients,
+                CcRecipients,
+                AttachmentsInfo,
             };
         }
 
@@ -748,6 +761,7 @@ namespace UtilitiesCS //QuickFiler
 
         public async Task<IEnumerable<string>> TokenizeAsync()
         {
+            MaterializeTokenizationDependencies();
             Tokens = await Task.Run(() => Tokenizer.Tokenize(this).ToArray());
             Sw?.LogDuration("TokenizeAsync");
             return Tokens;

--- a/UtilitiesCS/OutlookObjects/Recipient/RecipientStatic.cs
+++ b/UtilitiesCS/OutlookObjects/Recipient/RecipientStatic.cs
@@ -457,57 +457,35 @@ namespace UtilitiesCS
 
         private static string GetRecipientAddress(Recipient olRecipient)
         {
-            string smtpAddress;
+            string smtpAddress = string.Empty;
 
-            if (
-                olRecipient.AddressEntry.AddressEntryUserType
-                    == OlAddressEntryUserType.olExchangeUserAddressEntry
-                || olRecipient.AddressEntry.AddressEntryUserType
-                    == OlAddressEntryUserType.olExchangeRemoteUserAddressEntry
-            )
+            try
             {
-                ExchangeUser exchUser = olRecipient.AddressEntry.GetExchangeUser();
-                if (exchUser != null)
+                var addressEntry = olRecipient.AddressEntry;
+                if (IsExchangeAddressEntry(addressEntry))
                 {
-                    smtpAddress = exchUser.PrimarySmtpAddress;
+                    ExchangeUser exchUser = addressEntry.GetExchangeUser();
+                    if (exchUser != null)
+                    {
+                        smtpAddress = exchUser.PrimarySmtpAddress;
+                    }
                 }
                 else
                 {
                     smtpAddress = olRecipient.Address;
                 }
             }
-            else
+            catch (System.Exception ex)
             {
-                smtpAddress = olRecipient.Address;
+                logger.Warn(
+                    "GetRecipientAddress: Exchange directory lookup failed; falling back to recipient data.",
+                    ex
+                );
             }
-            if (smtpAddress.IsNullOrEmpty())
-            {
-                var olPA = olRecipient.PropertyAccessor;
-                try
-                {
-                    smtpAddress = (string)olPA.GetProperty(PR_SMTP_ADDRESS);
-                    if (smtpAddress.IsNullOrEmpty())
-                        throw new InvalidOperationException("SMTP address is null or empty");
-                }
-                catch
-                {
-                    try
-                    {
-                        smtpAddress = olRecipient.Name;
-                        if (
-                            smtpAddress.IsNullOrEmpty() || smtpAddress.StartsWith("/o=ExchangeLabs")
-                        )
-                            throw new InvalidOperationException(
-                                "SMTP address and name are null, empty, or malformed"
-                            );
-                    }
-                    catch (System.Exception)
-                    {
-                        smtpAddress = "";
-                    }
-                }
-            }
-            return smtpAddress;
+
+            return smtpAddress.IsNullOrEmpty()
+                ? GetRecipientFallbackAddress(olRecipient)
+                : smtpAddress;
             //var OlPA = OlRecipient.PropertyAccessor;
             //string StrSMTPAddress;
             //try
@@ -575,29 +553,28 @@ namespace UtilitiesCS
 
         private static string GetRecipientName(Recipient olRecipient)
         {
-            string recipientName;
-            if (
-                olRecipient.AddressEntry.AddressEntryUserType
-                    == OlAddressEntryUserType.olExchangeUserAddressEntry
-                || olRecipient.AddressEntry.AddressEntryUserType
-                    == OlAddressEntryUserType.olExchangeRemoteUserAddressEntry
-            )
+            try
             {
-                ExchangeUser exchUser = olRecipient.AddressEntry.GetExchangeUser();
-                if (exchUser != null)
+                var addressEntry = olRecipient.AddressEntry;
+                if (IsExchangeAddressEntry(addressEntry))
                 {
-                    recipientName = $"{exchUser.FirstName} {exchUser.LastName}";
-                }
-                else
-                {
-                    recipientName = olRecipient.Name;
+                    ExchangeUser exchUser = addressEntry.GetExchangeUser();
+                    var exchangeDisplayName = GetExchangeUserDisplayName(exchUser);
+                    if (!exchangeDisplayName.IsNullOrEmpty())
+                    {
+                        return exchangeDisplayName;
+                    }
                 }
             }
-            else
+            catch (System.Exception ex)
             {
-                recipientName = olRecipient.Name;
+                logger.Warn(
+                    "GetRecipientName: Exchange directory lookup failed; falling back to recipient data.",
+                    ex
+                );
             }
-            return recipientName;
+
+            return GetRecipientFallbackName(olRecipient);
         }
 
         private static string GetRecipientHtml(Recipient olRecipient)
@@ -606,6 +583,104 @@ namespace UtilitiesCS
                 GetRecipientName(olRecipient),
                 GetRecipientAddress(olRecipient)
             );
+        }
+
+        private static bool IsExchangeAddressEntry(AddressEntry addressEntry)
+        {
+            return addressEntry is not null
+                && (
+                    addressEntry.AddressEntryUserType
+                        == OlAddressEntryUserType.olExchangeUserAddressEntry
+                    || addressEntry.AddressEntryUserType
+                        == OlAddressEntryUserType.olExchangeRemoteUserAddressEntry
+                );
+        }
+
+        private static string GetExchangeUserDisplayName(ExchangeUser exchUser)
+        {
+            if (exchUser is null)
+            {
+                return string.Empty;
+            }
+
+            return $"{exchUser.FirstName} {exchUser.LastName}".Trim();
+        }
+
+        private static string GetRecipientFallbackName(Recipient olRecipient)
+        {
+            try
+            {
+                if (!olRecipient.Name.IsNullOrEmpty())
+                {
+                    return olRecipient.Name;
+                }
+            }
+            catch (System.Exception ex)
+            {
+                logger.Warn(
+                    "GetRecipientName: recipient display-name lookup failed; falling back to address data.",
+                    ex
+                );
+            }
+
+            return GetRecipientFallbackAddress(olRecipient);
+        }
+
+        private static string GetRecipientFallbackAddress(Recipient olRecipient)
+        {
+            string smtpAddress = string.Empty;
+
+            try
+            {
+                smtpAddress = olRecipient.Address;
+            }
+            catch (System.Exception ex)
+            {
+                logger.Warn(
+                    "GetRecipientAddress: recipient address lookup failed; falling back to property accessor.",
+                    ex
+                );
+            }
+
+            if (smtpAddress.IsNullOrEmpty())
+            {
+                try
+                {
+                    smtpAddress = (string)olRecipient.PropertyAccessor.GetProperty(PR_SMTP_ADDRESS);
+                    if (smtpAddress.IsNullOrEmpty())
+                    {
+                        throw new InvalidOperationException("SMTP address is null or empty");
+                    }
+                }
+                catch (System.Exception ex)
+                {
+                    logger.Warn(
+                        "GetRecipientAddress: property accessor lookup failed; falling back to recipient name.",
+                        ex
+                    );
+                    smtpAddress = string.Empty;
+                }
+            }
+
+            if (smtpAddress.IsNullOrEmpty())
+            {
+                try
+                {
+                    smtpAddress = olRecipient.Name;
+                    if (smtpAddress.IsNullOrEmpty() || smtpAddress.StartsWith("/o=ExchangeLabs"))
+                    {
+                        throw new InvalidOperationException(
+                            "SMTP address and name are null, empty, or malformed"
+                        );
+                    }
+                }
+                catch (System.Exception)
+                {
+                    smtpAddress = string.Empty;
+                }
+            }
+
+            return smtpAddress;
         }
     }
 }

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/code-review.2026-04-08T12-14.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/code-review.2026-04-08T12-14.md
@@ -1,0 +1,96 @@
+# Code Review — outlook-recipient-com-cross-thread-crash-124 (2026-04-08T12-14)
+
+- **Feature folder:** `docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/`
+- **Feature folder selection rule:** Used the user-specified active feature folder because it exists on disk, matches issue suffix `-124`, and contains `issue.md`, the approved plan, and canonical evidence.
+- **Current branch inspected:** `bug/outlook-recipient-com-cross-thread-crash-124`
+- **Base branch:** `development`
+- **Work mode:** `minor-audit`
+- **Primary diff evidence:** refreshed `artifacts/pr_context.appendix.txt` working-tree diff plus current branch status
+
+## Executive Summary
+
+This branch implements a focused Outlook COM-safety fix in two production files and two targeted test files. `MailItemHelper` now materializes COM-backed tokenization dependencies before background token access, and `RecipientStatic` now catches Exchange directory failures and falls back to safe recipient display/address data. The live review-time QA loop passed, the two focused regressions passed, and no file-local diagnostics remain in the changed C# files.
+
+**Top risks**
+
+1. **Live Outlook manual verification remains external to this review.** The automated tests prove the helper and recipient fallback behaviors, but a human still needs to confirm the add-in no longer crashes in a real Outlook session.
+2. **The branch is still uncommitted relative to `development`.** PR context summary cannot show a commit-range diff until the working-tree changes are committed, so this review relies on refreshed appendix diff evidence instead.
+3. **Repository aggregate coverage remains below 80%.** This fix improves the baseline slightly and gives both changed production files >80% line coverage, but the wider repository still sits below the global aspirational floor.
+
+**Go/No-Go recommendation:** **Go** for PR preparation against `development`. No blockers or major defects were identified in the reviewed implementation.
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Minor | `docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/issue.md` | `## Acceptance Criteria` vs. live product behavior | The issue's four acceptance criteria are all satisfied by code and automated QA, but the real Outlook add-in scenario is still only indirectly validated by test doubles. | Perform the planned manual Outlook repro/verification before merge or release promotion. | COM apartment/thread-affinity bugs can still surface only in a live Outlook host even when the unit-level fallback logic is correct. | `issue.md`; focused regressions; full QA loop results |
+| Nit | `artifacts/pr_context.summary.txt` | `Base/Head` section | Refreshed PR context summary shows `development` and HEAD at the same commit because the feature changes are still uncommitted in the working tree. | Commit the reviewed changes before opening a PR so future audit/PR tooling can use a normal commit-range diff. | This is a process limitation, not a code defect, but it weakens commit-range PR summaries until the branch state is recorded. | Refreshed `artifacts/pr_context.summary.txt`; `artifacts/pr_context.appendix.txt` |
+| Nit | Repository-wide coverage | QA evidence | Aggregate line coverage remains `78.18%`, below the repo-wide aspirational `>= 80%` floor, even though this bug fix improved coverage and raised both touched production files above 80%. | Treat as non-blocking for this scoped bug fix, but continue the repository-wide coverage uplift work separately. | The change did not regress coverage and directly tests the modified behavior; resolving the remaining aggregate gap is outside this issue's approved small-path scope. | `evidence/qa-gates/csharp-mstest-coverage.2026-04-08T12-02.md`; `evidence/qa-gates/csharp-coverage-summary.2026-04-08T12-02.md` |
+
+No Blocker or Major findings were identified.
+
+## Changed Scope Review
+
+### Production files
+
+- `UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs`
+  - `FromMailItemAsync` now constructs the helper on the caller thread and eagerly materializes tokenization dependencies before returning.
+  - `TokenizeAsync` also materializes dependencies before dispatching tokenization work to `Task.Run`.
+- `UtilitiesCS/OutlookObjects/Recipient/RecipientStatic.cs`
+  - `GetRecipientName` and `GetRecipientAddress` now catch Exchange directory lookup failures and route through explicit fallback helpers.
+  - Helper methods centralize Exchange-address detection plus recipient-name/address fallback behavior.
+
+### Test files
+
+- `UtilitiesCS.Test/OutlookObjects/MailItem/MailItemHelperCoreTests.cs`
+  - Adds a regression proving background token access does not cause additional COM-backed property reads after helper creation.
+- `UtilitiesCS.Test/OutlookObjects/Recipient/RecipientStaticTests.cs`
+  - Adds a regression proving COM exceptions in Exchange-user property access degrade to safe recipient display data rather than surfacing an unhandled crash.
+
+## C# Review Notes
+
+### Correctness and design
+
+- The fix remains minimal and aligns with the issue's root-cause chain: avoid off-thread COM-backed lazy evaluation, and make recipient fallback resilient when Exchange directory access fails.
+- `MailItemHelper.FromMailItemAsync` preserves the public signature and changes only the internal execution timing.
+- `RecipientStatic` follows the existing sender-helper pattern of try/catch plus fallback rather than introducing broader structural change.
+
+### Type safety and diagnostics
+
+- Live analyzer build passed with `0 Warning(s)` and `0 Error(s)`.
+- Live nullable-as-errors build passed with `0 Warning(s)` and `0 Error(s)`.
+- Editor diagnostics for all four changed C# files report no errors.
+
+### Security and safety
+
+- No secrets or credentials were introduced.
+- No subprocess or dynamic execution surface was added.
+- The change reduces runtime crash risk by isolating COM-affine access to safer call sites and by catching Outlook directory exceptions.
+
+## Typed Python Audit
+
+Not applicable. No Python files changed in this feature branch scope.
+
+## Test Quality Audit
+
+| Check | Status | Notes |
+|---|---|---|
+| Deterministic and isolated | PASS | Tests use Moq-backed COM stubs only; no external services or temp files. |
+| Focused on one behavior each | PASS | One test targets recipient fallback; one targets mail-helper materialization before background token access. |
+| Clear diagnostics | PASS | Assertions verify the exact fallback values and the no-extra-COM-read behavior. |
+| Coverage contribution | PASS | Full coverage run added 2 tests and improved overall coverage slightly; both changed production files are above 80% line coverage. |
+
+## Security / Correctness Checks
+
+| Check | Status | Notes |
+|---|---|---|
+| No secrets in code | PASS | No credentials or tokens were added. |
+| No unsafe subprocess usage | PASS | No process-spawning changes were introduced. |
+| Input / boundary safety | PASS | Defensive fallback around Outlook Exchange directory properties is now explicit. |
+| Crash-risk reduction | PASS | The new helper materialization and fallback helpers directly address the reported COM crash mode. |
+
+## Recommendation
+
+**No-Go for remediation; Go for PR preparation.**
+
+The implementation is consistent with the approved small-path scope, code quality is acceptable, and the validated evidence supports the explicit bug-fix acceptance criteria. The remaining items are informational process caveats rather than code defects.

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/baseline/csharp-analyzers-build.2026-04-08T11-39.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/baseline/csharp-analyzers-build.2026-04-08T11-39.md
@@ -1,0 +1,9 @@
+Timestamp: 2026-04-08T11-39
+Command: pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform 'Any CPU' -EnableNETAnalyzers -EnforceCodeStyleInBuild
+EXIT_CODE: 0
+Output Summary: Analyzer-enabled baseline build succeeded with 46 warnings and 0 errors in 00:00:05.74.
+Raw Highlights:
+- 46 Warning(s)
+- 0 Error(s)
+- Time Elapsed 00:00:05.74
+- Sample warnings included obsolete async enumerable API usage in `TaskMaster.csproj`, MSTEST0032 in `QuickFiler.Test`, and nullable-annotation-context warnings in `UtilitiesCS.Test`.

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/baseline/csharp-format.2026-04-08T11-39.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/baseline/csharp-format.2026-04-08T11-39.md
@@ -1,0 +1,8 @@
+Timestamp: 2026-04-08T11-39
+Command: dotnet tool run csharpier format .
+EXIT_CODE: 0
+Output Summary: csharpier formatted 1032 files in 949ms and emitted warnings that `TaskMaster/TaskMaster_BACKUP_1250.csproj` is invalid XML and was not formatted.
+Raw Highlights:
+- Warning: The csproj at `C:\Users\DanMoisan\repos\TaskMaster\TaskMaster\TaskMaster_BACKUP_1250.csproj` failed to load because the XML is invalid.
+- Warning: `.\TaskMaster\TaskMaster_BACKUP_1250.csproj` appeared to be invalid XML so was not formatted.
+- Formatted 1032 files in 949ms.

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/baseline/csharp-mstest-coverage.2026-04-08T11-39.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/baseline/csharp-mstest-coverage.2026-04-08T11-39.md
@@ -1,0 +1,11 @@
+Timestamp: 2026-04-08T11-39
+Command: pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-MSTestWithCoverage.ps1 -SearchRoot . -Configuration Debug
+EXIT_CODE: 0
+Output Summary: MSTest with coverage completed successfully; 3930 total tests, 3928 passed, 2 skipped, 0 failed, with line coverage 78.16% (157742/201826) and branch coverage 63.24% (18020/28495).
+Raw Highlights:
+- Total tests: 3930
+- Passed: 3928
+- Skipped: 2
+- Code coverage results: `C:\Users\DanMoisan\repos\TaskMaster\coverage\coverage.cobertura.xml`
+- Line coverage: 78.16% (157742/201826)
+- Branch coverage: 63.24% (18020/28495)

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/baseline/csharp-nullable-build.2026-04-08T11-39.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/baseline/csharp-nullable-build.2026-04-08T11-39.md
@@ -1,0 +1,9 @@
+Timestamp: 2026-04-08T11-39
+Command: pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform 'Any CPU' -EnableNullable -TreatWarningsAsErrors
+EXIT_CODE: 0
+Output Summary: Nullable/type-safe baseline build succeeded with 0 warnings and 0 errors in 00:00:01.51.
+Raw Highlights:
+- Build succeeded.
+- 0 Warning(s)
+- 0 Error(s)
+- Time Elapsed 00:00:01.51

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/baseline/phase0-instructions-read.2026-04-08T11-39.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/baseline/phase0-instructions-read.2026-04-08T11-39.md
@@ -1,0 +1,16 @@
+Timestamp: 2026-04-08T11-39
+Policy Order:
+1. .github/copilot-instructions.md
+2. .github/instructions/general-code-change.instructions.md
+3. .github/instructions/general-unit-test.instructions.md
+4. .github/instructions/csharp-code-change.instructions.md
+5. .github/instructions/csharp-unit-test.instructions.md
+Read List:
+- c:\Users\DanMoisan\repos\TaskMaster\.github\copilot-instructions.md
+- c:\Users\DanMoisan\repos\TaskMaster\.github\instructions\general-code-change.instructions.md
+- c:\Users\DanMoisan\repos\TaskMaster\.github\instructions\general-unit-test.instructions.md
+- c:\Users\DanMoisan\repos\TaskMaster\.github\instructions\csharp-code-change.instructions.md
+- c:\Users\DanMoisan\repos\TaskMaster\.github\instructions\csharp-unit-test.instructions.md
+Notes:
+- The required policy files were read in repository order before Phase 0 execution.
+- The approved plan file and issue requirements source were also reviewed for Phase 0 scope control.

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/other/change-plan-review.2026-04-08T11-39.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/other/change-plan-review.2026-04-08T11-39.md
@@ -1,0 +1,12 @@
+Timestamp: 2026-04-08T11-39
+Reviewed File: c:\Users\DanMoisan\repos\TaskMaster\change-plan.md
+Review Result:
+- `change-plan.md` was reviewed before executing the approved small-path plan.
+- The current repository-wide change plan concerns Codex/MCP runtime migration work and does not replace or expand this bug-specific minor-audit plan.
+Applicable Bug-Workflow Constraints:
+- Create the smallest deterministic regression test first during implementation work.
+- Apply only the minimal targeted fix required to satisfy the bug acceptance criteria.
+- Re-run the full C# toolchain in the required order before completion: format, analyzer build, nullable/type-safe build, test with coverage.
+Minor-Audit Requirements Source Confirmation:
+- `docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/issue.md` remains the sole requirements source for this minor-audit workflow.
+- No `spec.md`, `user-story.md`, or `research.md` input is required for this approved Phase 0 execution.

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/other/constrained-small-path-handoff.2026-04-08T12-02.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/other/constrained-small-path-handoff.2026-04-08T12-02.md
@@ -1,0 +1,20 @@
+Timestamp: 2026-04-08T12-02
+Plan Path: docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/plan.2026-04-08T00-00.md
+Requirements Source: docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/issue.md -> ## Acceptance Criteria
+
+In-scope production files:
+- UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs
+- UtilitiesCS/OutlookObjects/Recipient/RecipientStatic.cs
+
+Targeted test files:
+- UtilitiesCS.Test/OutlookObjects/Recipient/RecipientStaticTests.cs
+- UtilitiesCS.Test/OutlookObjects/MailItem/MailItemHelperCoreTests.cs
+
+Implementation constraints:
+- Stay within the scoped production and test files listed above.
+- Satisfy only the acceptance criteria under issue.md -> ## Acceptance Criteria.
+- Preserve this exact approved plan path as the controlling small-path plan.
+- Return to the unconditional Phase 2 C# QA loop after implementation.
+
+Stop-and-escalate rule:
+- If any additional production file is required, stop the small-path route and report the blocker instead of expanding scope.

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/other/minor-audit-inputs.2026-04-08T11-39.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/other/minor-audit-inputs.2026-04-08T11-39.md
@@ -1,0 +1,15 @@
+Timestamp: 2026-04-08T11-39
+Work Mode: minor-audit
+Requirements Source: c:\Users\DanMoisan\repos\TaskMaster\docs\features\active\2026-04-08-outlook-recipient-com-cross-thread-crash-124\issue.md
+Plan Path: c:\Users\DanMoisan\repos\TaskMaster\docs\features\active\2026-04-08-outlook-recipient-com-cross-thread-crash-124\plan.2026-04-08T00-00.md
+Acceptance Criteria Section Present: Yes (`## Acceptance Criteria`)
+Acceptance Criteria (verbatim):
+- [ ] `MailItemHelper` no longer relies on background `Task.Run` evaluation of Outlook COM-backed lazy sender/recipient properties during the `ProcessMailItemAsync` tokenization path.
+- [ ] Exchange recipient-name resolution no longer throws an unhandled COM exception when directory property access fails; it falls back to safe recipient data.
+- [ ] Regression tests cover the recipient fallback behavior and the helper/tokenization path that previously crossed thread-affinity boundaries.
+- [ ] The C# QA loop passes in the required order: format, analyzer build, nullable/type-safe build, and MSTest with coverage.
+Workflow Input Notes:
+- `issue.md` is the sole authoritative requirements source for this minor-audit workflow.
+- `spec.md` is not a required input and is absent from the feature folder.
+- `user-story.md` is not a required input and is absent from the feature folder.
+- `research.md` is not a required input and is absent from the feature folder.

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/qa-gates/csharp-analyzers-build.2026-04-08T12-02.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/qa-gates/csharp-analyzers-build.2026-04-08T12-02.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-08T12-02
+Command: pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform 'Any CPU' -EnableNETAnalyzers -EnforceCodeStyleInBuild
+EXIT_CODE: 0
+Output Summary: Analyzer build succeeded with 9 warnings and 0 errors. No new scoped analyzer failures were introduced by the MailItemHelper or RecipientStatic changes.

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/qa-gates/csharp-coverage-summary.2026-04-08T12-02.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/qa-gates/csharp-coverage-summary.2026-04-08T12-02.md
@@ -1,0 +1,23 @@
+Timestamp: 2026-04-08T12-02
+Baseline Evidence: evidence/baseline/csharp-mstest-coverage.2026-04-08T11-39.md
+Final Evidence: evidence/qa-gates/csharp-mstest-coverage.2026-04-08T12-02.md
+
+Coverage Comparison:
+- Baseline overall line coverage: 78.16%
+- Final overall line coverage: 78.18%
+- Delta: +0.02 percentage points
+- Baseline overall branch coverage: 63.24%
+- Final overall branch coverage: 63.26%
+- Delta: +0.02 percentage points
+
+Test Count Comparison:
+- Baseline total tests: 3930 (3928 passed, 2 skipped, 0 failed)
+- Final total tests: 3932 (3930 passed, 2 skipped, 0 failed)
+- Delta: +2 tests, +2 passed, 0 new failures
+
+Scoped Coverage Notes:
+- Final MailItemHelper line coverage: 82.95%
+- Final RecipientStatic line coverage: 83.44%
+- Phase 0 baseline evidence recorded overall coverage headlines but did not persist per-file baseline percentages for the two touched files.
+
+Coverage Conclusion: PASS. Overall coverage improved slightly and no coverage regression was observed in the final QA run.

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/qa-gates/csharp-format.2026-04-08T12-02.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/qa-gates/csharp-format.2026-04-08T12-02.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-08T12-02
+Command: dotnet tool run csharpier format .
+EXIT_CODE: 0
+Output Summary: CSharpier completed successfully and processed 1032 files. It also reported a pre-existing invalid backup project file (`TaskMaster_BACKUP_1250.csproj`) and skipped formatting that backup project.

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/qa-gates/csharp-mstest-coverage.2026-04-08T12-02.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/qa-gates/csharp-mstest-coverage.2026-04-08T12-02.md
@@ -1,0 +1,10 @@
+Timestamp: 2026-04-08T12-02
+Command: pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-MSTestWithCoverage.ps1 -SearchRoot . -Configuration Debug
+EXIT_CODE: 0
+Output Summary: MSTest with coverage completed successfully; 3932 total tests, 3930 passed, 2 skipped, 0 failed, with line coverage 78.18% and branch coverage 63.26%.
+
+Coverage Details:
+- Coverage artifact: coverage/coverage.cobertura.xml
+- Overall line coverage: 78.18%
+- Overall branch coverage: 63.26%
+- Final scoped line coverage: UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs => 82.95%; UtilitiesCS/OutlookObjects/Recipient/RecipientStatic.cs => 83.44%

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/qa-gates/csharp-nullable-build.2026-04-08T12-02.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/qa-gates/csharp-nullable-build.2026-04-08T12-02.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-08T12-02
+Command: pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform 'Any CPU' -EnableNullable -TreatWarningsAsErrors
+EXIT_CODE: 0
+Output Summary: Nullable/type-safe build succeeded with 0 warnings and 0 errors.

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/qa-gates/reduced-audit-handoff.2026-04-08T12-02.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/qa-gates/reduced-audit-handoff.2026-04-08T12-02.md
@@ -1,0 +1,37 @@
+Timestamp: 2026-04-08T12-02
+Plan Path: docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/plan.2026-04-08T00-00.md
+
+Final changed files:
+- UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs
+- UtilitiesCS/OutlookObjects/Recipient/RecipientStatic.cs
+- UtilitiesCS.Test/OutlookObjects/Recipient/RecipientStaticTests.cs
+- UtilitiesCS.Test/OutlookObjects/MailItem/MailItemHelperCoreTests.cs
+- docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/issue.md
+- docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/plan.2026-04-08T00-00.md
+
+Phase 0 baseline artifacts:
+- evidence/baseline/phase0-instructions-read.2026-04-08T11-39.md
+- evidence/baseline/csharp-format.2026-04-08T11-39.md
+- evidence/baseline/csharp-analyzers-build.2026-04-08T11-39.md
+- evidence/baseline/csharp-nullable-build.2026-04-08T11-39.md
+- evidence/baseline/csharp-mstest-coverage.2026-04-08T11-39.md
+- evidence/other/change-plan-review.2026-04-08T11-39.md
+- evidence/other/minor-audit-inputs.2026-04-08T11-39.md
+
+Phase 1 / Phase 2 artifacts:
+- evidence/other/constrained-small-path-handoff.2026-04-08T12-02.md
+- evidence/qa-gates/csharp-format.2026-04-08T12-02.md
+- evidence/qa-gates/csharp-analyzers-build.2026-04-08T12-02.md
+- evidence/qa-gates/csharp-nullable-build.2026-04-08T12-02.md
+- evidence/qa-gates/csharp-mstest-coverage.2026-04-08T12-02.md
+- evidence/qa-gates/targeted-regression.2026-04-08T12-02.md
+- evidence/qa-gates/csharp-coverage-summary.2026-04-08T12-02.md
+
+Acceptance-criteria to evidence mapping:
+- AC 1 (`MailItemHelper` avoids background COM-backed lazy sender/recipient evaluation in the tokenization path) -> production change in UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs; focused test UtilitiesCS.Test/OutlookObjects/MailItem/MailItemHelperCoreTests.cs; evidence/qa-gates/targeted-regression.2026-04-08T12-02.md
+- AC 2 (`RecipientStatic.GetRecipientName` falls back safely when Exchange directory access fails) -> production change in UtilitiesCS/OutlookObjects/Recipient/RecipientStatic.cs; focused test UtilitiesCS.Test/OutlookObjects/Recipient/RecipientStaticTests.cs; evidence/qa-gates/targeted-regression.2026-04-08T12-02.md
+- AC 3 (regression tests cover both bug behaviors) -> UtilitiesCS.Test scoped tests plus evidence/qa-gates/targeted-regression.2026-04-08T12-02.md
+- AC 4 (full C# QA loop passes) -> evidence/qa-gates/csharp-format.2026-04-08T12-02.md, csharp-analyzers-build.2026-04-08T12-02.md, csharp-nullable-build.2026-04-08T12-02.md, csharp-mstest-coverage.2026-04-08T12-02.md
+
+Next step:
+- Proceed to the reduced small-path review/remediation decision with this evidence bundle. No scope expansion was required during implementation.

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/qa-gates/targeted-regression.2026-04-08T12-02.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/evidence/qa-gates/targeted-regression.2026-04-08T12-02.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-08T12-02
+Command: $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\\Installer\\vswhere.exe'; $vstest = & $vswhere -latest -products * -find 'Common7\\IDE\\Extensions\\TestPlatform\\vstest.console.exe' | Select-Object -First 1; & $vstest 'c:\Users\DanMoisan\repos\TaskMaster\UtilitiesCS.Test\bin\Debug\UtilitiesCS.Test.dll' /InIsolation /Tests:'UtilitiesCS.Test.OutlookObjects.Recipient.RecipientStaticTests.GetInfo_WhenExchangeDirectoryAccessThrows_FallsBackToRecipientDisplayData,UtilitiesCS.Test.OutlookObjects.MailItem.MailItemHelperCoreTests.FromMailItemAsync_MaterializesTokenizationDependenciesBeforeBackgroundTokenAccess'
+EXIT_CODE: 0
+Output Summary: Focused MSTest regression run passed both scoped bug tests: RecipientStaticTests.GetInfo_WhenExchangeDirectoryAccessThrows_FallsBackToRecipientDisplayData and MailItemHelperCoreTests.FromMailItemAsync_MaterializesTokenizationDependenciesBeforeBackgroundTokenAccess.

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/feature-audit.2026-04-08T12-14.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/feature-audit.2026-04-08T12-14.md
@@ -1,0 +1,54 @@
+# Feature Audit — outlook-recipient-com-cross-thread-crash-124 (2026-04-08T12-14)
+
+## Scope and Baseline
+
+| Field | Value |
+|---|---|
+| Base branch | `development` |
+| Current branch | `bug/outlook-recipient-com-cross-thread-crash-124` |
+| Feature folder | `docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/` |
+| Work mode | `minor-audit` |
+| Authoritative AC source | `docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/issue.md` under explicit `## Acceptance Criteria` |
+| Approved plan | `docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/plan.2026-04-08T00-00.md` |
+| Primary evidence sources | Refreshed `artifacts/pr_context.summary.txt` and `artifacts/pr_context.appendix.txt`; feature-folder evidence under `evidence/baseline/`, `evidence/other/`, and `evidence/qa-gates/` |
+| Baseline note | The refreshed PR context summary shows `development` and HEAD at the same commit because the branch work is still uncommitted. This audit therefore uses the refreshed appendix working-tree diff plus current status as the authoritative diff source. |
+
+## Acceptance Criteria Inventory
+
+Authoritative criteria extracted verbatim from `issue.md` `## Acceptance Criteria`:
+
+1. `MailItemHelper` no longer relies on background `Task.Run` evaluation of Outlook COM-backed lazy sender/recipient properties during the `ProcessMailItemAsync` tokenization path.
+2. Exchange recipient-name resolution no longer throws an unhandled COM exception when directory property access fails; it falls back to safe recipient data.
+3. Regression tests cover the recipient fallback behavior and the helper/tokenization path that previously crossed thread-affinity boundaries.
+4. The C# QA loop passes in the required order: format, analyzer build, nullable/type-safe build, and MSTest with coverage.
+
+## Acceptance Criteria Evaluation
+
+| Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|---|---|---|---|
+| `MailItemHelper` no longer relies on background `Task.Run` evaluation of Outlook COM-backed lazy sender/recipient properties during the `ProcessMailItemAsync` tokenization path. | PASS | `MailItemHelper.cs` now calls `MaterializeTokenizationDependencies()` inside `FromMailItemAsync` before returning the helper, and the new `MailItemHelperCoreTests.FromMailItemAsync_MaterializesTokenizationDependenciesBeforeBackgroundTokenAccess` regression proves no additional COM-backed reads occur when `helper.Tokens` is forced on a background task. | `vstest.console.exe UtilitiesCS.Test\bin\Debug\UtilitiesCS.Test.dll /InIsolation /Tests:'UtilitiesCS.Test.OutlookObjects.MailItem.MailItemHelperCoreTests.FromMailItemAsync_MaterializesTokenizationDependenciesBeforeBackgroundTokenAccess'` | The focused test passed during live review and is also listed in `evidence/qa-gates/targeted-regression.2026-04-08T12-02.md`. |
+| Exchange recipient-name resolution no longer throws an unhandled COM exception when directory property access fails; it falls back to safe recipient data. | PASS | `RecipientStatic.cs` now catches Exchange directory access failures in `GetRecipientName` / `GetRecipientAddress` and falls back through `GetRecipientFallbackName` / `GetRecipientFallbackAddress`; the new `RecipientStaticTests.GetInfo_WhenExchangeDirectoryAccessThrows_FallsBackToRecipientDisplayData` regression proves the fallback result. | `vstest.console.exe UtilitiesCS.Test\bin\Debug\UtilitiesCS.Test.dll /InIsolation /Tests:'UtilitiesCS.Test.OutlookObjects.Recipient.RecipientStaticTests.GetInfo_WhenExchangeDirectoryAccessThrows_FallsBackToRecipientDisplayData'` | The focused test passed during live review and is also recorded in `evidence/qa-gates/targeted-regression.2026-04-08T12-02.md`. |
+| Regression tests cover the recipient fallback behavior and the helper/tokenization path that previously crossed thread-affinity boundaries. | PASS | Two new scoped tests were added in the approved test files, and both passed in the focused regression run plus the full MSTest-with-coverage run. | `vstest.console.exe UtilitiesCS.Test\bin\Debug\UtilitiesCS.Test.dll /InIsolation /Tests:'UtilitiesCS.Test.OutlookObjects.Recipient.RecipientStaticTests.GetInfo_WhenExchangeDirectoryAccessThrows_FallsBackToRecipientDisplayData,UtilitiesCS.Test.OutlookObjects.MailItem.MailItemHelperCoreTests.FromMailItemAsync_MaterializesTokenizationDependenciesBeforeBackgroundTokenAccess'`; `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-MSTestWithCoverage.ps1 -SearchRoot . -Configuration Debug` | `evidence/qa-gates/csharp-coverage-summary.2026-04-08T12-02.md` also records `+2` tests and no new failures. |
+| The C# QA loop passes in the required order: format, analyzer build, nullable/type-safe build, and MSTest with coverage. | PASS | Live review-time runs succeeded for `csharpier check`, analyzer build, nullable build, and full MSTest with coverage; feature-folder QA artifacts independently record the same sequence passing. | `dotnet tool run csharpier check .`; `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform 'Any CPU' -EnableNETAnalyzers -EnforceCodeStyleInBuild`; `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform 'Any CPU' -EnableNullable -TreatWarningsAsErrors`; `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-MSTestWithCoverage.ps1 -SearchRoot . -Configuration Debug` | Full coverage run reports `3932 total`, `3930 passed`, `2 skipped`, `0 failed`, with `78.18%` line coverage and `63.26%` branch coverage. |
+
+## Summary
+
+**Overall feature readiness: PASS**
+
+The active small-path bug fix satisfies all four authoritative acceptance criteria from `issue.md`, and the live review-time QA loop confirms the current branch state is green. No acceptance-criteria gaps remain for this feature audit.
+
+**Top gaps preventing PASS:** None.
+
+**Recommended follow-up verification steps:**
+- Optional but advisable: perform a final manual Outlook add-in smoke test before merge to confirm the crash no longer reproduces in a live COM host.
+
+## Acceptance Criteria Check-off
+
+No source-file checkbox edits were required during this review because `issue.md` already has all four authoritative acceptance criteria marked `[x]`, matching the verified PASS results above.
+
+### Acceptance Criteria Status
+- Source: `docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/issue.md`
+- Total AC items: 4
+- Checked off (delivered): 4
+- Remaining (unchecked): 0
+- Items remaining: none

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/issue.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/issue.md
@@ -1,0 +1,88 @@
+# outlook-recipient-com-cross-thread-crash (Issue #124)
+
+- Date captured: 2026-04-08
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/outlook-recipient-com-cross-thread-crash/ (Issue #124)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #124
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/124
+- Last Updated: 2026-04-08
+- Work Mode: minor-audit
+
+## Summary
+
+Background mail tokenization can crash with an unhandled Outlook COM/MAPI exception while
+resolving Exchange recipient names. The failure occurs when recipient/sender Outlook COM
+objects are accessed from background `Task.Run` paths and `RecipientStatic.GetRecipientName`
+does not provide a COM-safe fallback.
+
+## Environment
+
+- OS/version: Windows
+- Python version: N/A
+- Command/flags used: Normal Outlook add-in background processing during inbox item handling
+- Data source or fixture: Outlook `MailItem` objects with Exchange-backed sender/recipient metadata
+
+## Steps to Reproduce
+
+1. Let the add-in process a new Outlook `MailItem` through `TaskMaster.AppEvents.ProcessMailItemAsync`.
+2. Allow `MailItemHelper.FromMailItemAsync` and later tokenization work to run through background `Task.Run` paths.
+3. Trigger recipient or sender resolution for an Exchange-backed message where `ExchangeUser.FirstName` or `ExchangeUser.LastName` is read off the Outlook STA thread.
+4. Observe the unhandled `System.Runtime.InteropServices.COMException`.
+
+## Expected Behavior
+
+Background mail processing should not access Outlook apartment-threaded COM objects from pool
+threads, and recipient/sender name resolution should degrade safely to display-name/address
+fallbacks instead of crashing the add-in.
+
+## Actual Behavior
+
+The add-in throws an unhandled Outlook COM exception while resolving Exchange recipient names:
+
+`System.Runtime.InteropServices.COMException (0xD0740106): The operation failed. The messaging interfaces have returned an unknown error. If the problem persists, restart Outlook.`
+
+## Logs / Screenshots
+
+- [x] Attached minimal logs or screenshot
+- Snippet: `RecipientStatic.GetRecipientName` reads `ExchangeUser.FirstName` / `LastName` during background tokenization, and related logs show similar COM failures for sender lookup, `CurrentUser`, and store SMTP resolution when Outlook objects are accessed off the main STA thread.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+## Suspected Cause / Notes
+
+Confirmed root-cause chain from preliminary diagnosis and code inspection:
+
+- `TaskMaster.AppEvents.ProcessMailItemAsync` creates a `MailItemHelper` and then forces `helper.Tokens` inside `Task.Run`.
+- `UtilitiesCS.OutlookObjects.MailItem.MailItemHelper.FromMailItemAsync` currently constructs the helper inside `Task.Run`, and its lazy fields defer Outlook COM access for sender, recipients, body, folder, and HTML state.
+- `UtilitiesCS.OutlookObjects.Recipient.RecipientStatic.GetRecipientName` reads `ExchangeUser.FirstName` and `LastName` without a `try/catch` fallback, so intermittent off-thread MAPI failures become process-visible exceptions.
+- Existing sender helpers already show the intended defensive pattern: catch COM/lookup failures and fall back to `Name`, `Address`, or MAPI property accessors.
+
+## Proposed Fix / Validation Ideas
+
+- [x] Unit coverage areas
+- [x] Integration scenario to retest
+- [x] Manual verification notes
+
+- Materialize sender/recipient/tokenizer-required data on the Outlook/UI thread before any background tokenization path consumes it.
+- Add a defensive COM-safe fallback in `GetRecipientName` (and verify `GetRecipientAddress` remains safe) so Exchange directory lookup failures fall back to recipient display name or address data.
+- Add regression coverage for the fallback path and for the pre-materialized helper/tokenization path.
+
+## Acceptance Criteria
+
+- [x] `MailItemHelper` no longer relies on background `Task.Run` evaluation of Outlook COM-backed lazy sender/recipient properties during the `ProcessMailItemAsync` tokenization path.
+- [x] Exchange recipient-name resolution no longer throws an unhandled COM exception when directory property access fails; it falls back to safe recipient data.
+- [x] Regression tests cover the recipient fallback behavior and the helper/tokenization path that previously crossed thread-affinity boundaries.
+- [x] The C# QA loop passes in the required order: format, analyzer build, nullable/type-safe build, and MSTest with coverage.
+
+## Next Step
+
+- [x] Promote to GitHub issue (bug-report template)
+- [x] Move to active fix folder / branch

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/plan.2026-04-08T00-00.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/plan.2026-04-08T00-00.md
@@ -1,0 +1,84 @@
+# Plan — outlook-recipient-com-cross-thread-crash (Issue #124)
+
+DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED
+
+## Overview
+
+Deliver the small-path C# bug fix for the Outlook recipient COM cross-thread crash by keeping scope constrained to the confirmed helper and recipient paths, adding regression coverage for the two failing behaviors described in `issue.md`, and finishing with the required C# QA loop plus reduced audit handoff evidence.
+
+- Feature folder: `docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124`
+- Plan path: `docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/plan.2026-04-08T00-00.md`
+- Work mode: `minor-audit`
+- Sole requirements source: `docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/issue.md`
+- Acceptance-criteria source section: `## Acceptance Criteria`
+- Non-authoritative files: `spec.md` none, `user-story.md` none, `research.md` none
+- Confirmed small-path scope: `UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs`, `UtilitiesCS/OutlookObjects/Recipient/RecipientStatic.cs`, plus targeted tests under `UtilitiesCS.Test/OutlookObjects/Recipient/` and `UtilitiesCS.Test/OutlookObjects/MailItem/`
+- Preflight status for this planning session: pending required executor/validator validation outside the planner session
+
+## Acceptance Criteria Source Snapshot
+
+Use only the checkbox items under `## Acceptance Criteria` in `issue.md`:
+
+- `MailItemHelper` no longer relies on background `Task.Run` evaluation of Outlook COM-backed lazy sender/recipient properties during the `ProcessMailItemAsync` tokenization path.
+- Exchange recipient-name resolution no longer throws an unhandled COM exception when directory property access fails; it falls back to safe recipient data.
+- Regression tests cover the recipient fallback behavior and the helper/tokenization path that previously crossed thread-affinity boundaries.
+- The C# QA loop passes in the required order: format, analyzer build, nullable/type-safe build, and MSTest with coverage.
+
+### Phase 0 — Baseline Capture
+
+- [x] [P0-T1] Read the required policy files in repository order and write `evidence/baseline/phase0-instructions-read.YYYY-MM-DDTHH-mm.md`.
+  - Preconditions: The feature folder exists and the target plan file is present at `docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/plan.2026-04-08T00-00.md`.
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Policy Order:`, and the exact read list for `.github/copilot-instructions.md`, `.github/instructions/general-code-change.instructions.md`, `.github/instructions/general-unit-test.instructions.md`, `.github/instructions/csharp-code-change.instructions.md`, and `.github/instructions/csharp-unit-test.instructions.md`.
+
+- [x] [P0-T2] Review `change-plan.md` and write `evidence/other/change-plan-review.YYYY-MM-DDTHH-mm.md`.
+  - Acceptance: The artifact exists and states that `change-plan.md` was reviewed, records any bug-workflow constraints that apply, and confirms that `issue.md` remains the sole requirements source for this minor-audit plan.
+
+- [x] [P0-T3] Confirm the minor-audit inputs from `issue.md` and this plan file in `evidence/other/minor-audit-inputs.YYYY-MM-DDTHH-mm.md`.
+  - Acceptance: The artifact exists and records `Work Mode: minor-audit`, confirms that `issue.md` contains an explicit `## Acceptance Criteria` section, lists the four acceptance-criteria checkboxes verbatim, records this exact plan path, and states that `spec.md`, `user-story.md`, and `research.md` are not required inputs for this workflow.
+
+- [x] [P0-T4] Run `dotnet tool run csharpier format .` and write `evidence/baseline/csharp-format.YYYY-MM-DDTHH-mm.md`.
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: dotnet tool run csharpier format .`, `EXIT_CODE:`, and `Output Summary:` with the baseline formatter result.
+
+- [x] [P0-T5] Run `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform 'Any CPU' -EnableNETAnalyzers -EnforceCodeStyleInBuild` and write `evidence/baseline/csharp-analyzers-build.YYYY-MM-DDTHH-mm.md`.
+  - Acceptance: The artifact exists and contains `Timestamp:`, the exact command, `EXIT_CODE:`, and `Output Summary:` with the analyzer-build baseline result.
+
+- [x] [P0-T6] Run `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform 'Any CPU' -EnableNullable -TreatWarningsAsErrors` and write `evidence/baseline/csharp-nullable-build.YYYY-MM-DDTHH-mm.md`.
+  - Acceptance: The artifact exists and contains `Timestamp:`, the exact command, `EXIT_CODE:`, and `Output Summary:` with the nullable/type-safe baseline result.
+
+- [x] [P0-T7] Run `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-MSTestWithCoverage.ps1 -SearchRoot . -Configuration Debug` and write `evidence/baseline/csharp-mstest-coverage.YYYY-MM-DDTHH-mm.md`.
+  - Acceptance: The artifact exists and contains `Timestamp:`, the exact command, `EXIT_CODE:`, and `Output Summary:` with numeric coverage headline values from the baseline coverage run.
+
+### Phase 1 — Constrained Small-Path Implementation Placeholder
+
+Phase 1 execution note: This phase is a constrained small-path handoff placeholder only. Do not expand it into concrete code-change, test-authoring, or focused-regression execution steps inside this plan revision.
+
+- [x] [P1-T1] Write the small-path handoff note to `evidence/other/constrained-small-path-handoff.YYYY-MM-DDTHH-mm.md`.
+  - Acceptance: The artifact exists and lists the in-scope production files `UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs` and `UtilitiesCS/OutlookObjects/Recipient/RecipientStatic.cs`, the targeted test files `UtilitiesCS.Test/OutlookObjects/Recipient/RecipientStaticTests.cs` and one chosen file under `UtilitiesCS.Test/OutlookObjects/MailItem/`, states that `docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/issue.md` `## Acceptance Criteria` is the sole implementation requirements source, and records the stop-and-escalate rule that any required production change outside those files ends the small-path route.
+
+- [x] [P1-T2] Delegate constrained small-path implementation to the small-path implementation engineer using the scope locked by [P1-T1].
+  - Acceptance: The delegated handoff explicitly requires the downstream implementation to stay within the scoped production and test files from [P1-T1], satisfy only the `issue.md` `## Acceptance Criteria` items captured in Phase 0, preserve this exact plan path as the controlling small-path plan, and return control to Phase 2 for the unconditional C# QA loop without adding concrete implementation subtasks to this plan.
+
+### Phase 2 — Final QC Loop
+
+Execute `P2-T1` through `P2-T4` in order. If any step changes files or exits non-zero, fix the issue and restart at `P2-T1` until one clean pass is recorded. Complete `P2-T5` through `P2-T7` only after a clean pass across all four command tasks.
+
+- [x] [P2-T1] Run `dotnet tool run csharpier format .` and write `evidence/qa-gates/csharp-format.YYYY-MM-DDTHH-mm.md`.
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: dotnet tool run csharpier format .`, `EXIT_CODE: 0`, and `Output Summary:` for the clean final formatter pass.
+
+- [x] [P2-T2] Run `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform 'Any CPU' -EnableNETAnalyzers -EnforceCodeStyleInBuild` and write `evidence/qa-gates/csharp-analyzers-build.YYYY-MM-DDTHH-mm.md`.
+  - Acceptance: The artifact exists and contains `Timestamp:`, the exact command, `EXIT_CODE: 0`, and `Output Summary:` for the clean final analyzer-build pass.
+
+- [x] [P2-T3] Run `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform 'Any CPU' -EnableNullable -TreatWarningsAsErrors` and write `evidence/qa-gates/csharp-nullable-build.YYYY-MM-DDTHH-mm.md`.
+  - Acceptance: The artifact exists and contains `Timestamp:`, the exact command, `EXIT_CODE: 0`, and `Output Summary:` for the clean final nullable/type-safe build pass.
+
+- [x] [P2-T4] Run `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-MSTestWithCoverage.ps1 -SearchRoot . -Configuration Debug` and write `evidence/qa-gates/csharp-mstest-coverage.YYYY-MM-DDTHH-mm.md`.
+  - Acceptance: The artifact exists and contains `Timestamp:`, the exact command, `EXIT_CODE: 0`, and `Output Summary:` with numeric post-change coverage headline values from the final coverage run.
+
+- [x] [P2-T5] Run the focused MSTest regression verification for the two in-scope bug behaviors and write `evidence/qa-gates/targeted-regression.YYYY-MM-DDTHH-mm.md`.
+  - Acceptance: The artifact exists and contains `Timestamp:`, the exact focused test command, `EXIT_CODE: 0`, and `Output Summary:` identifying the recipient fallback regression test and the MailItem helper/tokenization regression test that passed.
+
+- [x] [P2-T6] Compare the baseline and final coverage evidence in `evidence/qa-gates/csharp-coverage-summary.YYYY-MM-DDTHH-mm.md`.
+  - Acceptance: The artifact exists and records the numeric baseline coverage headline from `evidence/baseline/csharp-mstest-coverage.*.md`, the numeric final coverage headline from `evidence/qa-gates/csharp-mstest-coverage.*.md`, the computed delta, and the pass or fail coverage conclusion for this bug workflow.
+
+- [x] [P2-T7] Write the reduced audit handoff to `evidence/qa-gates/reduced-audit-handoff.YYYY-MM-DDTHH-mm.md`.
+  - Acceptance: The artifact exists and lists the final changed files, the Phase 0 baseline artifacts, the targeted regression artifact from `evidence/qa-gates/targeted-regression.*.md`, the Phase 2 QA artifacts, the acceptance-criteria-to-evidence mapping, and the reduced-audit next step for small-path review or remediation.

--- a/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/policy-audit.2026-04-08T12-14.md
+++ b/docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/policy-audit.2026-04-08T12-14.md
@@ -1,0 +1,122 @@
+# Policy Audit — outlook-recipient-com-cross-thread-crash-124 (2026-04-08T12-14)
+
+- **Feature folder:** `docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/`
+- **Current branch inspected:** `bug/outlook-recipient-com-cross-thread-crash-124`
+- **Base branch:** `development`
+- **Work mode source:** `docs/features/active/2026-04-08-outlook-recipient-com-cross-thread-crash-124/issue.md` declares `- Work Mode: minor-audit`, so `issue.md` under the explicit `## Acceptance Criteria` section is the sole acceptance-criteria source.
+- **Feature folder selection rule:** Used the user-specified active feature folder because it exists on disk, matches issue suffix `-124`, and contains the active `issue.md`, approved `plan.2026-04-08T00-00.md`, and canonical evidence folders.
+- **Template note:** No repository template matching `docs/features/templates/policy_audit/policy-audit.yyyy-MM-ddTHH-mm.md` was present. This artifact uses the repository's established policy-audit structure plus the canonical headings required by `policy-audit-template-usage`.
+- **PR context note:** The canonical PR context bundle was refreshed against `development`, but its summary reports `Base == Head` because the feature work is still in the working tree rather than committed. For this review, the authoritative baseline-diff evidence is the refreshed `artifacts/pr_context.appendix.txt` working-tree diff plus current branch status and the feature-folder evidence artifacts.
+
+## Executive Summary
+
+**Verdict:** ✅ **PASS — small-path audit passed; no remediation required.**
+
+The issue `#124` bug fix remains within the approved small-path scope, the four authoritative acceptance criteria in `issue.md` are satisfied, the live review-time C# QA gates passed, and the changed files are free of editor diagnostics. The only non-blocking caveats are process-level: the policy-audit template file is absent from the repository, and the refreshed PR context summary cannot show a commit-range diff because the feature work has not been committed yet.
+
+## 1. General Unit Test Policy Compliance
+
+| Check | Status | Evidence |
+|---|---|---|
+| Independence / isolation / determinism | ✅ PASS | `UtilitiesCS.Test/OutlookObjects/Recipient/RecipientStaticTests.cs` and `UtilitiesCS.Test/OutlookObjects/MailItem/MailItemHelperCoreTests.cs` use MSTest + Moq + FluentAssertions with in-memory Outlook COM mocks only; no external services or temp files are required. |
+| Positive / negative / edge coverage | ✅ PASS | New tests cover the Exchange-recipient fallback path that used to throw and the pre-materialized tokenization path that used to access COM-backed properties during `Task.Run`. |
+| Clear diagnostics / AAA structure | ✅ PASS | Assertions are direct FluentAssertions checks with readable scenario names; the new recipient test explicitly asserts fallback name, address, and HTML output, while the helper test counts COM-backed property reads before and after background token access. |
+| Repository-wide coverage no-regression | ✅ PASS | `evidence/qa-gates/csharp-coverage-summary.2026-04-08T12-02.md` records overall line coverage improving from `78.16%` to `78.18%` and test count increasing from `3930` to `3932`. |
+
+## 2. General Code Change Policy Compliance
+
+| Check | Status | Evidence |
+|---|---|---|
+| Objective / plan documented before execution | ✅ PASS | `issue.md` describes the crash, scope, and acceptance criteria; `plan.2026-04-08T00-00.md` records the approved minimal-audit plan and the required evidence chain. |
+| Bugfix workflow followed | ✅ PASS | The issue and plan explicitly call for regression coverage first; the final evidence bundle includes targeted regression tests and the full C# QA loop under `evidence/qa-gates/`. |
+| Minimal targeted fix | ✅ PASS | Production scope remains limited to `UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs` and `UtilitiesCS/OutlookObjects/Recipient/RecipientStatic.cs`, matching the plan's constrained small-path handoff. |
+| Supporting documents updated | ✅ PASS | The active feature folder contains `issue.md`, `plan.2026-04-08T00-00.md`, baseline evidence, and QA evidence that all map to the final implementation. |
+
+## 3. Language-Specific Code Change Policy Compliance
+
+| Check | Status | Evidence |
+|---|---|---|
+| C# formatting policy | ✅ PASS | Live review-time `dotnet tool run csharpier check .` completed successfully. Output only warns that unrelated backup file `TaskMaster_BACKUP_1250.csproj` is invalid XML and was skipped; no changed C# file required formatting. |
+| Analyzer build | ✅ PASS | Live review-time command `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform 'Any CPU' -EnableNETAnalyzers -EnforceCodeStyleInBuild` succeeded with `0 Warning(s)` and `0 Error(s)`. |
+| Nullable / type-safety build | ✅ PASS | Live review-time command `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform 'Any CPU' -EnableNullable -TreatWarningsAsErrors` succeeded with `0 Warning(s)` and `0 Error(s)`. |
+| Focused type-safety in changed code | ✅ PASS | `get_errors` reported no diagnostics in `MailItemHelper.cs`, `RecipientStatic.cs`, `MailItemHelperCoreTests.cs`, or `RecipientStaticTests.cs`. |
+| Public API stability / minimal scope | ✅ PASS | `MailItemHelper.FromMailItemAsync` keeps the same signature; the fix changes internal execution timing only. `RecipientStatic` keeps public behavior but adds defensive fallback helpers. |
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+| Check | Status | Evidence |
+|---|---|---|
+| MSTest framework | ✅ PASS | New tests use `[TestClass]` / `[TestMethod]` under `UtilitiesCS.Test`. |
+| Moq for Outlook dependencies | ✅ PASS | Both changed test files use `Mock<...>` to isolate Outlook COM types and app-global dependencies. |
+| FluentAssertions | ✅ PASS | Assertions in both changed test files use FluentAssertions for clarity and diagnostics. |
+| Focused regression verification | ✅ PASS | Live review-time focused command against `UtilitiesCS.Test.dll` passed both scoped bug tests in `1.0347` seconds. |
+
+## 5. Test Coverage Detail
+
+| Metric | Status | Evidence |
+|---|---|---|
+| Full-suite overall line coverage | ✅ PASS | `evidence/qa-gates/csharp-mstest-coverage.2026-04-08T12-02.md` records `78.18%` overall line coverage and `63.26%` overall branch coverage. |
+| Baseline-to-final delta | ✅ PASS | `evidence/qa-gates/csharp-coverage-summary.2026-04-08T12-02.md` records `+0.02pp` line and `+0.02pp` branch improvement with `+2` passing tests. |
+| Changed-file coverage signal | ✅ PASS | `MailItemHelper.cs => 82.95%` and `RecipientStatic.cs => 83.44%` in `evidence/qa-gates/csharp-mstest-coverage.2026-04-08T12-02.md`. |
+| Repo-wide 80% policy floor | ⚠️ PASS WITH CAVEAT | The repository remains below the aspirational `>= 80%` aggregate floor at `78.18%`, but this bug fix improved coverage slightly, did not regress the baseline, and directly covers the changed production behavior. Consistent with prior small-path review precedent, that is non-blocking for this scoped audit. |
+
+## 6. Test Execution Metrics
+
+| Execution | Status | Evidence |
+|---|---|---|
+| Full MSTest with coverage | ✅ PASS | `3932 total tests`, `3930 passed`, `2 skipped`, `0 failed`; `coverage/coverage.cobertura.xml` refreshed. |
+| Focused regression run | ✅ PASS | `2 total`, `2 passed`, `0 failed`; covered `RecipientStaticTests.GetInfo_WhenExchangeDirectoryAccessThrows_FallsBackToRecipientDisplayData` and `MailItemHelperCoreTests.FromMailItemAsync_MaterializesTokenizationDependenciesBeforeBackgroundTokenAccess`. |
+| Changed-file diagnostics | ✅ PASS | No editor errors in the four changed C# files. |
+
+## 7. Code Quality Checks
+
+| Check | Status | Evidence |
+|---|---|---|
+| Scope isolation relative to approved plan | ✅ PASS | Working-tree diff is limited to the two approved production files, two approved test files, and the active feature folder docs/evidence. |
+| Defensive COM fallback | ✅ PASS | `RecipientStatic.GetRecipientName` and `GetRecipientAddress` now wrap Exchange-directory access and fall back to recipient display or address data rather than surfacing COM exceptions. |
+| Outlook-thread materialization | ✅ PASS | `MailItemHelper.FromMailItemAsync` now materializes tokenization dependencies before background token access; `TokenizeAsync` also materializes before dispatching to `Task.Run`. |
+| No new diagnostics in changed files | ✅ PASS | `get_errors` reported no file-local diagnostics. |
+
+## 8. Gaps and Exceptions
+
+- **Template gap (non-blocking):** The preferred policy-audit template file is missing from `docs/features/templates/`; this artifact uses the repository's established audit structure instead.
+- **PR-context limitation (non-blocking):** `artifacts/pr_context.summary.txt` cannot express the working-tree diff because the feature changes are not yet committed, so the review relies on the refreshed appendix diff and current git status.
+- **Formatter warning (non-blocking):** CSharpier reported unrelated invalid XML in `TaskMaster_BACKUP_1250.csproj`; the changed C# files themselves passed check mode.
+
+## 9. Summary of Changes
+
+The reviewed implementation makes two focused production changes and two focused test changes:
+
+- `UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs`
+  - `FromMailItemAsync` no longer constructs the helper inside `Task.Run`.
+  - The helper now materializes COM-backed tokenization dependencies on the caller's Outlook thread before background token access.
+- `UtilitiesCS/OutlookObjects/Recipient/RecipientStatic.cs`
+  - Exchange recipient name/address lookup now catches directory-access failures and falls back safely to recipient display-name, address, or MAPI property data.
+- `UtilitiesCS.Test/OutlookObjects/MailItem/MailItemHelperCoreTests.cs`
+  - Adds a regression test proving background token access does not trigger fresh COM-backed property reads after `FromMailItemAsync` materialization.
+- `UtilitiesCS.Test/OutlookObjects/Recipient/RecipientStaticTests.cs`
+  - Adds a regression test proving Exchange-recipient info falls back to safe recipient display data when directory-property access throws.
+
+## 10. Compliance Verdict
+
+**✅ PASS — Ready for PR preparation against `development` from a small-path audit perspective.**
+
+No remediation is required from this review. The implementation satisfies the issue's explicit acceptance criteria, the constrained bug-fix scope is intact, and the live review-time QA loop succeeded.
+
+## Appendix A: Test Inventory
+
+| Test | Type | Status | Evidence |
+|---|---|---|---|
+| `UtilitiesCS.Test.OutlookObjects.Recipient.RecipientStaticTests.GetInfo_WhenExchangeDirectoryAccessThrows_FallsBackToRecipientDisplayData` | Focused regression | ✅ PASS | Live focused vstest run; `evidence/qa-gates/targeted-regression.2026-04-08T12-02.md` |
+| `UtilitiesCS.Test.OutlookObjects.MailItem.MailItemHelperCoreTests.FromMailItemAsync_MaterializesTokenizationDependenciesBeforeBackgroundTokenAccess` | Focused regression | ✅ PASS | Live focused vstest run; `evidence/qa-gates/targeted-regression.2026-04-08T12-02.md` |
+| Full repository MSTest suite with coverage | QA gate | ✅ PASS | `evidence/qa-gates/csharp-mstest-coverage.2026-04-08T12-02.md` |
+
+## Appendix B: Toolchain Commands Reference
+
+| Step | Command | Review-time result | Evidence |
+|---|---|---|---|
+| Format check | `dotnet tool run csharpier check .` | Exit success; no changed-file formatting issues | Live review command output |
+| Analyzer build | `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform 'Any CPU' -EnableNETAnalyzers -EnforceCodeStyleInBuild` | `0 Warning(s)`, `0 Error(s)` | Live review command output |
+| Nullable build | `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform 'Any CPU' -EnableNullable -TreatWarningsAsErrors` | `0 Warning(s)`, `0 Error(s)` | Live review command output |
+| Full test with coverage | `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-MSTestWithCoverage.ps1 -SearchRoot . -Configuration Debug` | `3932 total`, `3930 passed`, `2 skipped`, `0 failed`, `78.18%` line coverage | `evidence/qa-gates/csharp-mstest-coverage.2026-04-08T12-02.md` |
+| Focused regression tests | `vstest.console.exe UtilitiesCS.Test\bin\Debug\UtilitiesCS.Test.dll /InIsolation /Tests:'UtilitiesCS.Test.OutlookObjects.Recipient.RecipientStaticTests.GetInfo_WhenExchangeDirectoryAccessThrows_FallsBackToRecipientDisplayData,UtilitiesCS.Test.OutlookObjects.MailItem.MailItemHelperCoreTests.FromMailItemAsync_MaterializesTokenizationDependenciesBeforeBackgroundTokenAccess'` | `2 total`, `2 passed`, `0 failed` | Live review command output |


### PR DESCRIPTION
- Materialize MailItemHelper tokenization dependencies on the Outlook thread before background token access
- Fall back to recipient display and address data when Exchange directory lookups throw COM exceptions
- Add focused regressions for the tokenization and recipient fallback paths and capture issue #124 QA evidence

Refs: #124