### PR TITLE
Stabilize parallel test execution and test host setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ BenchmarkDotNet.Artifacts/
 project.lock.json
 project.fragment.lock.json
 artifacts/
+artifiacts/
 
 # StyleCop
 StyleCopReport.xml

--- a/SVGControl/SvgRenderer.cs
+++ b/SVGControl/SvgRenderer.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Svg;
@@ -19,6 +20,108 @@ namespace SVGControl
         private static readonly log4net.ILog logger = log4net.LogManager.GetLogger(
             System.Reflection.MethodBase.GetCurrentMethod().DeclaringType
         );
+
+        // Svg 3.4.7 was compiled against ExCSS 4.2.3.0 but the repo deploys ExCSS 4.3.1.0
+        // (same publicKeyToken). Production resolves this via TaskMaster.exe.config binding
+        // redirects, but vstest's testhost ignores the test DLL's .config in some modes, so
+        // SvgDocument.Open throws FileNotFoundException for ExCSS 4.2.3. The exception is
+        // swallowed by GetSvgDocument and surfaces downstream as an NRE in the SvgRenderer
+        // ctor. Register an AssemblyResolve fallback that satisfies any version request
+        // for an already-loaded assembly with a matching simple name + public key token.
+        private static int _resolverInstalled;
+
+        [ThreadStatic]
+        private static HashSet<string> _resolving;
+
+        static SvgRenderer()
+        {
+            if (Interlocked.Exchange(ref _resolverInstalled, 1) == 0)
+            {
+                AppDomain.CurrentDomain.AssemblyResolve += ResolveByNameAndKey;
+            }
+        }
+
+        private static System.Reflection.Assembly ResolveByNameAndKey(
+            object sender,
+            ResolveEventArgs args
+        )
+        {
+            var requested = new System.Reflection.AssemblyName(args.Name);
+            byte[] requestedKey = requested.GetPublicKeyToken();
+            foreach (var loaded in System.AppDomain.CurrentDomain.GetAssemblies())
+            {
+                var loadedName = loaded.GetName();
+                if (
+                    !string.Equals(
+                        loadedName.Name,
+                        requested.Name,
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                )
+                {
+                    continue;
+                }
+                byte[] loadedKey = loadedName.GetPublicKeyToken();
+                if (PublicKeyTokensEqual(loadedKey, requestedKey))
+                {
+                    return loaded;
+                }
+            }
+
+            // No loaded match — fall back to loading by simple name from the probing path.
+            // This recovers cases where a versioned reference (e.g., ExCSS 4.2.3) is being
+            // requested but only a newer same-key version is deployed alongside the test DLL.
+            // Re-entrance guard prevents infinite recursion when Assembly.Load itself fails
+            // and re-raises AssemblyResolve on this thread.
+            _resolving ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (!_resolving.Add(requested.Name))
+            {
+                return null;
+            }
+            try
+            {
+                var byName = System.Reflection.Assembly.Load(
+                    new System.Reflection.AssemblyName(requested.Name)
+                );
+                if (
+                    byName != null
+                    && PublicKeyTokensEqual(byName.GetName().GetPublicKeyToken(), requestedKey)
+                )
+                {
+                    return byName;
+                }
+            }
+            catch
+            {
+                // Swallow — return null so other resolvers (or default resolution) can run.
+            }
+            finally
+            {
+                _resolving.Remove(requested.Name);
+            }
+
+            return null;
+        }
+
+        private static bool PublicKeyTokensEqual(byte[] a, byte[] b)
+        {
+            if (a == null || b == null)
+            {
+                return a == b || (a != null && a.Length == 0) || (b != null && b.Length == 0);
+            }
+            if (a.Length != b.Length)
+            {
+                return false;
+            }
+            for (int i = 0; i < a.Length; i++)
+            {
+                if (a[i] != b[i])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
 
         public SvgRenderer(byte[] doc, Size size, AutoSize autoSize)
         {

--- a/TaskMaster.runsettings
+++ b/TaskMaster.runsettings
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <MSTest>
+    <Parallelize>
+      <Workers>0</Workers>
+      <Scope>ClassLevel</Scope>
+    </Parallelize>
+  </MSTest>
+</RunSettings>

--- a/UtilitiesCS.Test/Extensions/AsyncSerialization_Tests.cs
+++ b/UtilitiesCS.Test/Extensions/AsyncSerialization_Tests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -69,7 +70,7 @@ namespace UtilitiesCS.Test.Extensions
                     sourceLength: source.Length,
                     destination,
                     bufferSize: 0,
-                    (ProgressTrackerPane)null,
+                    (ProgressTrackerPane)null!,
                     messagePrefix: "",
                     CancellationToken.None
                 );
@@ -177,7 +178,7 @@ namespace UtilitiesCS.Test.Extensions
             using var source = new MemoryStream(Array.Empty<byte>());
             using var destination = new MemoryStream();
             var reports = new List<KeyValuePair<long, long>>();
-            var progress = new Progress<KeyValuePair<long, long>>(reports.Add);
+            var progress = new SynchronousProgress<KeyValuePair<long, long>>(reports.Add);
 
             // Act
             await source.CopyToAsync(
@@ -313,7 +314,7 @@ namespace UtilitiesCS.Test.Extensions
                     sourceLength: -1,
                     destination,
                     bufferSize: 3,
-                    (ProgressTrackerPane)null,
+                    (ProgressTrackerPane)null!,
                     messagePrefix: "",
                     CancellationToken.None
                 );

--- a/UtilitiesCS.Test/Extensions/IEnumerableExtensions_Tests.cs
+++ b/UtilitiesCS.Test/Extensions/IEnumerableExtensions_Tests.cs
@@ -195,7 +195,10 @@ namespace UtilitiesCS.Test.Extensions
                 .Range(1, 3)
                 .Select(value =>
                 {
-                    System.Threading.Thread.Sleep(550);
+                    // Sleep for 700 ms (> the 500 ms timer period) so that at least one
+                    // timer tick fires while completed > 0, satisfying the Value > 0 assertion
+                    // even when Thread.Sleep runs slightly long under test-suite load.
+                    System.Threading.Thread.Sleep(700);
                     return value;
                 });
             var method = typeof(IEnumerableExtensions).GetMethod(

--- a/UtilitiesCS.Test/HelperClasses/NLogTraceWriter_Test.cs
+++ b/UtilitiesCS.Test/HelperClasses/NLogTraceWriter_Test.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using log4net;
 using log4net.Repository.Hierarchy;
@@ -14,10 +14,12 @@ namespace UtilitiesCS.Test.HelperClasses
         private MockRepository mockRepository;
         private Mock<ILog> mockLogger;
         private Mock<NLogTraceWriter> mockTraceWriter;
+        private System.IO.TextWriter originalOut;
 
         [TestInitialize]
         public void TestInitialize()
         {
+            this.originalOut = Console.Out;
             Console.SetOut(new DebugTextWriter());
             this.mockRepository = new MockRepository(MockBehavior.Loose);
             this.mockLogger = SetupLogger();
@@ -46,6 +48,12 @@ namespace UtilitiesCS.Test.HelperClasses
             Console.WriteLine($"Logger:    {loggerName}");
             Console.WriteLine($"Message:   {message}");
             Console.WriteLine($"Exception: {ex}");
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            Console.SetOut(this.originalOut);
         }
 
         [TestMethod]

--- a/UtilitiesCS.Test/HelperClasses/PrettyPrint_Tests.cs
+++ b/UtilitiesCS.Test/HelperClasses/PrettyPrint_Tests.cs
@@ -11,6 +11,12 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UtilitiesCS.Test.HelperClasses
 {
+    // [DoNotParallelize] — DataFramePrettyHelpers_RenderRowsMarkdownAndConsoleOutput
+    // captures and restores Console.Out, which is process-wide state. Under the
+    // class-level parallel scope set in TaskMaster.runsettings, a sibling test
+    // class's Console.SetOut overrides this class's redirect mid-test, causing
+    // PrettyPrint's Console.WriteLine output to land in the wrong writer.
+    [DoNotParallelize]
     [TestClass]
     public class PrettyPrint_Tests
     {

--- a/UtilitiesCS.Test/OutlookObjects/Table/OlTableExtensions_Tests.cs
+++ b/UtilitiesCS.Test/OutlookObjects/Table/OlTableExtensions_Tests.cs
@@ -947,6 +947,10 @@ namespace UtilitiesCS.Test.OutlookObjects.Table
                 null,
                 row
             );
+            // EtlAsync computes its TimeoutAfter budget as 250 ms * GetRowCount().
+            // Override to a large value so the timeout cannot fire under test-host
+            // contention; iteration is driven by EndOfTable/GetNextRow, not GetRowCount.
+            mockTable.Setup(t => t.GetRowCount()).Returns(120);
             var converters = new Dictionary<string, Func<object, string>>
             {
                 { "MessageRecipients", _ => "Converted Async Recipients" },

--- a/UtilitiesCS.Test/ReusableTypeClasses/TimedBatchAction_Tests.cs
+++ b/UtilitiesCS.Test/ReusableTypeClasses/TimedBatchAction_Tests.cs
@@ -83,8 +83,10 @@ namespace UtilitiesCS.Test.ReusableTypeClasses
             // Act
             action.RequestAction();
             action.RequestAction();
-            signal.Wait(500).Should().BeTrue();
-            Thread.Sleep(80);
+            // Allow 2 000 ms for the 20 ms timer to fire under full-suite thread-pool load.
+            signal.Wait(2000).Should().BeTrue();
+            // Wait long enough to detect any spurious second fire from the single-shot timer.
+            Thread.Sleep(200);
 
             // Assert
             count.Should().Be(1);

--- a/UtilitiesCS.Test/ReusableTypeClasses/TimedQueueOfActions_Tests.cs
+++ b/UtilitiesCS.Test/ReusableTypeClasses/TimedQueueOfActions_Tests.cs
@@ -67,7 +67,10 @@ namespace UtilitiesCS.Test.ReusableTypeClasses
             queue.StartTimer();
 
             // Assert
-            SpinWait.SpinUntil(() => !queue.TimerActive, 1000).Should().BeTrue();
+            // The timer fires every 20 ms; after 5 consecutive empty-queue ticks the
+            // implementation stops it.  Allow 5 000 ms to absorb thread-pool delays
+            // that occur when the full test suite runs in parallel.
+            SpinWait.SpinUntil(() => !queue.TimerActive, 5000).Should().BeTrue();
             queue.TimerActive.Should().BeFalse();
         }
 

--- a/UtilitiesCS.Test/TestAssemblyInitializer.cs
+++ b/UtilitiesCS.Test/TestAssemblyInitializer.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UtilitiesCS.Test
+{
+    /// <summary>
+    /// Installs a process-wide AssemblyResolve fallback before any test runs.
+    ///
+    /// Purpose:
+    ///     vstest's testhost does not always honor binding redirects from
+    ///     UtilitiesCS.Test.dll.config (depending on AppDomain mode), which causes
+    ///     FileNotFoundException for assemblies referenced at one version but deployed
+    ///     at another (e.g. ExCSS 4.2.3 vs 4.3.1, System.Threading.Tasks.Extensions
+    ///     4.2.0.1 vs 4.2.4.0). Production resolves these via TaskMaster.exe.config and
+    ///     is unaffected; this initializer applies an equivalent fallback for the test
+    ///     process so any same-name + same-public-key-token request is satisfied by
+    ///     whatever version is actually loaded or available alongside the test DLL.
+    /// </summary>
+    [TestClass]
+    public static class TestAssemblyInitializer
+    {
+        [AssemblyInitialize]
+        public static void Initialize(TestContext context)
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += ResolveByNameAndKey;
+        }
+
+        [ThreadStatic]
+        private static HashSet<string> _resolving;
+
+        private static Assembly ResolveByNameAndKey(object sender, ResolveEventArgs args)
+        {
+            var requested = new AssemblyName(args.Name);
+            byte[] requestedKey = requested.GetPublicKeyToken();
+
+            foreach (var loaded in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                var loadedName = loaded.GetName();
+                if (
+                    !string.Equals(
+                        loadedName.Name,
+                        requested.Name,
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                )
+                {
+                    continue;
+                }
+                if (PublicKeyTokensEqual(loadedName.GetPublicKeyToken(), requestedKey))
+                {
+                    return loaded;
+                }
+            }
+
+            // Fall back to a simple-name load from the probing path. Re-entrance guard
+            // prevents infinite recursion when Assembly.Load itself fails and re-raises
+            // AssemblyResolve on this thread.
+            _resolving ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (!_resolving.Add(requested.Name))
+            {
+                return null;
+            }
+            try
+            {
+                var byName = Assembly.Load(new AssemblyName(requested.Name));
+                if (
+                    byName != null
+                    && PublicKeyTokensEqual(byName.GetName().GetPublicKeyToken(), requestedKey)
+                )
+                {
+                    return byName;
+                }
+            }
+            catch
+            {
+                // Swallow — return null so default resolution can run.
+            }
+            finally
+            {
+                _resolving.Remove(requested.Name);
+            }
+
+            return null;
+        }
+
+        private static bool PublicKeyTokensEqual(byte[] a, byte[] b)
+        {
+            if (a == null || b == null)
+            {
+                return a == b || (a != null && a.Length == 0) || (b != null && b.Length == 0);
+            }
+            if (a.Length != b.Length)
+            {
+                return false;
+            }
+            for (int i = 0; i < a.Length; i++)
+            {
+                if (a[i] != b[i])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/UtilitiesCS.Test/Threading/TimeOutTask_AdditionalTests.cs
+++ b/UtilitiesCS.Test/Threading/TimeOutTask_AdditionalTests.cs
@@ -245,7 +245,7 @@ namespace UtilitiesCS.Test
             var result = await function.RunWithTimeout(
                 7,
                 CancellationToken.None,
-                milliseconds: 200,
+                milliseconds: 5000,
                 maxAttempts: 0,
                 strict: true
             );

--- a/UtilitiesCS.Test/Threading/TimeOutTask_Tests.cs
+++ b/UtilitiesCS.Test/Threading/TimeOutTask_Tests.cs
@@ -72,7 +72,7 @@ namespace UtilitiesCS.Test
             // Arrange
             Func<CancellationToken, Task<int>> function = async token =>
             {
-                await Task.Delay(100, token);
+                await Task.Delay(5000, token); // increased from 100ms to 5000ms
                 return 7;
             };
 
@@ -98,7 +98,7 @@ namespace UtilitiesCS.Test
             Func<Task> act = async () =>
                 await function.RunWithTimeout(
                     CancellationToken.None,
-                    milliseconds: 100,
+                    milliseconds: 5000,
                     maxAttempts: 0,
                     strict: true
                 );

--- a/UtilitiesCS.Test/UtilitiesCS.Test.csproj
+++ b/UtilitiesCS.Test/UtilitiesCS.Test.csproj
@@ -1,29 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project
-  ToolsVersion="15.0"
-  DefaultTargets="Build"
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
->
-  <Import
-    Project="..\packages\MSTest.TestAdapter.4.2.2\build\net462\MSTest.TestAdapter.props"
-    Condition="Exists('..\packages\MSTest.TestAdapter.4.2.2\build\net462\MSTest.TestAdapter.props')"
-  />
-  <Import
-    Project="..\packages\Microsoft.Testing.Extensions.Telemetry.2.2.2\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props"
-    Condition="Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.2.2\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')"
-  />
-  <Import
-    Project="..\packages\Microsoft.Testing.Platform.MSBuild.2.2.2\build\Microsoft.Testing.Platform.MSBuild.props"
-    Condition="Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.2.2\build\Microsoft.Testing.Platform.MSBuild.props')"
-  />
-  <Import
-    Project="..\packages\Microsoft.Testing.Platform.2.2.2\build\netstandard2.0\Microsoft.Testing.Platform.props"
-    Condition="Exists('..\packages\Microsoft.Testing.Platform.2.2.2\build\netstandard2.0\Microsoft.Testing.Platform.props')"
-  />
-  <Import
-    Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"
-    Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"
-  />
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.4.2.2\build\net462\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.4.2.2\build\net462\MSTest.TestAdapter.props')" />
+  <Import Project="..\packages\Microsoft.Testing.Extensions.Telemetry.2.2.2\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props" Condition="Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.2.2\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" />
+  <Import Project="..\packages\Microsoft.Testing.Platform.MSBuild.2.2.2\build\Microsoft.Testing.Platform.MSBuild.props" Condition="Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.2.2\build\Microsoft.Testing.Platform.MSBuild.props')" />
+  <Import Project="..\packages\Microsoft.Testing.Platform.2.2.2\build\netstandard2.0\Microsoft.Testing.Platform.props" Condition="Exists('..\packages\Microsoft.Testing.Platform.2.2.2\build\netstandard2.0\Microsoft.Testing.Platform.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -37,13 +18,12 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''"
-      >$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath
-    >
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp></NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -87,6 +67,7 @@
     <OutputPath>bin\x86\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="HelperClasses\NLogTraceWriter_Test.cs" />
     <Compile Include="TestAssemblyInitializer.cs" />
     <Compile Include="Dialogs\ActionButtonTests.cs" />
     <Compile Include="Dialogs\DelegateButton_Tests.cs" />
@@ -219,7 +200,6 @@
     <Compile Include="HelperClasses\PrettyPrint_Tests.cs" />
     <Compile Include="HelperClasses\PrettyPrintTest.cs" />
     <Compile Include="HelperClasses\TableLayoutHelper_Tests.cs" />
-    <Compile Include="HelperClasses\NLogTraceWriter_Test.cs" />
     <Compile Include="HelperClasses\SysImageListHelperTests.cs" />
     <Compile Include="HelperClasses\StringManipulation_Tests.cs" />
     <Compile Include="HelperClasses\FilePathHelper_Tests.cs" />
@@ -437,6 +417,7 @@
     <None Include="packages.config" />
     <None Include="Resources\AbstractCube.svg" />
     <None Include="Resources\pplkey.json" />
+    <None Include="test.runsettings" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutBox.png" />
@@ -812,70 +793,25 @@
     <Analyzer Include="..\packages\MSTest.Analyzers.4.2.2\analyzers\dotnet\cs\MSTest.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\MSTest.Analyzers.4.2.2\analyzers\dotnet\cs\MSTest.Analyzers.dll" />
   </ItemGroup>
-  <Import
-    Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets"
-    Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')"
-  />
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error
-      Condition="!Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')"
-      Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets'))"
-    />
-    <Error
-      Condition="!Exists('..\packages\Microsoft.Testing.Platform.2.2.2\build\netstandard2.0\Microsoft.Testing.Platform.props')"
-      Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Platform.2.2.2\build\netstandard2.0\Microsoft.Testing.Platform.props'))"
-    />
-    <Error
-      Condition="!Exists('..\packages\Microsoft.Testing.Platform.2.2.2\build\netstandard2.0\Microsoft.Testing.Platform.targets')"
-      Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Platform.2.2.2\build\netstandard2.0\Microsoft.Testing.Platform.targets'))"
-    />
-    <Error
-      Condition="!Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.2.2\build\Microsoft.Testing.Platform.MSBuild.props')"
-      Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Platform.MSBuild.2.2.2\build\Microsoft.Testing.Platform.MSBuild.props'))"
-    />
-    <Error
-      Condition="!Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.2.2\build\Microsoft.Testing.Platform.MSBuild.targets')"
-      Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Platform.MSBuild.2.2.2\build\Microsoft.Testing.Platform.MSBuild.targets'))"
-    />
-    <Error
-      Condition="!Exists('..\packages\MSTest.TestFramework.4.2.2\build\net462\MSTest.TestFramework.targets')"
-      Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestFramework.4.2.2\build\net462\MSTest.TestFramework.targets'))"
-    />
-    <Error
-      Condition="!Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.2.2\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')"
-      Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Extensions.Telemetry.2.2.2\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props'))"
-    />
-    <Error
-      Condition="!Exists('..\packages\MSTest.TestAdapter.4.2.2\build\net462\MSTest.TestAdapter.props')"
-      Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.2.2\build\net462\MSTest.TestAdapter.props'))"
-    />
-    <Error
-      Condition="!Exists('..\packages\MSTest.TestAdapter.4.2.2\build\net462\MSTest.TestAdapter.targets')"
-      Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.2.2\build\net462\MSTest.TestAdapter.targets'))"
-    />
+    <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Testing.Platform.2.2.2\build\netstandard2.0\Microsoft.Testing.Platform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Platform.2.2.2\build\netstandard2.0\Microsoft.Testing.Platform.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Testing.Platform.2.2.2\build\netstandard2.0\Microsoft.Testing.Platform.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Platform.2.2.2\build\netstandard2.0\Microsoft.Testing.Platform.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.2.2\build\Microsoft.Testing.Platform.MSBuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Platform.MSBuild.2.2.2\build\Microsoft.Testing.Platform.MSBuild.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.2.2\build\Microsoft.Testing.Platform.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Platform.MSBuild.2.2.2\build\Microsoft.Testing.Platform.MSBuild.targets'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestFramework.4.2.2\build\net462\MSTest.TestFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestFramework.4.2.2\build\net462\MSTest.TestFramework.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.2.2\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Extensions.Telemetry.2.2.2\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.2.2\build\net462\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.2.2\build\net462\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.2.2\build\net462\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.2.2\build\net462\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import
-    Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets"
-    Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')"
-  />
-  <Import
-    Project="..\packages\Microsoft.Testing.Platform.2.2.2\build\netstandard2.0\Microsoft.Testing.Platform.targets"
-    Condition="Exists('..\packages\Microsoft.Testing.Platform.2.2.2\build\netstandard2.0\Microsoft.Testing.Platform.targets')"
-  />
-  <Import
-    Project="..\packages\Microsoft.Testing.Platform.MSBuild.2.2.2\build\Microsoft.Testing.Platform.MSBuild.targets"
-    Condition="Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.2.2\build\Microsoft.Testing.Platform.MSBuild.targets')"
-  />
-  <Import
-    Project="..\packages\MSTest.TestFramework.4.2.2\build\net462\MSTest.TestFramework.targets"
-    Condition="Exists('..\packages\MSTest.TestFramework.4.2.2\build\net462\MSTest.TestFramework.targets')"
-  />
-  <Import
-    Project="..\packages\MSTest.TestAdapter.4.2.2\build\net462\MSTest.TestAdapter.targets"
-    Condition="Exists('..\packages\MSTest.TestAdapter.4.2.2\build\net462\MSTest.TestAdapter.targets')"
-  />
+  <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
+  <Import Project="..\packages\Microsoft.Testing.Platform.2.2.2\build\netstandard2.0\Microsoft.Testing.Platform.targets" Condition="Exists('..\packages\Microsoft.Testing.Platform.2.2.2\build\netstandard2.0\Microsoft.Testing.Platform.targets')" />
+  <Import Project="..\packages\Microsoft.Testing.Platform.MSBuild.2.2.2\build\Microsoft.Testing.Platform.MSBuild.targets" Condition="Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.2.2\build\Microsoft.Testing.Platform.MSBuild.targets')" />
+  <Import Project="..\packages\MSTest.TestFramework.4.2.2\build\net462\MSTest.TestFramework.targets" Condition="Exists('..\packages\MSTest.TestFramework.4.2.2\build\net462\MSTest.TestFramework.targets')" />
+  <Import Project="..\packages\MSTest.TestAdapter.4.2.2\build\net462\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.4.2.2\build\net462\MSTest.TestAdapter.targets')" />
 </Project>

--- a/UtilitiesCS.Test/UtilitiesCS.Test.csproj
+++ b/UtilitiesCS.Test/UtilitiesCS.Test.csproj
@@ -87,6 +87,7 @@
     <OutputPath>bin\x86\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="TestAssemblyInitializer.cs" />
     <Compile Include="Dialogs\ActionButtonTests.cs" />
     <Compile Include="Dialogs\DelegateButton_Tests.cs" />
     <Compile Include="Dialogs\FolderNotFoundViewer_Tests.cs" />

--- a/UtilitiesCS.Test/test.runsettings
+++ b/UtilitiesCS.Test/test.runsettings
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Forces all MSTest test methods to execute on an STA thread.
+     Required for any test that creates WinForms controls (Forms, UserControls,
+     ObjectListView / TreeListView) which mandate STA apartment state.
+     The [STAThread] attribute on individual methods is silently ignored by
+     vstest/MSTest because tests run on thread-pool (MTA) threads; this
+     RunSettings entry is the supported mechanism for the full test assembly. -->
+<RunSettings>
+  <RunConfiguration>
+    <ExecutionThread>STA</ExecutionThread>
+  </RunConfiguration>
+</RunSettings>

--- a/UtilitiesCS/Dialogs/InputBox.cs
+++ b/UtilitiesCS/Dialogs/InputBox.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Windows.Forms;
 
 namespace UtilitiesCS
@@ -31,8 +32,20 @@ namespace UtilitiesCS
         /// Returns:
         ///     The <see cref="DialogResult"/> reported by the actual or injected dialog.
         /// </summary>
-        internal static Func<InputBoxViewer, DialogResult> DialogInvoker { get; set; } =
-            viewer => viewer.ShowDialog();
+        // Per-flow storage so parallel test classes (ClassLevel parallelization) do not race
+        // on a single shared static seam. AsyncLocal flows the value with the logical call
+        // context, isolating injected stubs across concurrently executing test classes.
+        private static readonly AsyncLocal<Func<InputBoxViewer, DialogResult>> _dialogInvoker =
+            new AsyncLocal<Func<InputBoxViewer, DialogResult>>();
+
+        private static readonly Func<InputBoxViewer, DialogResult> RealDialogInvoker = viewer =>
+            viewer.ShowDialog();
+
+        internal static Func<InputBoxViewer, DialogResult> DialogInvoker
+        {
+            get => _dialogInvoker.Value ?? RealDialogInvoker;
+            set => _dialogInvoker.Value = value;
+        }
 
         /// <summary>
         /// Presents an input-box dialog and returns the entered text, or null if cancelled.

--- a/UtilitiesCS/Dialogs/MyBox.cs
+++ b/UtilitiesCS/Dialogs/MyBox.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using UtilitiesCS.Dialogs;
@@ -20,12 +21,26 @@ namespace UtilitiesCS
 
     public static class MyBox
     {
+        // Per-flow storage so parallel test classes (ClassLevel parallelization) do not race
+        // on a single shared static seam. AsyncLocal flows the value with the logical call
+        // context, so a [TestCleanup] reset in one test class cannot clobber an injected
+        // stub used by another test class running concurrently.
+        private static readonly AsyncLocal<Func<MyBoxViewer, DialogResult>> _dialogInvoker =
+            new AsyncLocal<Func<MyBoxViewer, DialogResult>>();
+
+        private static readonly Func<MyBoxViewer, DialogResult> RealDialogInvoker = viewer =>
+            viewer.ShowDialog();
+
         /// <summary>
         /// Replaceable dialog-invoker seam. The default implementation delegates to
         /// <see cref="MyBoxViewer.ShowDialog()"/>; tests replace it with a non-modal stub.
+        /// Storage is per-async-flow so parallel test classes do not contaminate each other.
         /// </summary>
-        internal static Func<MyBoxViewer, DialogResult> DialogInvoker { get; set; } =
-            viewer => viewer.ShowDialog();
+        internal static Func<MyBoxViewer, DialogResult> DialogInvoker
+        {
+            get => _dialogInvoker.Value ?? RealDialogInvoker;
+            set => _dialogInvoker.Value = value;
+        }
 
         public static DialogResult ShowDialog(
             string Message,

--- a/UtilitiesCS/Dialogs/YesNoToAll.cs
+++ b/UtilitiesCS/Dialogs/YesNoToAll.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
@@ -46,16 +47,22 @@ namespace UtilitiesCS
             Response = YesNoToAllResponse.Empty;
         }
 
-        private static YesNoToAllResponse _response = YesNoToAllResponse.Empty;
+        // Per-flow response storage so concurrent test classes (ClassLevel parallelization)
+        // and concurrent production callers cannot corrupt each other's button-click state.
+        // AsyncLocal<TEnum>.Value defaults to default(TEnum), which is
+        // YesNoToAllResponse.Empty (0), matching the previous initializer.
+        private static readonly AsyncLocal<YesNoToAllResponse> _response =
+            new AsyncLocal<YesNoToAllResponse>();
+
         public static YesNoToAllResponse Response
         {
-            get => _response;
-            set => _response = value;
+            get => _response.Value;
+            set => _response.Value = value;
         }
 
         public static YesNoToAllResponse ShowDialog(string message)
         {
-            _response = YesNoToAllResponse.Empty;
+            _response.Value = YesNoToAllResponse.Empty;
 
             List<DelegateButton> delegateButtons = new List<DelegateButton>()
             {

--- a/UtilitiesCS/EmailIntelligence/Bayesian/Obsolete/BayesianClassifier.cs
+++ b/UtilitiesCS/EmailIntelligence/Bayesian/Obsolete/BayesianClassifier.cs
@@ -453,11 +453,16 @@ namespace UtilitiesCS.EmailIntelligence.Bayesian
             sw?.LogDuration("Create new Prob Dict");
 
             var processors = Math.Max(Environment.ProcessorCount - 2, 1);
-            var chunkSize = (int)
-                Math.Round(
+            // Ensure chunkSize is at least 1.  Math.Round can produce 0 when the token
+            // count is smaller than half the processor count, which causes Chunk(0) to
+            // throw ArgumentOutOfRangeException.
+            var chunkSize = Math.Max(
+                1,
+                (int)Math.Round(
                     (double)Parent.SharedTokenBase.TokenFrequency.Keys.Count() / (double)processors,
                     0
-                );
+                )
+            );
             sw?.LogDuration("Calculate Chunk Size");
 
             var chunks = Parent.SharedTokenBase.TokenFrequency.Keys.Chunk(chunkSize);

--- a/UtilitiesCS/Threading/TimeOutTask.cs
+++ b/UtilitiesCS/Threading/TimeOutTask.cs
@@ -39,8 +39,8 @@ namespace UtilitiesCS
         {
             token.ThrowIfCancellationRequested();
 
-            var timeoutSource = new CancellationTokenSource(milliseconds);
-            var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
+            using var timeoutSource = new CancellationTokenSource(milliseconds);
+            using var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
                 token,
                 timeoutSource.Token
             );
@@ -74,7 +74,7 @@ namespace UtilitiesCS
                 logger.Error(e);
                 if (strict)
                 {
-                    throw e;
+                    throw;
                 }
             }
 
@@ -103,8 +103,8 @@ namespace UtilitiesCS
         {
             token.ThrowIfCancellationRequested();
 
-            var timeoutSource = new CancellationTokenSource(milliseconds);
-            var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
+            using var timeoutSource = new CancellationTokenSource(milliseconds);
+            using var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
                 token,
                 timeoutSource.Token
             );
@@ -138,7 +138,7 @@ namespace UtilitiesCS
                 logger.Error(e);
                 if (strict)
                 {
-                    throw e;
+                    throw;
                 }
             }
 
@@ -173,8 +173,8 @@ namespace UtilitiesCS
         {
             token.ThrowIfCancellationRequested();
 
-            var timeoutSource = new CancellationTokenSource(milliseconds);
-            var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
+            using var timeoutSource = new CancellationTokenSource(milliseconds);
+            using var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
                 token,
                 timeoutSource.Token
             );
@@ -209,7 +209,7 @@ namespace UtilitiesCS
                 logger.Error(e);
                 if (strict)
                 {
-                    throw e;
+                    throw;
                 }
             }
 
@@ -240,8 +240,8 @@ namespace UtilitiesCS
         {
             cancel.ThrowIfCancellationRequested();
 
-            var timeoutSource = new CancellationTokenSource(milliseconds);
-            var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
+            using var timeoutSource = new CancellationTokenSource(milliseconds);
+            using var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
                 cancel,
                 timeoutSource.Token
             );
@@ -324,8 +324,8 @@ namespace UtilitiesCS
         {
             token.ThrowIfCancellationRequested();
 
-            var timeoutSource = new CancellationTokenSource(milliseconds);
-            var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
+            using var timeoutSource = new CancellationTokenSource(milliseconds);
+            using var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
                 token,
                 timeoutSource.Token
             );
@@ -361,7 +361,7 @@ namespace UtilitiesCS
                 logger.Error(e);
                 if (strict)
                 {
-                    throw e;
+                    throw;
                 }
             }
 
@@ -402,8 +402,8 @@ namespace UtilitiesCS
         {
             cancel.ThrowIfCancellationRequested();
 
-            var timeoutSource = new CancellationTokenSource(milliseconds);
-            var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
+            using var timeoutSource = new CancellationTokenSource(milliseconds);
+            using var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
                 cancel,
                 timeoutSource.Token
             );
@@ -439,7 +439,7 @@ namespace UtilitiesCS
                 logger.Error(e);
                 if (strict)
                 {
-                    throw e;
+                    throw;
                 }
             }
 
@@ -472,8 +472,8 @@ namespace UtilitiesCS
         {
             cancel.ThrowIfCancellationRequested();
 
-            var timeoutSource = new CancellationTokenSource(milliseconds);
-            var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
+            using var timeoutSource = new CancellationTokenSource(milliseconds);
+            using var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
                 cancel,
                 timeoutSource.Token
             );
@@ -508,7 +508,7 @@ namespace UtilitiesCS
                 logger.Error(e);
                 if (strict)
                 {
-                    throw e;
+                    throw;
                 }
             }
         }
@@ -554,8 +554,8 @@ namespace UtilitiesCS
         {
             token.ThrowIfCancellationRequested();
 
-            var timeoutSource = new CancellationTokenSource(milliseconds);
-            var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
+            using var timeoutSource = new CancellationTokenSource(milliseconds);
+            using var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
                 token,
                 timeoutSource.Token
             );
@@ -592,7 +592,7 @@ namespace UtilitiesCS
                 logger.Error(e);
                 if (strict)
                 {
-                    throw e;
+                    throw;
                 }
             }
 
@@ -636,8 +636,8 @@ namespace UtilitiesCS
         {
             cancel.ThrowIfCancellationRequested();
 
-            var timeoutSource = new CancellationTokenSource(milliseconds);
-            var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
+            using var timeoutSource = new CancellationTokenSource(milliseconds);
+            using var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
                 cancel,
                 timeoutSource.Token
             );
@@ -674,7 +674,7 @@ namespace UtilitiesCS
                 logger.Error(e);
                 if (strict)
                 {
-                    throw e;
+                    throw;
                 }
             }
 
@@ -718,8 +718,8 @@ namespace UtilitiesCS
         {
             cancel.ThrowIfCancellationRequested();
 
-            var timeoutSource = new CancellationTokenSource(milliseconds);
-            var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
+            using var timeoutSource = new CancellationTokenSource(milliseconds);
+            using var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(
                 cancel,
                 timeoutSource.Token
             );
@@ -755,7 +755,7 @@ namespace UtilitiesCS
                 logger.Error(e);
                 if (strict)
                 {
-                    throw e;
+                    throw;
                 }
             }
         }

--- a/UtilitiesCS/Threading/UiThread.cs
+++ b/UtilitiesCS/Threading/UiThread.cs
@@ -126,7 +126,7 @@ namespace UtilitiesCS
                 {
                     Init();
                 }
-                return (System.Drawing.SizeF)_autoScaleFactor;
+                return _autoScaleFactor ?? new System.Drawing.SizeF(1f, 1f);
             }
             private set => _autoScaleFactor = value;
         }


### PR DESCRIPTION
# Stabilize parallel test execution and test host setup

## Summary

- Stabilizes the test suite against shared-state races and testhost assembly resolution issues.
- Adds runsettings files for the TaskMaster and UtilitiesCS test execution paths.
- Introduces a UtilitiesCS test assembly initializer for shared test setup.
- Updates dialog and threading code paths that are exercised by the affected tests.
- Simplifies the UtilitiesCS test project configuration while retaining test coverage for the touched areas.

## Why

The branch contains two test-focused fix commits that target parallel test instability, shared-state races, and testhost assembly resolution. The changed files indicate the work is concentrated in UtilitiesCS tests, test setup, dialog seams, timeout behavior, and supporting renderer/classifier code paths needed by the affected test scenarios.

## What Changed

Core behavior or architecture:
- Updated `TimeOutTask`, `UiThread`, dialog helpers, `BayesianClassifier`, and `SvgRenderer` behavior used by the stabilized tests.
- Adjusted dialog seams in `InputBox`, `MyBox`, and `YesNoToAll`.

Tooling, automation, CI, or developer experience:
- Added `TaskMaster.runsettings`.
- Added `UtilitiesCS.Test/test.runsettings`.
- Updated `.gitignore`.

Tests:
- Added `UtilitiesCS.Test/TestAssemblyInitializer.cs`.
- Updated UtilitiesCS tests for async serialization, enumerable extensions, trace writing, pretty printing, Outlook table extensions, timed batch/queue behavior, and timeout task behavior.
- Updated `UtilitiesCS.Test/UtilitiesCS.Test.csproj`.

Docs, templates, or agents:
- No documentation, template, or agent changes are listed in the PR context.

## Architecture / How It Fits Together

The branch centralizes shared UtilitiesCS test initialization in a test assembly initializer and pairs that with runsettings files for deterministic test execution. The production changes are scoped to code paths directly related to the stabilized tests, including dialog abstractions, timeout/threading behavior, rendering support, and obsolete Bayesian classifier behavior.

## Verification

### Completed

- Not verified in this PR (no tool outputs recorded in the PR-context summary).

### Recommended

- `csharpier .`
- `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
- `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`
- `vstest.console.exe <test-assembly-paths> /Settings:TaskMaster.runsettings /EnableCodeCoverage`

## Backward Compatibility / Migration Notes

No migration steps are identified in the PR context. The changes appear limited to test stabilization, test configuration, and supporting code paths.

## Risks and Mitigations

- Risk: Test execution behavior may differ when run without the added runsettings files.
  Mitigation: Run the recommended validation commands with the checked-in runsettings before merge.
- Risk: Dialog and timeout behavior changes may affect callers outside the updated tests.
  Mitigation: Review the touched dialog and threading files closely and run the relevant UtilitiesCS test assembly.

## Review Guide

- Review the runsettings files and `UtilitiesCS.Test/TestAssemblyInitializer.cs` first to confirm the intended shared test setup.
- Review `UtilitiesCS.Test/UtilitiesCS.Test.csproj` for project configuration changes.
- Review the dialog and timeout/threading changes alongside their corresponding test updates.
- Confirm the `SvgRenderer` and obsolete Bayesian classifier changes are necessary for the stabilized scenarios.

## Follow-ups

- Record final formatter, analyzer, nullable, and test command outputs before merging.
- Add any issue references if this work is later associated with tracked GitHub issues.

## GitHub Auto-close

- None (no verified closing issues and no author-asserted autoclose issues)

## Related issues / PRs

- None