### PR TITLE
Stabilize conversation resolver startup and deterministic UtilitiesCS test execution

### DIFF
--- a/QuickFiler.Test/Controllers/EfcDataModelTests.cs
+++ b/QuickFiler.Test/Controllers/EfcDataModelTests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Microsoft.Office.Interop.Outlook;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using QuickFiler.Helper_Classes;
 using UtilitiesCS;
 
 namespace QuickFiler.Controllers.Tests
@@ -79,6 +80,103 @@ namespace QuickFiler.Controllers.Tests
             dataModel.ConversationResolver.Mail.Should().BeSameAs(onlyMail.Object);
         }
 
+        [TestMethod]
+        public async Task LoadConversationInfoAsync_WhenGlobalsDoNotExposeOutlookApp_DoesNotRequireApp()
+        {
+            var globals = CreateGlobals();
+            var folder = new Mock<Folder>(MockBehavior.Strict);
+            var conversation = new Mock<Conversation>(MockBehavior.Loose);
+            var table = CreateConversationTable();
+            var mailItem = CreateMailItem("entry-1", "Subject 1");
+
+            folder.SetupGet(x => x.Name).Returns("Inbox");
+            folder.SetupGet(x => x.FolderPath).Returns("\\Archive\\Inbox");
+            mailItem.SetupGet(x => x.Parent).Returns(folder.Object);
+            mailItem.Setup(x => x.GetConversation()).Returns(conversation.Object);
+            conversation.Setup(x => x.GetTable()).Returns(table.Object);
+
+            var helper = await MailItemHelper.FromMailItemAsync(
+                mailItem.Object,
+                globals.Object,
+                CancellationToken.None,
+                loadAll: false
+            );
+            var resolver = new ConversationResolver(globals.Object, mailItem.Object)
+            {
+                MailHelper = helper,
+            };
+
+            await resolver.LoadDfAsync(CancellationToken.None, backgroundLoad: false);
+
+            var info = await resolver.LoadConversationInfoAsync(
+                CancellationToken.None,
+                backgroundLoad: false
+            );
+
+            info.Expanded.Should().ContainSingle();
+            info.Expanded[0].Should().BeSameAs(helper);
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_WithSingleSelectedMail_LeavesBackgroundInitializationStaged()
+        {
+            var globals = CreateGlobals();
+            var onlyMail = CreateMailItem("entry-1", "Subject 1");
+            var folder = new Mock<Folder>(MockBehavior.Strict);
+            var conversation = new Mock<Conversation>(MockBehavior.Loose);
+            var table = CreateConversationTable();
+            var selection = new List<MailItem> { onlyMail.Object };
+
+            folder.SetupGet(x => x.Name).Returns("Inbox");
+            folder.SetupGet(x => x.FolderPath).Returns("\\Archive\\Inbox");
+            onlyMail.SetupGet(x => x.Parent).Returns(folder.Object);
+            onlyMail.Setup(x => x.GetConversation()).Returns(conversation.Object);
+            conversation.Setup(x => x.GetTable()).Returns(table.Object);
+
+            var dataModel = await EfcDataModel.CreateAsync(
+                globals.Object,
+                selection,
+                new CancellationTokenSource(),
+                CancellationToken.None,
+                loadAll: false
+            );
+
+            SpinWait
+                .SpinUntil(() => dataModel.ConversationResolver.FullyLoaded, 250)
+                .Should()
+                .BeFalse();
+            dataModel.ConversationResolver.FullyLoaded.Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void Constructor_WhenMailProvided_LeavesBackgroundInitializationStaged()
+        {
+            var globals = CreateGlobals();
+            var folder = new Mock<Folder>(MockBehavior.Strict);
+            var conversation = new Mock<Conversation>(MockBehavior.Loose);
+            var table = CreateConversationTable();
+            var mailItem = CreateMailItem("entry-1", "Subject 1");
+
+            folder.SetupGet(x => x.Name).Returns("Inbox");
+            folder.SetupGet(x => x.FolderPath).Returns("\\Archive\\Inbox");
+            mailItem.SetupGet(x => x.Parent).Returns(folder.Object);
+            mailItem.Setup(x => x.GetConversation()).Returns(conversation.Object);
+            conversation.Setup(x => x.GetTable()).Returns(table.Object);
+
+            var dataModel = new EfcDataModel(
+                globals.Object,
+                mailItem.Object,
+                new CancellationTokenSource(),
+                CancellationToken.None
+            );
+
+            SpinWait
+                .SpinUntil(() => dataModel.ConversationResolver.FullyLoaded, 250)
+                .Should()
+                .BeFalse();
+            dataModel.ConversationResolver.FullyLoaded.Should().BeFalse();
+        }
+
         /// <summary>
         /// Locks in the synchronous constructor snapshot contract used by the first-selection
         /// controller path. Supplying a mail item should eagerly build a resolver and snapshot
@@ -142,6 +240,7 @@ namespace QuickFiler.Controllers.Tests
 
             var mailItem = new Mock<MailItem>(MockBehavior.Strict);
             mailItem.SetupGet(x => x.EntryID).Returns(entryId);
+            mailItem.SetupGet(x => x.ConversationID).Returns("conversation-1");
             mailItem.SetupGet(x => x.Subject).Returns(subject);
             mailItem.SetupGet(x => x.Body).Returns("Body");
             mailItem.SetupGet(x => x.HTMLBody).Returns("<html><body>Body</body></html>");

--- a/QuickFiler/Controllers/EfcDataModel.cs
+++ b/QuickFiler/Controllers/EfcDataModel.cs
@@ -65,6 +65,8 @@ namespace QuickFiler.Controllers
                 );
                 ConversationResolver = new ConversationResolver(Globals, Mail, TokenSource, Token);
                 _conversationResolver.Df = _conversationResolver.LoadDf(); // Load Synchronously
+                _conversationResolver.PropertyChanged +=
+                    _conversationResolver.Handler_PropertyChanged;
                 LogDataModelTiming(
                     "EfcDataModel constructor snapshot load complete | constructor load",
                     $"constructor snapshot load elapsedMs={constructorStopwatch.ElapsedMilliseconds}"

--- a/QuickFiler/Helper Classes/ConversationResolver.Loading.cs
+++ b/QuickFiler/Helper Classes/ConversationResolver.Loading.cs
@@ -56,7 +56,6 @@ namespace QuickFiler.Helper_Classes
             }
 
             var df = Df.Expanded;
-            var olNs = _globals.Ol.App.GetNamespace("MAPI");
             var convInfoExpanded = Enumerable
                 .Range(0, Count.Expanded)
                 .Select(indexRow => MailItemHelper.FromDf(df, indexRow, _globals, Token))
@@ -84,8 +83,6 @@ namespace QuickFiler.Helper_Classes
             TaskCreationOptions options = backgroundLoad
                 ? TaskCreationOptions.LongRunning
                 : TaskCreationOptions.None;
-
-            var olNs = _globals.Ol.App.GetNamespace("MAPI");
 
             var tasksConvInfoExp = Enumerable
                 .Range(0, Count.Expanded)

--- a/QuickFiler/Helper Classes/ConversationResolver.cs
+++ b/QuickFiler/Helper Classes/ConversationResolver.cs
@@ -81,7 +81,6 @@ namespace QuickFiler.Helper_Classes
             _mailItem = mailItem;
             MailHelper = new MailItemHelper(mailItem, _globals); //.LoadPriority(appGlobals, token);
             _updateUI = updateUI;
-            PropertyChanged += Handler_PropertyChanged;
         }
 
         public static async Task<ConversationResolver> LoadAsync(
@@ -116,8 +115,9 @@ namespace QuickFiler.Helper_Classes
             }
             else
             {
-                resolver.PropertyChanged += resolver.Handler_PropertyChanged;
+                // Subscribe after LoadDfAsync so initial dataframe assignment does not trigger background initialization.
                 await resolver.LoadDfAsync(token, loadAll);
+                resolver.PropertyChanged += resolver.Handler_PropertyChanged;
             }
 
             return resolver;
@@ -151,8 +151,9 @@ namespace QuickFiler.Helper_Classes
             }
             else
             {
-                resolver.PropertyChanged += resolver.Handler_PropertyChanged;
+                // Subscribe after LoadDfAsync so initial dataframe assignment does not trigger background initialization.
                 await resolver.LoadDfAsync(token, loadAll);
+                resolver.PropertyChanged += resolver.Handler_PropertyChanged;
             }
 
             return resolver;

--- a/UtilitiesCS.Test/Dialogs/ActionButtonTests.cs
+++ b/UtilitiesCS.Test/Dialogs/ActionButtonTests.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UtilitiesCS.Test
 {
-    [TestClass]
+    [STATestClass]
     public class ActionButtonTests
     {
         [TestMethod]

--- a/UtilitiesCS.Test/Dialogs/DialogTests.cs
+++ b/UtilitiesCS.Test/Dialogs/DialogTests.cs
@@ -6,13 +6,12 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UtilitiesCS.Test.Dialogs
 {
-    [TestClass]
+    [STATestClass]
     public class DelegateButton_Tests
     {
         #region Constructors
 
         [TestMethod]
-        [STAThread]
         public void DefaultConstructor_CreatesInstance()
         {
             var db = new DelegateButton();
@@ -20,7 +19,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void Constructor_WithNameAndText_CreatesButton()
         {
             Action del = () => { };
@@ -33,7 +31,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void Constructor_WithDialogResult_SetsDialogResult()
         {
             Action del = () => { };
@@ -43,7 +40,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void Constructor_WithButtonAndDialogResult_SetsProperties()
         {
             var button = new Button();
@@ -59,7 +55,6 @@ namespace UtilitiesCS.Test.Dialogs
         #region Properties
 
         [TestMethod]
-        [STAThread]
         public void Name_SetAndGet()
         {
             var db = new DelegateButton();
@@ -68,7 +63,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void Delegate_SetAndGet()
         {
             var db = new DelegateButton();
@@ -82,7 +76,6 @@ namespace UtilitiesCS.Test.Dialogs
         #region MakeButton
 
         [TestMethod]
-        [STAThread]
         public void MakeButton_WithText_CreatesButton()
         {
             Action del = () => { };
@@ -96,7 +89,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void MakeButton_WithDialogResult_SetsResult()
         {
             Action del = () => { };
@@ -111,7 +103,6 @@ namespace UtilitiesCS.Test.Dialogs
         #region Button_Click
 
         [TestMethod]
-        [STAThread]
         public void Button_Click_InvokesDelegate()
         {
             bool delegateCalled = false;
@@ -127,7 +118,6 @@ namespace UtilitiesCS.Test.Dialogs
         #region FromButton
 
         [TestMethod]
-        [STAThread]
         public void FromButton_CreatesFromExistingButton()
         {
             var button = new Button { Text = "Existing" };

--- a/UtilitiesCS.Test/Dialogs/FolderNotFoundViewer_Tests.cs
+++ b/UtilitiesCS.Test/Dialogs/FolderNotFoundViewer_Tests.cs
@@ -14,10 +14,10 @@ namespace UtilitiesCS.Test.Dialogs
     ///     hide rather than dispose the viewer.
     ///
     /// Constraints:
-    ///     All tests run on an STA thread (required by WinForms).
+    ///     This class runs under MSTest's STA class execution mode (required by WinForms).
     ///     Click handlers are invoked via reflection because they are private.
     /// </summary>
-    [TestClass]
+    [STATestClass]
     public class FolderNotFoundViewer_Tests
     {
         // ---------------------------------------------------------------------------
@@ -45,7 +45,6 @@ namespace UtilitiesCS.Test.Dialogs
         // ---------------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void CreateFolder_Click_SetsFolderActionToCreate()
         {
             // Arrange — create viewer and confirm FolderAction starts null
@@ -64,7 +63,6 @@ namespace UtilitiesCS.Test.Dialogs
         // ---------------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void Cancel_Click_SetsFolderActionToCancel()
         {
             // Arrange
@@ -82,7 +80,6 @@ namespace UtilitiesCS.Test.Dialogs
         // ---------------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void OpenFolder_Click_SetsFolderActionToFind()
         {
             // Arrange
@@ -96,7 +93,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void NoToAll_Click_SetsFolderActionToNoToAll()
         {
             // Arrange
@@ -114,7 +110,6 @@ namespace UtilitiesCS.Test.Dialogs
         // ---------------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void FolderName_ReturnsAssignedText()
         {
             // Arrange
@@ -133,7 +128,6 @@ namespace UtilitiesCS.Test.Dialogs
         // ---------------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void CreateFolder_Click_DoesNotDisposeViewer()
         {
             // Arrange

--- a/UtilitiesCS.Test/Dialogs/FunctionButton_Tests.cs
+++ b/UtilitiesCS.Test/Dialogs/FunctionButton_Tests.cs
@@ -8,13 +8,12 @@ using UtilitiesCS.Dialogs;
 
 namespace UtilitiesCS.Test.Dialogs
 {
-    [TestClass]
+    [STATestClass]
     public class FunctionButton_Tests
     {
         #region Constructors
 
         [TestMethod]
-        [STAThread]
         public void DefaultConstructor_CreatesInstance()
         {
             var fb = new FunctionButton<int>();
@@ -22,7 +21,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void Constructor_WithNameAndText_CreatesButton()
         {
             Func<int> func = () => 42;
@@ -34,7 +32,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void Constructor_WithDialogResult_SetsResult()
         {
             Func<int> func = () => 42;
@@ -44,7 +41,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void SyncConstructorOverloads_InitializeButtonsTemplatesAndImages()
         {
             // Arrange
@@ -99,7 +95,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void AsyncConstructorOverloads_InitializeButtonsTemplatesAndImages()
         {
             // Arrange
@@ -177,7 +172,6 @@ namespace UtilitiesCS.Test.Dialogs
         #region MakeButton
 
         [TestMethod]
-        [STAThread]
         public void MakeButton_SetsText()
         {
             Func<int> func = () => 1;
@@ -189,7 +183,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void MakeButton_WithDialogResult_SetsDialogResult()
         {
             Func<int> func = () => 1;
@@ -204,7 +197,6 @@ namespace UtilitiesCS.Test.Dialogs
         #region Button_Click
 
         [TestMethod]
-        [STAThread]
         public void Button_Click_InvokesFunction()
         {
             Func<int> func = () => 42;
@@ -219,7 +211,6 @@ namespace UtilitiesCS.Test.Dialogs
         #region FromButton
 
         [TestMethod]
-        [STAThread]
         public void FromButton_CreatesFromExistingButton()
         {
             var button = new Button { Text = "Existing" };
@@ -235,7 +226,6 @@ namespace UtilitiesCS.Test.Dialogs
         #region Properties
 
         [TestMethod]
-        [STAThread]
         public void Name_SetAndGet()
         {
             var fb = new FunctionButton<int>();
@@ -244,7 +234,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void Delegate_SetAndGet()
         {
             var fb = new FunctionButton<int>();
@@ -254,7 +243,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void ButtonTemplate_SetAndGet_ClonesAssignedTemplate()
         {
             // Arrange
@@ -291,7 +279,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     is clicked following reassignment.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ReassignButton_UnwiresOldClickHandler()
         {
             // Arrange: create a FunctionButton whose ButtonClicked wires Button_Click
@@ -329,7 +316,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     Passes when Value equals 99 and the delegate was invoked exactly once.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ButtonClickAsync_ExecutesCallbackExactlyOnce()
         {
             // Arrange: wire an already-complete async callback so the await resolves
@@ -353,7 +339,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void ButtonClicked_Setter_ReplacesOldHandler()
         {
             // Arrange
@@ -369,7 +354,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void ButtonClickedAsync_Setter_ReplacesOldHandler()
         {
             // Arrange

--- a/UtilitiesCS.Test/Dialogs/InputBox_Test.cs
+++ b/UtilitiesCS.Test/Dialogs/InputBox_Test.cs
@@ -30,10 +30,10 @@ namespace UtilitiesCS.Test.Dialogs
     ///     ShowDialog(), so tests remain non-blocking and deterministic.
     ///
     /// Constraints:
-    ///     All tests run on an STA thread (required by WinForms).
+    ///     This class runs under MSTest's STA class execution mode (required by WinForms).
     ///     Click handlers and private fields are accessed via reflection.
     /// </summary>
-    [TestClass]
+    [STATestClass]
     public class InputBoxViewer_Tests
     {
         [TestCleanup]
@@ -51,7 +51,6 @@ namespace UtilitiesCS.Test.Dialogs
         // ---------------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void Input_Text_ReflectsValueSetByDefaultResponse()
         {
             // Arrange — simulate what InputBox.ShowDialog does when setting DefaultResponse
@@ -70,7 +69,6 @@ namespace UtilitiesCS.Test.Dialogs
         // ---------------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void OkClick_WithNonEmptyText_SetsDialogResultToOk()
         {
             // Arrange — set a non-empty value so Ok_Click does not show a MessageBox
@@ -90,7 +88,6 @@ namespace UtilitiesCS.Test.Dialogs
         // ---------------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void CancelClick_SetsDialogResultToCancel()
         {
             // Arrange — InputBox.ShowDialog returns null when viewer.ShowDialog() == Cancel
@@ -108,7 +105,6 @@ namespace UtilitiesCS.Test.Dialogs
         // ---------------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void OkClick_CopiesTextboxTextAndHidesViewer()
         {
             // Arrange
@@ -129,7 +125,6 @@ namespace UtilitiesCS.Test.Dialogs
         // ---------------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void CancelClick_LeavesViewerInCancelState()
         {
             // Arrange — pre-populate the textbox
@@ -149,7 +144,6 @@ namespace UtilitiesCS.Test.Dialogs
         // ---------------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void DpiAware_SetsDpiCalledToTrue()
         {
             // Arrange — DpiCalled is reset in TestCleanup; confirm starting state
@@ -167,7 +161,6 @@ namespace UtilitiesCS.Test.Dialogs
         // ---------------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void ShowDialog_SeamReturnsOk_ReturnsEnteredText()
         {
             // Arrange — inject a seam that immediately returns OK and hard-wires the viewer's
@@ -191,7 +184,6 @@ namespace UtilitiesCS.Test.Dialogs
         // ---------------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void ShowDialog_SeamReturnsCancel_ReturnsNull()
         {
             // Arrange — inject a seam that immediately reports Cancel.

--- a/UtilitiesCS.Test/Dialogs/MyBox_ShowDialog_Tests.cs
+++ b/UtilitiesCS.Test/Dialogs/MyBox_ShowDialog_Tests.cs
@@ -23,10 +23,11 @@ namespace UtilitiesCS.Test.Dialogs
     ///     after every test to prevent cross-test contamination.
     ///
     /// Invariants / Constraints:
-    ///     Tests that create WinForms controls must run on an STA thread.
+    ///     This class runs under MSTest's STA class execution mode because every
+    ///     test creates WinForms controls.
     ///     Internal members are accessible via InternalsVisibleTo("UtilitiesCS.Test").
     /// </summary>
-    [TestClass]
+    [STATestClass]
     public class MyBox_ShowDialog_Tests
     {
         // ---------------------------------------------------------------------------
@@ -61,7 +62,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     DialogResult.OK from the injected seam.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ShowDialog_BoxIconNone_SeamReturnsOk_ReturnsOkResult()
         {
             // Arrange: inject non-modal stub so no real dialog is displayed
@@ -96,7 +96,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     DialogResult.OK from the injected seam.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ShowDialog_BoxIconCritical_SeamReturnsOk_ReturnsOkResult()
         {
             // Arrange
@@ -128,7 +127,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     DialogResult.OK from the injected seam.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ShowDialog_BoxIconWarning_SeamReturnsOk_ReturnsOkResult()
         {
             // Arrange
@@ -160,7 +158,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     DialogResult.OK from the injected seam.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ShowDialog_BoxIconQuestion_SeamReturnsOk_ReturnsOkResult()
         {
             // Arrange
@@ -192,7 +189,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     DialogResult.OK from the injected seam.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ShowDialog_MessageBoxIconError_SeamReturnsOk_ReturnsOkResult()
         {
             // Arrange
@@ -223,7 +219,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     DialogResult.OK from the injected seam.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ShowDialog_MessageBoxIconNone_SeamReturnsOk_ReturnsOkResult()
         {
             // Arrange
@@ -254,7 +249,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     DialogResult.OK from the injected seam.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ShowDialog_MessageBoxIconWarning_SeamReturnsOk_ReturnsOkResult()
         {
             // Arrange
@@ -285,7 +279,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     DialogResult.OK from the injected seam.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ShowDialog_MessageBoxIconQuestion_SeamReturnsOk_ReturnsOkResult()
         {
             // Arrange
@@ -316,7 +309,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     DialogResult.OK from the injected seam.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ShowDialog_MessageBoxIconInformation_SeamReturnsOk_ReturnsOkResult()
         {
             // Arrange
@@ -353,7 +345,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     DialogResult.OK from the injected seam.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ShowDialog_ConvenienceMessageBoxButtons_SeamReturnsOk_ReturnsExpectedResult()
         {
             // Arrange: inject seam; overload 5 creates its own viewer internally
@@ -384,7 +375,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     DialogResult.OK from the injected seam.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ShowDialog_ConvenienceActionDictionary_SeamReturnsOk_ReturnsExpectedResult()
         {
             // Arrange
@@ -421,7 +411,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     ShowDialog itself; group.Result stays at its default value.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ShowDialog_ConvenienceGenericFunctionDict_SeamReturnsOk_ReturnsDefaultGroupResult()
         {
             // Arrange: seam returns immediately; function is never invoked, so group.Result = default(int).
@@ -456,7 +445,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     DialogResult.OK from the injected seam.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ShowDialog_DelegateButtonOverload_SeamReturnsOk_ReturnsOkResult()
         {
             // Arrange: overload 1 creates its own viewer internally using a using block
@@ -494,7 +482,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     DialogResult.Cancel from the injected seam.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ShowDialog_BoxIconOverload_SeamReturnsCancel_ReturnsDefaultCancelResult()
         {
             // Arrange: inject seam that returns Cancel to simulate the user dismissing
@@ -530,7 +517,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     DialogResult.No from the injected seam.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ShowDialog_MessageBoxIconOverload_SeamReturnsNo_ReturnsNoResult()
         {
             // Arrange

--- a/UtilitiesCS.Test/Dialogs/MyBox_Tests.cs
+++ b/UtilitiesCS.Test/Dialogs/MyBox_Tests.cs
@@ -18,10 +18,11 @@ namespace UtilitiesCS.Test.Dialogs
     ///     FunctionButtonGroup&lt;T&gt; routes results through the delegate correctly.
     ///
     /// Constraints:
-    ///     Tests that instantiate WinForms controls require STA threads.
+    ///     This class runs under MSTest's STA class execution mode because its
+    ///     tests create WinForms controls directly or through MyBox helpers.
     ///     Internal members are accessible via InternalsVisibleTo("UtilitiesCS.Test").
     /// </summary>
-    [TestClass]
+    [STATestClass]
     public class MyBox_Tests
     {
         // ---------------------------------------------------------------------------
@@ -81,7 +82,6 @@ namespace UtilitiesCS.Test.Dialogs
         // ---------------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void ToActionButtons_KeyContainingCancel_AssignsCancelDialogResult()
         {
             // Arrange — create actions where one key contains "Cancel" and one does not
@@ -101,7 +101,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void ToActionButtons_NoKeyContainingCancel_AllGetOkDialogResult()
         {
             // Arrange
@@ -125,7 +124,6 @@ namespace UtilitiesCS.Test.Dialogs
         // ---------------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void ToFunctionButtonsAsync_WhenFunctionInvoked_SetsGroupResult()
         {
             // Arrange — create a single-entry dictionary mapping a label to an async function
@@ -147,7 +145,6 @@ namespace UtilitiesCS.Test.Dialogs
         }
 
         [TestMethod]
-        [STAThread]
         public void ToFunctionButtonsAsync_MultipleFunctions_EachButtonHasOkDialogResult()
         {
             // Arrange
@@ -183,7 +180,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     Passes when <c>wasCalled</c> is true after Button1.PerformClick().
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void MappedDelegate_IsInvokedWhenButton1IsClicked()
         {
             // Arrange: build a map whose first delegate records a call
@@ -233,7 +229,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     Passes when L2Bottom.Controls contains zero Button instances.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void RemoveStandardButtons_LeavesNoButtonControlsInBottomPanel()
         {
             // Arrange
@@ -271,7 +266,6 @@ namespace UtilitiesCS.Test.Dialogs
         ///     sum of ColumnStyles[1] and ColumnStyles[2] widths.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void CalcMinSize_AfterInit_ReturnsExpectedReducedWidth()
         {
             // Arrange: read the actual (DPI-scaled) values to avoid hardcoding

--- a/UtilitiesCS.Test/Dialogs/NotImplementedDialog_Tests.cs
+++ b/UtilitiesCS.Test/Dialogs/NotImplementedDialog_Tests.cs
@@ -112,8 +112,7 @@ namespace UtilitiesCS.Test.Dialogs
         /// Returns:
         ///     true when seam returns DialogResult.Yes.
         /// </summary>
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void StopAtNotImplemented_SeamReturnsYes_ReturnsTrueThrowPath()
         {
             // Arrange: inject seam that returns Yes (throw-exception decision)
@@ -141,8 +140,7 @@ namespace UtilitiesCS.Test.Dialogs
         /// Returns:
         ///     false when seam returns DialogResult.No.
         /// </summary>
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void StopAtNotImplemented_SeamReturnsNo_ReturnsFalseKeepRunningPath()
         {
             // Arrange: inject seam that returns No (keep-running decision)

--- a/UtilitiesCS.Test/Dialogs/YesNoToAll_Tests.cs
+++ b/UtilitiesCS.Test/Dialogs/YesNoToAll_Tests.cs
@@ -113,8 +113,7 @@ namespace UtilitiesCS.Test
         /// Returns:
         ///     YesNoToAllResponse.Yes after the seam invokes RespondYes().
         /// </summary>
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void ShowDialog_SeamInvokesRespondYes_ReturnsYesResponse()
         {
             // Arrange: inject seam that simulates the Yes delegate button being clicked
@@ -146,8 +145,7 @@ namespace UtilitiesCS.Test
         /// Returns:
         ///     YesNoToAllResponse.No after the seam invokes RespondNo().
         /// </summary>
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void ShowDialog_SeamInvokesRespondNo_ReturnsNoResponse()
         {
             // Arrange: simulate No button click
@@ -178,8 +176,7 @@ namespace UtilitiesCS.Test
         /// Returns:
         ///     YesNoToAllResponse.YesToAll after the seam invokes RespondYesToAll().
         /// </summary>
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void ShowDialog_SeamInvokesRespondYesToAll_ReturnsYesToAllResponse()
         {
             // Arrange: simulate YesToAll button click

--- a/UtilitiesCS.Test/EmailIntelligence/AutoFile_Tests.cs
+++ b/UtilitiesCS.Test/EmailIntelligence/AutoFile_Tests.cs
@@ -238,8 +238,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         ///     capturing stub; <see cref="TestCleanup_ResetMyBoxDialogInvokerSeam"/>
         ///     restores the real implementation after the test.
         /// </summary>
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void AutoFindPeople_WhenMissingRecipientsAndNotifyEnabled_ShowsUnknownRecipientsDialog()
         {
             // Arrange: one known sender and one unknown recipient force the warning path

--- a/UtilitiesCS.Test/EmailIntelligence/Bayesian/ObsoleteBayesianClassifier_Tests.cs
+++ b/UtilitiesCS.Test/EmailIntelligence/Bayesian/ObsoleteBayesianClassifier_Tests.cs
@@ -395,6 +395,35 @@ namespace UtilitiesCS.Test.EmailIntelligence.Bayesian
         }
 
         [TestMethod]
+        public async Task InferNegativeTokensAsync_WithLegacyNullProbabilities_RebuildsMatchFromSharedTokenBase()
+        {
+            // Arrange
+            var sharedTokens = Enumerable
+                .Repeat("shared-strong", 6)
+                .Concat(Enumerable.Repeat("shared-peer", 6))
+                .Concat(Enumerable.Repeat("negative-only", 6))
+                .ToArray();
+            var parent = CreateLegacyClassifierGroup(sharedTokens);
+            var classifier = new BayesianClassifierProbe
+            {
+                ParentGroup = parent,
+                MatchCorpus = new Corpus(Enumerable.Repeat("stale-match", 6)),
+                NotMatchCorpus = new Corpus(Enumerable.Repeat("negative-only", 6)),
+                ProbabilityMap = null,
+            };
+
+            // Act
+            await classifier.InferNegativeTokensAsync(CancellationToken.None);
+            await classifier.RecalcProbsAsync(CancellationToken.None);
+
+            // Assert
+            classifier.Match.TokenFrequency.Should().ContainKey("shared-strong");
+            classifier.Match.TokenFrequency.Should().ContainKey("shared-peer");
+            classifier.Match.TokenFrequency.Should().NotContainKey("stale-match");
+            classifier.Prob.Should().NotBeNullOrEmpty();
+        }
+
+        [TestMethod]
         public async Task FromTokenBaseAsync_WithValidInputs_ReturnsClassifierWithProbabilities()
         {
             // Arrange

--- a/UtilitiesCS.Test/EmailIntelligence/ClassifierGroup_Tests.cs
+++ b/UtilitiesCS.Test/EmailIntelligence/ClassifierGroup_Tests.cs
@@ -103,9 +103,7 @@ namespace UtilitiesCS.Test.EmailIntelligence.Bayesian
         )
         {
             var autoFiles = new Mock<IAppAutoFileObjects>(MockBehavior.Loose);
-            autoFiles
-                .SetupGet(x => x.ProgressTracker)
-                .Returns(CreateFakeProgressTrackerPane());
+            autoFiles.SetupGet(x => x.ProgressTracker).Returns(CreateFakeProgressTrackerPane());
             autoFiles.SetupGet(x => x.ProgressPane).Returns(progressPane);
             autoFiles.SetupGet(x => x.CancelToken).Returns(cancelToken);
 

--- a/UtilitiesCS.Test/EmailIntelligence/ClassifierGroup_Tests.cs
+++ b/UtilitiesCS.Test/EmailIntelligence/ClassifierGroup_Tests.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -9,11 +9,13 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using UtilitiesCS.EmailIntelligence.Bayesian;
 using UtilitiesCS.HelperClasses;
+using UtilitiesCS.Threading;
 
 #pragma warning disable CS0618
 
 namespace UtilitiesCS.Test.EmailIntelligence.Bayesian
 {
+    [DoNotParallelize]
     [TestClass]
     public class ClassifierGroup_Remediation_Tests
     {
@@ -103,13 +105,48 @@ namespace UtilitiesCS.Test.EmailIntelligence.Bayesian
             var autoFiles = new Mock<IAppAutoFileObjects>(MockBehavior.Loose);
             autoFiles
                 .SetupGet(x => x.ProgressTracker)
-                .Returns(BayesianPerformanceMeasurement_Tests.CreateFakeProgressTrackerPane());
+                .Returns(CreateFakeProgressTrackerPane());
             autoFiles.SetupGet(x => x.ProgressPane).Returns(progressPane);
             autoFiles.SetupGet(x => x.CancelToken).Returns(cancelToken);
 
             var globals = new Mock<IApplicationGlobals>(MockBehavior.Loose);
             globals.SetupGet(x => x.AF).Returns(autoFiles.Object);
             return globals.Object;
+        }
+
+        private static ProgressTrackerPane CreateFakeProgressTrackerPane()
+        {
+            var pane = (ProgressTrackerPane)
+                FormatterServices.GetUninitializedObject(typeof(ProgressTrackerPane));
+            var parentField = typeof(ProgressTrackerPane).GetField(
+                "_parent",
+                BindingFlags.Instance | BindingFlags.NonPublic
+            );
+            var parent = Activator.CreateInstance(
+                parentField.FieldType,
+                new SynchronousProgress<(int Value, string JobName)>(_ => { }),
+                100,
+                0
+            );
+
+            parentField.SetValue(pane, parent);
+            typeof(ProgressTrackerPane)
+                .GetField("_progressViewer", BindingFlags.Instance | BindingFlags.NonPublic)
+                .SetValue(pane, null);
+            typeof(ProgressTrackerPane)
+                .GetField("_isRoot", BindingFlags.Instance | BindingFlags.NonPublic)
+                .SetValue(pane, false);
+            typeof(ProgressTrackerPane)
+                .GetField("_root100", BindingFlags.Instance | BindingFlags.NonPublic)
+                .SetValue(pane, false);
+            typeof(ProgressTrackerPane)
+                .GetField("_progress", BindingFlags.Instance | BindingFlags.NonPublic)
+                .SetValue(pane, 0d);
+            typeof(ProgressTrackerPane)
+                .GetField("_jobName", BindingFlags.Instance | BindingFlags.NonPublic)
+                .SetValue(pane, string.Empty);
+
+            return pane;
         }
 
         private static ClassifierGroup CreateConfiguredGroup(
@@ -138,6 +175,21 @@ namespace UtilitiesCS.Test.EmailIntelligence.Bayesian
             }
 
             return group;
+        }
+
+        private sealed class SynchronousProgress<T> : IProgress<T>
+        {
+            private readonly Action<T> _callback;
+
+            public SynchronousProgress(Action<T> callback)
+            {
+                _callback = callback;
+            }
+
+            public void Report(T value)
+            {
+                _callback(value);
+            }
         }
     }
 }

--- a/UtilitiesCS.Test/EmailIntelligence/ClassifierGroup_Tests.cs
+++ b/UtilitiesCS.Test/EmailIntelligence/ClassifierGroup_Tests.cs
@@ -63,6 +63,38 @@ namespace UtilitiesCS.Test.EmailIntelligence.Bayesian
             }
         }
 
+        [TestMethod]
+        public async Task HeavyParallelizationAsync_WithFewerClassifiersThanProcessors_DoesNotThrow()
+        {
+            // Regression: InferNegative computed chunkSize via Math.Round(count / processors),
+            // which rounds to 0 when the classifier count is smaller than half the processor
+            // count. Chunk(0) then throws ArgumentOutOfRangeException. A single classifier
+            // forces the chunkSize == 0 path on any multi-core host. The sibling RecalcProbsAsync
+            // was already clamped; this guards the matching InferNegative path.
+            var progressPane = new Mock<Microsoft.Office.Tools.CustomTaskPane>();
+            progressPane.SetupProperty(x => x.Visible, false);
+            var group = CreateConfiguredGroup(
+                CreateGlobals(progressPane.Object, CancellationToken.None),
+                classifierCount: 1,
+                clearProbabilities: true
+            );
+            var stopwatch = new SegmentStopWatch().Start();
+
+            Func<Task> act = () =>
+                group.AfterDeserialized_HeavyParallelizationAsync(
+                    CancellationToken.None,
+                    stopwatch
+                );
+
+            // The fix's contract: the chunk pipeline runs end-to-end without the
+            // ArgumentOutOfRangeException that Chunk(0) previously raised. Probability
+            // rebuild content is covered by the sibling test with a realistic classifier
+            // count; asserting Prob is non-null here confirms the rebuild path executed
+            // while keeping this test deterministic under parallel load.
+            await act.Should().NotThrowAsync();
+            group.Classifiers.Values.Should().OnlyContain(classifier => classifier.Prob != null);
+        }
+
         private static IApplicationGlobals CreateGlobals(
             Microsoft.Office.Tools.CustomTaskPane progressPane,
             CancellationToken cancelToken

--- a/UtilitiesCS.Test/EmailIntelligence/ClassifierGroups/ClassifierGroups_Tests.cs
+++ b/UtilitiesCS.Test/EmailIntelligence/ClassifierGroups/ClassifierGroups_Tests.cs
@@ -853,8 +853,7 @@ namespace UtilitiesCS.Test.EmailIntelligence.ClassifierGroups
                 );
         }
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public async Task BuildClassifiersAsync_MissingStagingData_ShowsActionableWarningInsteadOfThrowing()
         {
             var mockGlobals = CreateMockGlobals();

--- a/UtilitiesCS.Test/EmailIntelligence/FilterOlFoldersController_Tests.cs
+++ b/UtilitiesCS.Test/EmailIntelligence/FilterOlFoldersController_Tests.cs
@@ -23,10 +23,9 @@ namespace UtilitiesCS.Test.EmailIntelligence
     ///     PutCheckedStateMethod without requiring a live COM Outlook session.
     ///
     /// Usage:
-    ///     All tests bypass the COM-dependent constructor via
-    ///     FormatterServices.GetUninitializedObject and inject dependencies
-    ///     through reflection. Every test that touches WinForms controls must
-    ///     run on an STA thread.
+    ///     Tests bypass the COM-dependent constructor via FormatterServices.GetUninitializedObject
+    ///     and inject dependencies through reflection. WinForms-affine tests opt into MSTest's
+    ///     scoped STA execution explicitly.
     /// </summary>
     [TestClass]
     public class FilterOlFoldersController_Tests
@@ -157,8 +156,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// The test also exercises the three GetCheckedState outcomes: Checked,
         /// Indeterminate, and Unchecked.
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void Constructor_WithMockedArchiveRoot_InitializesViewerAndGetCheckedStatePaths()
         {
             // Arrange
@@ -251,8 +249,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// The test uses an empty ScoDictionary so Serialize() is a no-op
         /// (Filepath is "").
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void Save_ClosesViewer_AndAccessesFilteredFolderScraping()
         {
             // Arrange
@@ -278,8 +275,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that Save removes keys that are no longer selected and adds new
         /// selected keys before serializing the backing dictionary.
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void Save_WhenSelectionChanges_RemovesDeselectedKeysAndAddsSelectedKeys()
         {
             // Arrange
@@ -332,8 +328,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that Discard() closes the viewer form without requiring
         /// COM globals.
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void Discard_ClosesViewer()
         {
             // Arrange
@@ -358,8 +353,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// (setting empty roots on both tree list views) given a synthetic tree
         /// and pre-initialized ExpandedObjects collections.
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void OlFolderTree_PropertyChangedInternal_WithSyntheticTree_SetsEmptyRootsOnViewer()
         {
             // Arrange
@@ -390,8 +384,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that OlFolderTree_PropertyChanged follows the same-thread path when
         /// InvokeRequired is false and delegates to the internal refresh logic.
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void OlFolderTree_PropertyChanged_OnSameThread_RefreshesViewerWithoutInvoke()
         {
             // Arrange
@@ -425,8 +418,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// all descendants when the tree is collapsed (IsExpanded returns false for
         /// a fresh TreeListView), returning CheckState.Checked.
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void PutCheckedStateMethod_Collapsed_ChecksNodeAndDescendants()
         {
             // Arrange — bypass COM constructor; _viewer/_globals not needed
@@ -456,8 +448,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// all descendants when unchecking while the tree is collapsed, returning
         /// CheckState.Unchecked.
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void PutCheckedStateMethod_Collapsed_UnchecksNodeAndDescendants()
         {
             // Arrange
@@ -486,8 +477,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that PutCheckedStateMethod updates only the current node when the
         /// tree reports the node as expanded.
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void PutCheckedStateMethod_Expanded_UpdatesOnlyCurrentNode()
         {
             // Arrange
@@ -529,8 +519,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that the filtered and not-filtered forwarding helpers delegate to
         /// the correct viewer tree list view instance.
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void PutCheckedStateMethodForwarders_UseTheirAssignedViewerTrees()
         {
             // Arrange

--- a/UtilitiesCS.Test/EmailIntelligence/FilterOlFoldersViewer_Tests.cs
+++ b/UtilitiesCS.Test/EmailIntelligence/FilterOlFoldersViewer_Tests.cs
@@ -17,11 +17,12 @@ namespace UtilitiesCS.Test.EmailIntelligence
     ///     (BtnDiscard_Click and BtnSave_Click) without requiring a live COM controller.
     ///
     /// Usage:
-    ///     All tests instantiate FilterOlFoldersViewer on an STA thread.
+    ///     This class runs under MSTest's STA class execution mode because every
+    ///     test instantiates FilterOlFoldersViewer.
     ///     SetController tests inject an uninitialized controller whose _olFolderTree
     ///     is set to a synthetic FolderTree so that SetupTree() does not hit COM.
     /// </summary>
-    [TestClass]
+    [STATestClass]
     public class FilterOlFoldersViewer_Tests
     {
         // ---------------------------------------------------------------------------
@@ -33,7 +34,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// and ChildrenGetter on both tree list views) when the controller has a
         /// synthetic, COM-free FolderTree.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void SetController_WithSyntheticController_ConfiguresBothTreeDelegates()
         {
@@ -78,7 +78,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that FormatFileSize returns a "bytes" string for inputs below
         /// the 1 KB threshold (less than 1024 bytes).
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void FormatFileSize_WithBytesInput_ReturnsBytesString()
         {
@@ -100,7 +99,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that FormatFileSize returns a "KB" string for a 1-KB input and
         /// an "MB" string for a 1-MB input.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void FormatFileSize_WithKbInput_ReturnsKbString()
         {
@@ -120,7 +118,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that the private SetupDragAndDrop helper enables simple drag/drop
         /// behaviour on the non-filtered tree list view.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void SetupDragAndDrop_WhenInvoked_EnablesSimpleDragAndDropFlags()
         {
@@ -147,7 +144,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// then invoking the private click handler via reflection.
         /// The expected observable side effect is that the viewer is closed.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void BtnDiscard_Click_ForwardsDiscardToController_ClosesViewer()
         {
@@ -181,7 +177,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that BtnDiscard_Click is a no-op (does not throw) when the
         /// controller field is null, exercising the ?. null-coalescing guard.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void BtnDiscard_Click_WithNullController_DoesNotThrow()
         {
@@ -204,7 +199,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// an uninitialized controller with a synthetic FolderTree and a real viewer.
         /// The observable side effect is that the viewer is closed.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void BtnSave_Click_ForwardsSaveToController_ClosesViewer()
         {
@@ -263,7 +257,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that BtnSave_Click is a no-op when the viewer has no controller,
         /// exercising the null-conditional forwarding path.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void BtnSave_Click_WithNullController_DoesNotThrow()
         {

--- a/UtilitiesCS.Test/EmailIntelligence/FolderInfoViewer_Tests.cs
+++ b/UtilitiesCS.Test/EmailIntelligence/FolderInfoViewer_Tests.cs
@@ -17,11 +17,12 @@ namespace UtilitiesCS.Test.EmailIntelligence
     ///     FolderTree property mirrors the most-recently supplied reference.
     ///
     /// Usage:
-    ///     All tests instantiate FolderInfoViewer and FolderTree on an STA thread.
+    ///     This class runs under MSTest's STA class execution mode because every
+    ///     test instantiates FolderInfoViewer and FolderTree.
     ///     A synthetic FolderTree with an empty _roots list is used to avoid
     ///     accessing COM MAPIFolder objects; TreeListView.Roots accepts null/empty.
     /// </summary>
-    [TestClass]
+    [STATestClass]
     public class FolderInfoViewer_Tests
     {
         // ---------------------------------------------------------------------------
@@ -49,7 +50,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that after calling SetFolderTree the internal FolderTree property
         /// returns the same instance that was passed in.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void SetFolderTree_AssignedOnce_PropertyReturnsSuppliedReference()
         {
@@ -72,7 +72,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that calling SetFolderTree a second time replaces the previously
         /// stored reference with the most-recently supplied instance.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void SetFolderTree_ReassignedWithNewInstance_PropertyReturnsMostRecentReference()
         {

--- a/UtilitiesCS.Test/EmailIntelligence/FolderRemapController_Tests.cs
+++ b/UtilitiesCS.Test/EmailIntelligence/FolderRemapController_Tests.cs
@@ -23,8 +23,8 @@ namespace UtilitiesCS.Test.EmailIntelligence
     /// Usage:
     ///     All tests bypass the COM-dependent constructor via
     ///     FormatterServices.GetUninitializedObject and inject dependencies through
-    ///     reflection. Every test that touches WinForms controls must run on an STA
-    ///     thread.
+    ///     reflection. Tests that touch WinForms controls opt into MSTest's scoped
+    ///     STA execution explicitly.
     /// </summary>
     [TestClass]
     public partial class FolderRemapController_Tests
@@ -115,8 +115,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that HandleModelDropped with DropTargetLocation.Item causes the
         /// source node's MappedTo to be set to the target node's OlFolderRemap value.
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void HandleModelDropped_ItemDrop_SetsMappedToOnSourceNode()
         {
             // Arrange
@@ -162,8 +161,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that Save() closes the viewer and accesses TD.FolderRemap on the
         /// backing model. Uses an empty ScoDictionary so Serialize() is a no-op.
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void Save_ClosesViewer_AndAccessesFolderRemap()
         {
             // Arrange
@@ -192,8 +190,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// <summary>
         /// Verifies that Discard() closes the viewer form.
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void Discard_ClosesViewer()
         {
             // Arrange
@@ -218,8 +215,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// expand nodes at depth 0 (all root-level nodes). The assertion confirms
         /// no exception is raised regardless of OLV expand behavior on a hidden form.
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void ExpandTo_WithDepthLevelOne_DoesNotThrow()
         {
             // Arrange
@@ -247,8 +243,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// dictionary's Keys property when Mappings2 is empty (resulting in no
         /// removals and no additions). Serialize() is a no-op for an unfiled dict.
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void SyncGlobalMap_WithEmptyMappings_PropagatesEmptyStateToGlobals()
         {
             // Arrange
@@ -362,8 +357,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         }
 
         // P14-T9: ExpandTo(1, addChecked=true) expands nodes whose descendants have mappings
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void ExpandTo_WithAddCheckedTrue_DoesNotThrowOnMappedNodes()
         {
             // Arrange — node with MappedTo set so the addChecked branch executes
@@ -402,8 +396,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         }
 
         // P14-T11: OlFolderTree_PropertyChanged syncs and updates viewer when _update is false
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void OlFolderTreePropertyChanged_WhenUpdateIsFalse_SyncsRemapTreeAndUpdatesViewer()
         {
             // Arrange — default _update=false so normal sync path is taken

--- a/UtilitiesCS.Test/EmailIntelligence/FolderRemapController_Tests2.cs
+++ b/UtilitiesCS.Test/EmailIntelligence/FolderRemapController_Tests2.cs
@@ -118,8 +118,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies MoveObjectsToChildren redirects source to target's existing MappedTo
         /// when target.Value.MappedTo is already populated.
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void HandleModelDropped_WhenTargetHasMappedTo_SetsSourceMappedToTargetsMappedTo()
         {
             var finalDest = new OlFolderRemap();
@@ -157,8 +156,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         // ---------------------------------------------------------------------------
 
         /// <summary>Verifies MakeCheckedStatePutter() returns a callable CheckStatePutterDelegate.</summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void MakeCheckedStatePutter_ReturnsDelegateInstance()
         {
             var viewer = new FolderRemapViewer();
@@ -178,8 +176,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         // ---------------------------------------------------------------------------
 
         /// <summary>Verifies the Unchecked branch of the returned delegate sets MappedTo to null.</summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void MakeCheckedStatePutter_Delegate_WhenUnchecked_ClearsMappedToAndReturnsUnchecked()
         {
             var viewer = new FolderRemapViewer();
@@ -381,8 +378,7 @@ namespace UtilitiesCS.Test.EmailIntelligence
         ///     3. Assert delegate properties are non-null and tree/mappings are populated.
         ///     4. Discard (close) the modeless viewer form.
         /// </summary>
-        [STAThread]
-        [TestMethod]
+        [STATestMethod]
         public void Constructor_WithMockedOutlookFolder_InitializesAllFieldsAndDelegates()
         {
             // Arrange: build a mock Outlook root folder with no children

--- a/UtilitiesCS.Test/EmailIntelligence/FolderRemapViewer_Tests.cs
+++ b/UtilitiesCS.Test/EmailIntelligence/FolderRemapViewer_Tests.cs
@@ -18,11 +18,12 @@ namespace UtilitiesCS.Test.EmailIntelligence
     ///     SetController, and the FormatFileSize helper.
     ///
     /// Usage:
-    ///     All tests instantiate FolderRemapViewer on an STA thread.
+    ///     This class runs under MSTest's STA class execution mode because every
+    ///     test instantiates FolderRemapViewer.
     ///     SetController tests inject an uninitialized controller whose _folderRemapTree
     ///     and _mappings2 are set via reflection to avoid COM access.
     /// </summary>
-    [TestClass]
+    [STATestClass]
     public class FolderRemapViewer_Tests
     {
         // ---------------------------------------------------------------------------
@@ -73,7 +74,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// reflection. Uses DropTargetLocation.Background so HandleModelDropped is
         /// a no-op and no additional dependencies are required.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void TlvOriginal_ModelDropped_ForwardsEventToController_DoesNotThrow()
         {
@@ -114,7 +114,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that SetController runs to completion and configures the
         /// CanExpandGetter on TlvOriginal (confirming SetupTree executed).
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void SetController_WithSyntheticController_ConfiguresTreeDelegates()
         {
@@ -139,7 +138,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that FormatFileSize returns a "KB" string for a 1 KB input and a
         /// "bytes" string for a sub-KB input.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void FormatFileSize_ReturnsExpectedStringForSampleInputs()
         {

--- a/UtilitiesCS.Test/EmailIntelligence/FolderSelector_Tests.cs
+++ b/UtilitiesCS.Test/EmailIntelligence/FolderSelector_Tests.cs
@@ -18,11 +18,11 @@ namespace UtilitiesCS.Test.EmailIntelligence
     ///     invoked.
     ///
     /// Usage:
-    ///     All tests instantiate FolderSelector on an STA thread. OlFolderRemap is
+    ///     This class runs under MSTest's STA class execution mode. OlFolderRemap is
     ///     constructed with the default no-arg constructor; RelativePath and Name
     ///     remain null but are not required by the tested paths.
     /// </summary>
-    [TestClass]
+    [STATestClass]
     public class FolderSelector_Tests
     {
         // ---------------------------------------------------------------------------
@@ -34,7 +34,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// TlvOriginal.Roots to the supplied collection and assigns a non-null
         /// CheckStatePutter delegate.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void Initialize_WithNonEmptyRoots_ConfiguresTreeRootsAndCheckStatePutter()
         {
@@ -60,7 +59,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// assigns the corresponding OlFolderRemap to the Selection property and
         /// returns CheckState.Checked.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void CheckStatePutter_WhenInvoked_SetsSelectionToNodeValue()
         {
@@ -88,7 +86,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that calling Initialize with an empty roots list does not throw
         /// and leaves the Selection property as null (no selection was made).
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void Initialize_WithEmptyRootsList_LeavesSelectionNull()
         {

--- a/UtilitiesCS.Test/EmailIntelligence/OSBrowser_Tests.cs
+++ b/UtilitiesCS.Test/EmailIntelligence/OSBrowser_Tests.cs
@@ -19,11 +19,11 @@ namespace UtilitiesCS.Test.EmailIntelligence
     ///     constructor are asserted via reflection on the private treeListView field).
     ///
     /// Usage:
-    ///     All tests instantiate OSBrowser on an STA thread. The constructor calls
+    ///     This class runs under MSTest's STA class execution mode. The constructor calls
     ///     SetupColumns(), SetupDragAndDrop(), and SetupTree() which enumerate real
     ///     drives; tests only assert on delegate assignment and format output.
     /// </summary>
-    [TestClass]
+    [STATestClass]
     public class OSBrowser_Tests
     {
         // ---------------------------------------------------------------------------
@@ -49,7 +49,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// AspectGetters to the size and file-type columns (confirming columns were
         /// initialised with custom configuration, not left at designer defaults only).
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void Constructor_SetupColumns_AttachesAspectGetterToSizeColumn()
         {
@@ -71,7 +70,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that the OSBrowser constructor's SetupTree() call assigns both
         /// CanExpandGetter and ChildrenGetter on the TreeListView.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void Constructor_SetupTree_AssignsBothDelegates()
         {
@@ -92,7 +90,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that FormatFileSize returns a "bytes" string when the input is
         /// below the 1 KB threshold.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void FormatFileSize_WithBytesInput_ReturnsBytesString()
         {
@@ -114,7 +111,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// Verifies that FormatFileSize returns a "KB" string for a 1 KB input and
         /// an "MB" string for a 1 MB input.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void FormatFileSize_WithKbAndMbInputs_ReturnsCorrectUnits()
         {
@@ -139,7 +135,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         ///     AspectGetter and AspectToStringConverter branches for directory, file,
         ///     missing-file, file-type, and attribute scenarios.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void Constructor_WiredDelegates_HandleDirectoryFileAndMissingFileInputs()
         {
@@ -229,7 +224,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
         /// <see cref="System.Collections.ArrayList"/> when directory enumeration raises
         /// <see cref="UnauthorizedAccessException"/>.
         /// </summary>
-        [STAThread]
         [TestMethod]
         public void Constructor_ChildrenGetter_WhenDirectoryAccessDenied_ReturnsEmptyArrayList()
         {

--- a/UtilitiesCS.Test/EmailIntelligence/SubjectMapMetrics_Tests.cs
+++ b/UtilitiesCS.Test/EmailIntelligence/SubjectMapMetrics_Tests.cs
@@ -10,7 +10,7 @@ using UtilitiesCS.EmailIntelligence.SubjectMap;
 
 namespace UtilitiesCS.Test.EmailIntelligence
 {
-    [TestClass]
+    [STATestClass]
     public class SubjectMapMetrics_Tests
     {
         private static DataListView GetMetricsListView(SubjectMapMetrics viewer) =>
@@ -19,7 +19,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
                     .GetField("DlvMetrics", BindingFlags.NonPublic | BindingFlags.Instance)
                     .GetValue(viewer);
 
-        [STAThread]
         [TestMethod]
         public void Constructor_WithMetrics_PopulatesDlvMetricsWithExpectedNumericValues()
         {
@@ -47,7 +46,6 @@ namespace UtilitiesCS.Test.EmailIntelligence
                 .Contain(column => column.AspectName == "EmailCount");
         }
 
-        [STAThread]
         [TestMethod]
         public void Constructors_WithEquivalentEmptyInputs_ProduceEquivalentDlvMetricsState()
         {

--- a/UtilitiesCS.Test/Extensions/WinFormsExtensions_Tests.cs
+++ b/UtilitiesCS.Test/Extensions/WinFormsExtensions_Tests.cs
@@ -12,8 +12,7 @@ namespace UtilitiesCS.Test.Extensions
     {
         #region ForAllControls (Action)
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void ForAllControls_Action_VisitsAllControls()
         {
             var parent = new Panel { Name = "parent" };
@@ -33,8 +32,7 @@ namespace UtilitiesCS.Test.Extensions
             visited.Should().Contain("grandchild");
         }
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void ForAllControls_IEnumerable_VisitsAll()
         {
             var parent1 = new Panel { Name = "p1" };
@@ -52,8 +50,7 @@ namespace UtilitiesCS.Test.Extensions
 
         #region ForAllControls (with except)
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void ForAllControls_WithExcept_SkipsExcludedControls()
         {
             var parent = new Panel { Name = "parent" };
@@ -75,8 +72,7 @@ namespace UtilitiesCS.Test.Extensions
 
         #region GetAllChildren
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void GetAllChildren_ReturnsAllDescendants()
         {
             var root = new Panel { Name = "root" };
@@ -92,8 +88,7 @@ namespace UtilitiesCS.Test.Extensions
             all.Select(c => c.Name).Should().Contain("grandchild");
         }
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void GetAllChildren_WithExcept_SkipsExcluded()
         {
             var root = new Panel { Name = "root" };
@@ -111,8 +106,7 @@ namespace UtilitiesCS.Test.Extensions
 
         #region GetAncestor
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void GetAncestor_FormParent_ReturnsForm()
         {
             var form = new Form { Name = "myForm" };
@@ -125,8 +119,7 @@ namespace UtilitiesCS.Test.Extensions
             ancestor.Should().BeSameAs(form);
         }
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void GetAncestor_NoMatchingParent_ReturnsNull()
         {
             var panel = new Panel { Name = "panel" };
@@ -137,8 +130,7 @@ namespace UtilitiesCS.Test.Extensions
             ancestor.Should().BeNull();
         }
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void GetAncestor_Strict_NoMatch_ThrowsArgumentOutOfRange()
         {
             var panel = new Panel { Name = "panel" };
@@ -154,8 +146,7 @@ namespace UtilitiesCS.Test.Extensions
         //           ancestor chain contains no match for the requested type.
         // -----------------------------------------------------------------------
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void GetAncestor_ChainWithNoMatchingType_ReturnsNullWithoutThrowing()
         {
             // Arrange: three-level Panel chain — no Form ancestor exists.
@@ -183,8 +174,7 @@ namespace UtilitiesCS.Test.Extensions
         //           being invoked when the event fires after removal.
         // -----------------------------------------------------------------------
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void RemoveEventHandlers_Click_HandlerNotInvokedAfterRemoval()
         {
             // Arrange: wire a click handler that increments a counter.
@@ -204,8 +194,7 @@ namespace UtilitiesCS.Test.Extensions
 
         #region ForAllControls (Func transform)
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void ForAllControls_FuncTransform_PropagatesValue()
         {
             var parent = new Panel { Name = "parent" };
@@ -225,8 +214,7 @@ namespace UtilitiesCS.Test.Extensions
             callCount.Should().BeGreaterThanOrEqualTo(2);
         }
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void Clone_TableLayoutPanelWithName_CopiesLayoutSettingsAndAssignedName()
         {
             var source = new TableLayoutPanel
@@ -293,8 +281,7 @@ namespace UtilitiesCS.Test.Extensions
             clone.Count.Should().Be(7);
         }
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void ForAllControls_IEnumerableWithExcept_SkipsExcludedRoots()
         {
             var included = new Panel { Name = "included" };
@@ -312,8 +299,7 @@ namespace UtilitiesCS.Test.Extensions
             visited.Should().NotContain("excluded");
         }
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void ForAllControls_ControlCollectionWithExcept_SkipsExcludedChildren()
         {
             var parent = new Panel();
@@ -334,8 +320,7 @@ namespace UtilitiesCS.Test.Extensions
             visited.Should().NotContain("excluded");
         }
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void ForAllControls_ActionWithValueAndExcept_UsesProvidedValueOnNonExcludedControls()
         {
             var parent = new Panel { Name = "parent" };
@@ -356,8 +341,7 @@ namespace UtilitiesCS.Test.Extensions
             visited.Should().NotContain("excluded:7");
         }
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void ForAllControls_FuncWithExcept_PropagatesSeedOnlyThroughIncludedControls()
         {
             var parent = new Panel { Name = "parent" };
@@ -422,8 +406,7 @@ namespace UtilitiesCS.Test.Extensions
             public void TriggerFormClicked() => OnFormClicked();
         }
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void PreFilterMessage_WM_LBUTTONDOWN_RaisesFormClickedWithFormAsSender()
         {
             // Arrange: subscribe to FormClicked to capture sender and args.
@@ -450,8 +433,7 @@ namespace UtilitiesCS.Test.Extensions
             receivedSender.Should().BeSameAs(form);
         }
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void PreFilterMessage_UnrelatedMessage_ReturnsFalseAndDoesNotRaiseEvent()
         {
             // Arrange: subscribe to detect any unexpected FormClicked raise.
@@ -471,8 +453,7 @@ namespace UtilitiesCS.Test.Extensions
             raised.Should().BeFalse("non-mouse messages must not raise FormClicked");
         }
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void PreFilterMessage_NoSubscribers_DoesNotThrow()
         {
             // Arrange: plain MouseDownFilter with no FormClicked subscribers.

--- a/UtilitiesCS.Test/HelperClasses/TableLayoutHelper_Tests.cs
+++ b/UtilitiesCS.Test/HelperClasses/TableLayoutHelper_Tests.cs
@@ -7,11 +7,10 @@ using UtilitiesCS;
 
 namespace UtilitiesCS.Test.HelperClasses
 {
-    [TestClass]
+    [STATestClass]
     public class TableLayoutHelper_Additional_Tests
     {
         [TestMethod]
-        [STAThread]
         public void InsertSpecificRow_WithExistingControls_ShiftsRowsAndClonesStyles()
         {
             var panel = CreatePanel(rowCount: 2, columnCount: 1);
@@ -34,7 +33,6 @@ namespace UtilitiesCS.Test.HelperClasses
         }
 
         [TestMethod]
-        [STAThread]
         public void RemoveSpecificRow_WhenIndexIsOutOfRange_LeavesPanelUnchanged()
         {
             var panel = CreatePanel(rowCount: 2, columnCount: 1);
@@ -46,7 +44,6 @@ namespace UtilitiesCS.Test.HelperClasses
         }
 
         [TestMethod]
-        [STAThread]
         public void RemoveSpecificRow_RemovesTargetedControlsAndShiftsRemainingRows()
         {
             var panel = CreatePanel(rowCount: 3, columnCount: 2);
@@ -67,7 +64,6 @@ namespace UtilitiesCS.Test.HelperClasses
         }
 
         [TestMethod]
-        [STAThread]
         public void RemoveSpecificColumn_WhenIndexIsOutOfRange_LeavesPanelUnchanged()
         {
             var panel = CreatePanel(rowCount: 1, columnCount: 2);
@@ -79,7 +75,6 @@ namespace UtilitiesCS.Test.HelperClasses
         }
 
         [TestMethod]
-        [STAThread]
         public void RemoveSpecificColumn_RemovesTargetedControlsAndShiftsRemainingColumns()
         {
             var panel = CreatePanel(rowCount: 2, columnCount: 3);

--- a/UtilitiesCS.Test/HelperClasses/ThemeHelpers/ThemeTests.cs
+++ b/UtilitiesCS.Test/HelperClasses/ThemeHelpers/ThemeTests.cs
@@ -59,13 +59,12 @@ namespace UtilitiesCS.Test.HelperClasses.ThemeHelpers
         #endregion
     }
 
-    [TestClass]
+    [STATestClass]
     public class ThemeControlGroup_Tests
     {
         #region OneField Constructor
 
         [TestMethod]
-        [STAThread]
         public void Constructor_OneField_CreatesInstance()
         {
             var controls = new List<Control> { new Label() };
@@ -93,7 +92,6 @@ namespace UtilitiesCS.Test.HelperClasses.ThemeHelpers
         #region TwoField Constructor
 
         [TestMethod]
-        [STAThread]
         public void Constructor_TwoField_CreatesInstance()
         {
             var controls = new List<Control> { new Label() };
@@ -121,7 +119,6 @@ namespace UtilitiesCS.Test.HelperClasses.ThemeHelpers
         #region TwoFieldAlt Constructor
 
         [TestMethod]
-        [STAThread]
         public void Constructor_TwoFieldAlt_CreatesInstance()
         {
             var controls = new List<Control> { new Label() };
@@ -142,7 +139,6 @@ namespace UtilitiesCS.Test.HelperClasses.ThemeHelpers
         #region TwoFieldAltHover Constructor
 
         [TestMethod]
-        [STAThread]
         public void Constructor_TwoFieldAltHover_CreatesInstance()
         {
             var controls = new List<Control> { new Label() };
@@ -168,7 +164,6 @@ namespace UtilitiesCS.Test.HelperClasses.ThemeHelpers
         // -----------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void ApplyTheme_TwoField_SetsExpectedColors()
         {
             // Arrange: two controls with a known fore/back pair.
@@ -193,7 +188,6 @@ namespace UtilitiesCS.Test.HelperClasses.ThemeHelpers
         // -----------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void ApplyTheme_TwoFieldAlt_IsAltTrue_SetsAltColors()
         {
             // Arrange: alternate-selector always returns true so alt colors apply.
@@ -227,7 +221,6 @@ namespace UtilitiesCS.Test.HelperClasses.ThemeHelpers
         // -----------------------------------------------------------------------
 
         [TestMethod]
-        [STAThread]
         public void ApplyTheme_HeterogeneousControls_DoesNotThrow()
         {
             // Arrange: mix of different WinForms control subtypes.
@@ -250,7 +243,6 @@ namespace UtilitiesCS.Test.HelperClasses.ThemeHelpers
         }
 
         [TestMethod]
-        [STAThread]
         public void ApplyTheme_OneField_SetsBackColorOnAllControls()
         {
             var label = new Label();
@@ -264,7 +256,6 @@ namespace UtilitiesCS.Test.HelperClasses.ThemeHelpers
         }
 
         [TestMethod]
-        [STAThread]
         public void ApplyTheme_TwoFieldAlt_IsAltFalse_SetsMainColors()
         {
             var label = new Label();
@@ -321,7 +312,6 @@ namespace UtilitiesCS.Test.HelperClasses.ThemeHelpers
         }
 
         [TestMethod]
-        [STAThread]
         public void ApplyTheme_TwoFieldAltHover_SetsEventColorsForAltAndMainControls()
         {
             var mainControl = new Label();
@@ -345,7 +335,6 @@ namespace UtilitiesCS.Test.HelperClasses.ThemeHelpers
         }
 
         [TestMethod]
-        [STAThread]
         public void HoverHandlers_UpdateBackColorForMouseEnterAndLeave()
         {
             var mainControl = new Label();
@@ -373,7 +362,6 @@ namespace UtilitiesCS.Test.HelperClasses.ThemeHelpers
         }
 
         [TestMethod]
-        [STAThread]
         public void DeactivateEvents_TwoFieldAltHover_DoesNotThrowAfterWiringHandlers()
         {
             var group = new ThemeControlGroup(
@@ -393,7 +381,6 @@ namespace UtilitiesCS.Test.HelperClasses.ThemeHelpers
         }
 
         [TestMethod]
-        [STAThread]
         public void DeactivateEvents_NonHoverGroup_DefaultBranchDoesNothing()
         {
             var group = new ThemeControlGroup(new List<Control> { new Label() }, Color.Red);

--- a/UtilitiesCS.Test/HelperClasses/WindowsForms/ScreenAndTableLayoutTests.cs
+++ b/UtilitiesCS.Test/HelperClasses/WindowsForms/ScreenAndTableLayoutTests.cs
@@ -38,11 +38,10 @@ namespace UtilitiesCS.Test.HelperClasses.WindowsForms
         }
     }
 
-    [TestClass]
+    [STATestClass]
     public class TableLayoutHelper_Tests
     {
         [TestMethod]
-        [STAThread]
         public void InsertSpecificRow_NegativeIndex_ThrowsArgumentOutOfRange()
         {
             var tlp = new System.Windows.Forms.TableLayoutPanel();
@@ -57,7 +56,6 @@ namespace UtilitiesCS.Test.HelperClasses.WindowsForms
         }
 
         [TestMethod]
-        [STAThread]
         public void InsertSpecificRow_ZeroInsertCount_ThrowsArgumentOutOfRange()
         {
             var tlp = new System.Windows.Forms.TableLayoutPanel();
@@ -72,7 +70,6 @@ namespace UtilitiesCS.Test.HelperClasses.WindowsForms
         }
 
         [TestMethod]
-        [STAThread]
         public void InsertSpecificRow_ValidIndex_IncreasesRowCount()
         {
             var tlp = new System.Windows.Forms.TableLayoutPanel();

--- a/UtilitiesCS.Test/HelperClasses/WindowsForms/WinFormsInteractionTests.cs
+++ b/UtilitiesCS.Test/HelperClasses/WindowsForms/WinFormsInteractionTests.cs
@@ -7,11 +7,10 @@ using UtilitiesCS.Windows_Forms;
 
 namespace UtilitiesCS.Test.HelperClasses.WindowsForms
 {
-    [TestClass]
+    [STATestClass]
     public class MouseDownFilter_Tests
     {
         [TestMethod]
-        [STAThread]
         public void Constructor_WithForm_CreatesInstance()
         {
             var form = new Form();
@@ -20,7 +19,6 @@ namespace UtilitiesCS.Test.HelperClasses.WindowsForms
         }
 
         [TestMethod]
-        [STAThread]
         public void FormClicked_EventCanBeSubscribed()
         {
             var form = new Form();

--- a/UtilitiesCS.Test/HelperClasses/WindowsForms/WinFormsLayoutTests.cs
+++ b/UtilitiesCS.Test/HelperClasses/WindowsForms/WinFormsLayoutTests.cs
@@ -143,8 +143,7 @@ namespace UtilitiesCS.Test.HelperClasses.WindowsForms
 
         #region Set (static)
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void Set_WithControlPosition_SetsControlProperties()
         {
             var control = new Label();
@@ -162,8 +161,7 @@ namespace UtilitiesCS.Test.HelperClasses.WindowsForms
 
         #region CreateTemplate
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void CreateTemplate_FromControl_CapturesProperties()
         {
             var control = new Label();
@@ -202,8 +200,7 @@ namespace UtilitiesCS.Test.HelperClasses.WindowsForms
 
         #region FindAllControls
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void FindAllControls_WithNestedControls_PopulatesDict()
         {
             var resizer = new ControlResizer();
@@ -231,8 +228,7 @@ namespace UtilitiesCS.Test.HelperClasses.WindowsForms
 
         #region ResizeAllControls
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void ResizeAllControls_AfterFind_DoesNotThrow()
         {
             var resizer = new ControlResizer();
@@ -254,8 +250,7 @@ namespace UtilitiesCS.Test.HelperClasses.WindowsForms
 
         #region SetResizeDimensions
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void SetResizeDimensions_KnownControl_ReturnsTrue()
         {
             var resizer = new ControlResizer();
@@ -278,8 +273,7 @@ namespace UtilitiesCS.Test.HelperClasses.WindowsForms
             result.Should().BeTrue();
         }
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void SetResizeDimensions_UnknownControl_ReturnsFalse()
         {
             var resizer = new ControlResizer();

--- a/UtilitiesCS.Test/Properties/AssemblyInfo.cs
+++ b/UtilitiesCS.Test/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 [assembly: AssemblyTitle("UtilitiesCS.Test")]
 [assembly: AssemblyDescription("")]
@@ -14,6 +15,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 [assembly: Guid("5db8647f-4479-451f-b19a-10a4a0d62675")]
+[assembly: Parallelize(Workers = 0, Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.ClassLevel)]
 
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/UtilitiesCS.Test/Properties/AssemblyInfo.cs
+++ b/UtilitiesCS.Test/Properties/AssemblyInfo.cs
@@ -15,7 +15,10 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 [assembly: ComVisible(false)]
 
 [assembly: Guid("5db8647f-4479-451f-b19a-10a4a0d62675")]
-[assembly: Parallelize(Workers = 0, Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.ClassLevel)]
+[assembly: Parallelize(
+    Workers = 0,
+    Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.ClassLevel
+)]
 
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/UtilitiesCS.Test/ReusableTypeClasses/ConfigViewer_Tests.cs
+++ b/UtilitiesCS.Test/ReusableTypeClasses/ConfigViewer_Tests.cs
@@ -17,9 +17,9 @@ namespace UtilitiesCS.Test.ReusableTypeClasses
     ///     null-safety contract, and the disk-group activation toggle on
     ///     <see cref="ConfigViewer"/>.
     ///
-        /// Constraints:
-        ///     ConfigViewer is a WinForms Form; this class uses MSTest's STA class
-        ///     execution mode to satisfy WinForms initialization requirements.
+    /// Constraints:
+    ///     ConfigViewer is a WinForms Form; this class uses MSTest's STA class
+    ///     execution mode to satisfy WinForms initialization requirements.
     /// </summary>
     [STATestClass]
     public class ConfigViewer_Tests

--- a/UtilitiesCS.Test/ReusableTypeClasses/ConfigViewer_Tests.cs
+++ b/UtilitiesCS.Test/ReusableTypeClasses/ConfigViewer_Tests.cs
@@ -17,12 +17,11 @@ namespace UtilitiesCS.Test.ReusableTypeClasses
     ///     null-safety contract, and the disk-group activation toggle on
     ///     <see cref="ConfigViewer"/>.
     ///
-    /// Constraints:
-    ///     ConfigViewer is a WinForms Form; tests are decorated with [STAThread] so
-    ///     the MSTest runner invokes them on an STA thread to satisfy WinForms
-    ///     initialization requirements.
+        /// Constraints:
+        ///     ConfigViewer is a WinForms Form; this class uses MSTest's STA class
+        ///     execution mode to satisfy WinForms initialization requirements.
     /// </summary>
-    [TestClass]
+    [STATestClass]
     public class ConfigViewer_Tests
     {
         private static ConfigViewer CreateHeadlessViewer() =>
@@ -45,7 +44,6 @@ namespace UtilitiesCS.Test.ReusableTypeClasses
         ///     and <c>SetController</c> returns the same viewer reference.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void SetController_SetsControllerPropertyAndReturnsViewer()
         {
             ConfigViewer viewer = null;
@@ -93,7 +91,6 @@ namespace UtilitiesCS.Test.ReusableTypeClasses
         ///     constructed viewer; the viewer is disposed in the finally block.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ButtonCancelClick_WithNullController_IsNoOpWithoutThrowing()
         {
             ConfigViewer viewer = null;
@@ -152,7 +149,6 @@ namespace UtilitiesCS.Test.ReusableTypeClasses
         ///     active after the call.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void ActivateUiBox_NetDiskType_ActivatesNetBoxAndDeactivatesLocalBox()
         {
             ConfigViewer viewer = null;
@@ -204,7 +200,6 @@ namespace UtilitiesCS.Test.ReusableTypeClasses
         ///     viewer's control tree.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void GroupBoxEnterHandler_WithInactiveBox_SetsHighlightColors()
         {
             ConfigViewer viewer = null;
@@ -259,7 +254,6 @@ namespace UtilitiesCS.Test.ReusableTypeClasses
         ///     controller.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void GroupBoxClickHandler_WithNullControllerAndInactiveBox_IsNoOp()
         {
             ConfigViewer viewer = null;
@@ -318,7 +312,6 @@ namespace UtilitiesCS.Test.ReusableTypeClasses
         ///     transient <see cref="ConfigGroupBox"/>.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void GroupBoxLeaveHandler_WithInactiveBox_RestoresControlColors()
         {
             ConfigViewer viewer = null;
@@ -375,7 +368,6 @@ namespace UtilitiesCS.Test.ReusableTypeClasses
         ///     viewer with a null controller.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void SpecialFolderSelectedValueChangedHandler_WithNullController_IsNoOp()
         {
             ConfigViewer viewer = null;

--- a/UtilitiesCS.Test/ReusableTypeClasses/TimedBatchAction_Tests.cs
+++ b/UtilitiesCS.Test/ReusableTypeClasses/TimedBatchAction_Tests.cs
@@ -36,7 +36,11 @@ namespace UtilitiesCS.Test.ReusableTypeClasses
             // Arrange
             var timerFactory = new FakeTimerFactory();
             var wasCalled = false;
-            var action = new TimedBatchAction(TimeSpan.FromMilliseconds(20), null, timerFactory.Create);
+            var action = new TimedBatchAction(
+                TimeSpan.FromMilliseconds(20),
+                null,
+                timerFactory.Create
+            );
 
             // Act
             action.RequestAction(() => wasCalled = true);
@@ -160,9 +164,7 @@ namespace UtilitiesCS.Test.ReusableTypeClasses
 
             public double IntervalInMilliseconds { get; set; }
 
-            public void Dispose()
-            {
-            }
+            public void Dispose() { }
 
             public void Fire()
             {

--- a/UtilitiesCS.Test/ReusableTypeClasses/TimedBatchAction_Tests.cs
+++ b/UtilitiesCS.Test/ReusableTypeClasses/TimedBatchAction_Tests.cs
@@ -1,8 +1,9 @@
 using System;
-using System.Threading;
+using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using UtilitiesCS.HelperClasses;
+using UtilitiesCS.Interfaces;
 
 namespace UtilitiesCS.Test.ReusableTypeClasses
 {
@@ -13,43 +14,57 @@ namespace UtilitiesCS.Test.ReusableTypeClasses
         public void RequestAction_WithConfiguredAction_InvokesActionAfterInterval()
         {
             // Arrange
-            using var signal = new ManualResetEventSlim(false);
-            var action = new TimedBatchAction(TimeSpan.FromMilliseconds(20), signal.Set);
+            var timerFactory = new FakeTimerFactory();
+            var wasCalled = false;
+            var action = new TimedBatchAction(
+                TimeSpan.FromMilliseconds(20),
+                () => wasCalled = true,
+                timerFactory.Create
+            );
 
             // Act
             action.RequestAction();
+            timerFactory.SingleCreatedTimer.Fire();
 
             // Assert
-            signal.Wait(500).Should().BeTrue();
+            wasCalled.Should().BeTrue();
         }
 
         [TestMethod]
         public void RequestAction_WithProvidedAction_InvokesActionAfterInterval()
         {
             // Arrange
-            using var signal = new ManualResetEventSlim(false);
-            var action = new TimedBatchAction(TimeSpan.FromMilliseconds(20));
+            var timerFactory = new FakeTimerFactory();
+            var wasCalled = false;
+            var action = new TimedBatchAction(TimeSpan.FromMilliseconds(20), null, timerFactory.Create);
 
             // Act
-            action.RequestAction(signal.Set);
+            action.RequestAction(() => wasCalled = true);
+            timerFactory.SingleCreatedTimer.Fire();
 
             // Assert
-            signal.Wait(500).Should().BeTrue();
+            wasCalled.Should().BeTrue();
         }
 
         [TestMethod]
         public void CancelAction_PreventsPendingExecution()
         {
             // Arrange
-            using var signal = new ManualResetEventSlim(false);
-            var action = new TimedBatchAction(TimeSpan.FromMilliseconds(150), signal.Set);
+            var timerFactory = new FakeTimerFactory();
+            var wasCalled = false;
+            var action = new TimedBatchAction(
+                TimeSpan.FromMilliseconds(150),
+                () => wasCalled = true,
+                timerFactory.Create
+            );
 
             // Act
             action.RequestAction();
             action.CancelAction();
+            timerFactory.SingleCreatedTimer.Fire();
 
             // Assert
-            signal.Wait(250).Should().BeFalse();
+            wasCalled.Should().BeFalse();
         }
 
         [TestMethod]
@@ -69,24 +84,22 @@ namespace UtilitiesCS.Test.ReusableTypeClasses
         public void RequestAction_TwiceBeforeExecution_OnlyInvokesCallbackOnce()
         {
             // Arrange
+            var timerFactory = new FakeTimerFactory();
             var count = 0;
-            using var signal = new ManualResetEventSlim(false);
             var action = new TimedBatchAction(
                 TimeSpan.FromMilliseconds(20),
                 () =>
                 {
-                    Interlocked.Increment(ref count);
-                    signal.Set();
-                }
+                    count++;
+                },
+                timerFactory.Create
             );
 
             // Act
             action.RequestAction();
             action.RequestAction();
-            // Allow 2 000 ms for the 20 ms timer to fire under full-suite thread-pool load.
-            signal.Wait(2000).Should().BeTrue();
-            // Wait long enough to detect any spurious second fire from the single-shot timer.
-            Thread.Sleep(200);
+            timerFactory.CreatedTimers.Should().HaveCount(1);
+            timerFactory.SingleCreatedTimer.Fire();
 
             // Assert
             count.Should().Be(1);
@@ -96,33 +109,90 @@ namespace UtilitiesCS.Test.ReusableTypeClasses
         public void AfterActionExecutes_RequestActionCanScheduleAnotherRun()
         {
             // Arrange
+            var timerFactory = new FakeTimerFactory();
             var count = 0;
-            using var first = new ManualResetEventSlim(false);
-            using var second = new ManualResetEventSlim(false);
             var action = new TimedBatchAction(
                 TimeSpan.FromMilliseconds(20),
-                () =>
-                {
-                    var current = Interlocked.Increment(ref count);
-                    if (current == 1)
-                    {
-                        first.Set();
-                    }
-                    else
-                    {
-                        second.Set();
-                    }
-                }
+                () => count++,
+                timerFactory.Create
             );
 
             // Act
             action.RequestAction();
-            first.Wait(500).Should().BeTrue();
+            timerFactory.CreatedTimers[0].Fire();
             action.RequestAction();
+            timerFactory.CreatedTimers.Should().HaveCount(2);
+            timerFactory.CreatedTimers[1].Fire();
 
             // Assert
-            second.Wait(500).Should().BeTrue();
             count.Should().Be(2);
+        }
+
+        private sealed class FakeTimerFactory
+        {
+            public List<FakeTimer> CreatedTimers { get; } = new List<FakeTimer>();
+
+            public FakeTimer SingleCreatedTimer => CreatedTimers.Should().ContainSingle().Subject;
+
+            public ITimerWrapper Create(TimeSpan interval)
+            {
+                var timer = new FakeTimer(interval);
+                CreatedTimers.Add(timer);
+                return timer;
+            }
+        }
+
+        private sealed class FakeTimer : ITimerWrapper
+        {
+            public FakeTimer(TimeSpan interval)
+            {
+                Interval = interval;
+                IntervalInMilliseconds = interval.TotalMilliseconds;
+            }
+
+            public event EventHandler<TimeElapsedEventArgs> Elapsed;
+
+            public bool AutoReset { get; set; }
+
+            public bool Enabled { get; set; }
+
+            public TimeSpan Interval { get; set; }
+
+            public double IntervalInMilliseconds { get; set; }
+
+            public void Dispose()
+            {
+            }
+
+            public void Fire()
+            {
+                if (!Enabled)
+                {
+                    return;
+                }
+
+                if (!AutoReset)
+                {
+                    Enabled = false;
+                }
+
+                Elapsed?.Invoke(this, new TimeElapsedEventArgs(DateTime.UtcNow));
+            }
+
+            public void ResetTimer()
+            {
+                Enabled = true;
+            }
+
+            public void StartTimer()
+            {
+                Enabled = true;
+            }
+
+            public void StopTimer()
+            {
+                Enabled = false;
+            }
         }
     }
 }

--- a/UtilitiesCS.Test/Threading/ApplicationIdleTimer_Tests.cs
+++ b/UtilitiesCS.Test/Threading/ApplicationIdleTimer_Tests.cs
@@ -7,11 +7,29 @@ using UtilitiesCS.Threading;
 
 namespace UtilitiesCS.Test.Threading
 {
+    // ApplicationIdleTimer exposes a static event whose backing field is shared
+    // with IdleAsyncQueue / IdleActionQueue, both of which Subscribe to the same
+    // event from their production paths. Running this class in parallel with
+    // those classes lets a concurrent Subscribe leave the event non-null when
+    // Unsubscribe runs here, which prevents Stop() from decrementing
+    // subscriptionCount and produces a deterministic-looking false failure.
     [TestClass]
+    [DoNotParallelize]
     public class ApplicationIdleTimer_Tests
     {
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            ResetSingletonState();
+        }
+
         [TestCleanup]
         public void TestCleanup()
+        {
+            ResetSingletonState();
+        }
+
+        private static void ResetSingletonState()
         {
             ClearApplicationIdleHandlers();
             ApplicationIdleTimer.Stop();

--- a/UtilitiesCS.Test/Threading/ProgressPane_Tests.cs
+++ b/UtilitiesCS.Test/Threading/ProgressPane_Tests.cs
@@ -17,8 +17,8 @@ namespace UtilitiesCS.Test.Threading
     ///     cancel path is invoked, and that its exposed state (Bar value, JobName
     ///     text) can be updated and read back.
     ///
-        /// Constraints:
-        ///     This class runs under MSTest's STA class execution mode (required by WinForms).
+    /// Constraints:
+    ///     This class runs under MSTest's STA class execution mode (required by WinForms).
     ///     Construction requires a non-null SynchronizationContext.Current so that
     ///     TaskScheduler.FromCurrentSynchronizationContext() can succeed; each test
     ///     installs and then restores the SynchronizationContext around the pane.

--- a/UtilitiesCS.Test/Threading/ProgressPane_Tests.cs
+++ b/UtilitiesCS.Test/Threading/ProgressPane_Tests.cs
@@ -17,15 +17,15 @@ namespace UtilitiesCS.Test.Threading
     ///     cancel path is invoked, and that its exposed state (Bar value, JobName
     ///     text) can be updated and read back.
     ///
-    /// Constraints:
-    ///     All tests run on an STA thread (required by WinForms).
+        /// Constraints:
+        ///     This class runs under MSTest's STA class execution mode (required by WinForms).
     ///     Construction requires a non-null SynchronizationContext.Current so that
     ///     TaskScheduler.FromCurrentSynchronizationContext() can succeed; each test
     ///     installs and then restores the SynchronizationContext around the pane.
     ///     The CancelButton_Click handler disposes the pane — tests that invoke that
     ///     path must not use 'using' on the pane variable.
     /// </summary>
-    [TestClass]
+    [STATestClass]
     public class ProgressPane_Tests
     {
         // ---------------------------------------------------------------------------
@@ -54,7 +54,6 @@ namespace UtilitiesCS.Test.Threading
         ///     restores the prior context in the finally block.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void Constructor_CapturesCurrentSynchronizationContextAndScheduler()
         {
             // Arrange — install a known SynchronizationContext so the constructor
@@ -106,7 +105,6 @@ namespace UtilitiesCS.Test.Threading
         ///     must not be inside a using block.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void CancelButtonClick_WhenInvoked_CancelsTokenSource()
         {
             // Arrange — install a SynchronizationContext so the constructor succeeds.
@@ -166,7 +164,6 @@ namespace UtilitiesCS.Test.Threading
         ///     Pane is disposed via using block.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void BarValueAndJobNameText_WhenSet_ReflectAssignedValues()
         {
             // Arrange — install SynchronizationContext so the constructor succeeds.

--- a/UtilitiesCS.Test/Threading/ProgressTracker_Tests.cs
+++ b/UtilitiesCS.Test/Threading/ProgressTracker_Tests.cs
@@ -363,8 +363,7 @@ namespace UtilitiesCS.Test
         ///     Temporarily installs a SynchronizationContext on the calling STA thread.
         ///     ProgressViewer.Close() disposes the un-shown Form.
         /// </summary>
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void Report_At100Percent_WhenRootTracker_ClosesProgressViewer()
         {
             // Arrange — SynchronizationContext is required for ProgressViewer construction.
@@ -403,8 +402,7 @@ namespace UtilitiesCS.Test
             }
         }
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public void Initialize_WithCurrentDispatcherAndScreen_InitializesViewerAndUpdatesUi()
         {
             using var cts = new CancellationTokenSource();
@@ -468,8 +466,7 @@ namespace UtilitiesCS.Test
             parent.LastValue.Should().Be(100);
         }
 
-        [TestMethod]
-        [STAThread]
+        [STATestMethod]
         public async Task ReportAsync_At100Percent_WhenRootTracker_ClosesProgressViewer()
         {
             var priorContext = SynchronizationContext.Current;

--- a/UtilitiesCS.Test/Threading/ProgressViewer_Tests.cs
+++ b/UtilitiesCS.Test/Threading/ProgressViewer_Tests.cs
@@ -18,8 +18,8 @@ namespace UtilitiesCS.Test.Threading
     ///     correctly transitions the supplied CancellationTokenSource into the
     ///     cancelled state.
     ///
-    /// Constraints:
-    ///     All tests run on an STA thread (required by WinForms).
+        /// Constraints:
+        ///     This class runs under MSTest's STA class execution mode (required by WinForms).
     ///     Construction requires a non-null SynchronizationContext.Current so that
     ///     TaskScheduler.FromCurrentSynchronizationContext() succeeds; each test
     ///     installs and then restores the SynchronizationContext around the viewer.
@@ -27,7 +27,7 @@ namespace UtilitiesCS.Test.Threading
     ///     tests that invoke the cancel path must not use 'using' on the viewer,
     ///     and must capture the CancellationToken before invoking the handler.
     /// </summary>
-    [TestClass]
+    [STATestClass]
     public class ProgressViewer_Tests
     {
         private static ProgressViewer CreateHeadlessViewer() =>
@@ -58,7 +58,6 @@ namespace UtilitiesCS.Test.Threading
         ///     because it was created outside the viewer.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void CancelPath_WhenInvoked_CancelsTokenSource()
         {
             // Arrange — install a SynchronizationContext so the constructor does not throw.
@@ -124,7 +123,6 @@ namespace UtilitiesCS.Test.Threading
         ///     restores the prior context in the finally block.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void Constructor_PopulatesSyncContextAndScheduler()
         {
             // Arrange — install a known SynchronizationContext so that
@@ -167,7 +165,6 @@ namespace UtilitiesCS.Test.Threading
         ///     once; creates and disposes the viewer in the finally block.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void UiDispatcher_SetterAndGetter_RoundTripAssignedValue()
         {
             // Arrange
@@ -206,7 +203,6 @@ namespace UtilitiesCS.Test.Threading
         ///     Creates and disposes a ProgressViewer in the finally block.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void UiThreadNumber_SetterAndGetter_RoundTripAssignedValue()
         {
             // Arrange
@@ -244,7 +240,6 @@ namespace UtilitiesCS.Test.Threading
         ///     finally block.
         /// </summary>
         [TestMethod]
-        [STAThread]
         public void CancelSource_SetterAndGetter_RoundTripAssignedValue()
         {
             // Arrange

--- a/UtilitiesCS.Test/Threading/ProgressViewer_Tests.cs
+++ b/UtilitiesCS.Test/Threading/ProgressViewer_Tests.cs
@@ -112,15 +112,17 @@ namespace UtilitiesCS.Test.Threading
         ///     via UiSyncContext.  Both must be non-null after construction.
         ///
         /// Args:
-        ///     None — relies on a SynchronizationContext installed on the calling
-        ///     thread before construction.
+        ///     None — WinForms automatically installs a WindowsFormsSynchronizationContext
+        ///     during Form construction.
         ///
         /// Returns:
         ///     N/A (test assertion).
         ///
         /// Side Effects:
         ///     Temporarily installs a SynchronizationContext on the calling thread;
-        ///     restores the prior context in the finally block.
+        ///     restores the prior context in the finally block. WinForms replaces
+        ///     the installed context with a WindowsFormsSynchronizationContext during
+        ///     InitializeComponent.
         /// </summary>
         [TestMethod]
         public void Constructor_PopulatesSyncContextAndScheduler()
@@ -134,11 +136,14 @@ namespace UtilitiesCS.Test.Threading
             try
             {
                 // Act — create the viewer with the installed context in scope.
+                // WinForms will install a WindowsFormsSynchronizationContext during construction.
                 using ProgressViewer viewer = new ProgressViewer();
 
-                // Assert — UiSyncContext references the installed context, and
-                // UiScheduler is non-null (created via FromCurrentSynchronizationContext).
-                viewer.UiSyncContext.Should().BeSameAs(context);
+                // Assert — UiSyncContext is non-null and is the WinForms context installed
+                // during construction. UiScheduler is non-null (created via
+                // FromCurrentSynchronizationContext).
+                viewer.UiSyncContext.Should().NotBeNull();
+                viewer.UiSyncContext.Should().BeOfType<System.Windows.Forms.WindowsFormsSynchronizationContext>();
                 viewer.UiScheduler.Should().NotBeNull();
             }
             finally

--- a/UtilitiesCS.Test/Threading/ProgressViewer_Tests.cs
+++ b/UtilitiesCS.Test/Threading/ProgressViewer_Tests.cs
@@ -18,8 +18,8 @@ namespace UtilitiesCS.Test.Threading
     ///     correctly transitions the supplied CancellationTokenSource into the
     ///     cancelled state.
     ///
-        /// Constraints:
-        ///     This class runs under MSTest's STA class execution mode (required by WinForms).
+    /// Constraints:
+    ///     This class runs under MSTest's STA class execution mode (required by WinForms).
     ///     Construction requires a non-null SynchronizationContext.Current so that
     ///     TaskScheduler.FromCurrentSynchronizationContext() succeeds; each test
     ///     installs and then restores the SynchronizationContext around the viewer.
@@ -143,7 +143,9 @@ namespace UtilitiesCS.Test.Threading
                 // during construction. UiScheduler is non-null (created via
                 // FromCurrentSynchronizationContext).
                 viewer.UiSyncContext.Should().NotBeNull();
-                viewer.UiSyncContext.Should().BeOfType<System.Windows.Forms.WindowsFormsSynchronizationContext>();
+                viewer
+                    .UiSyncContext.Should()
+                    .BeOfType<System.Windows.Forms.WindowsFormsSynchronizationContext>();
                 viewer.UiScheduler.Should().NotBeNull();
             }
             finally

--- a/UtilitiesCS.Test/test.runsettings
+++ b/UtilitiesCS.Test/test.runsettings
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Forces all MSTest test methods to execute on an STA thread.
-     Required for any test that creates WinForms controls (Forms, UserControls,
-     ObjectListView / TreeListView) which mandate STA apartment state.
-     The [STAThread] attribute on individual methods is silently ignored by
-     vstest/MSTest because tests run on thread-pool (MTA) threads; this
-     RunSettings entry is the supported mechanism for the full test assembly. -->
-<RunSettings>
-  <RunConfiguration>
-    <ExecutionThread>STA</ExecutionThread>
-  </RunConfiguration>
-</RunSettings>
+<!-- Global STA execution is intentionally disabled.
+     Tests that require an STA apartment must opt in with MSTest's
+     STATestMethod or STATestClass attributes so the rest of the suite can run
+     under the default threading model and participate in parallel execution. -->
+<RunSettings />

--- a/UtilitiesCS/EmailIntelligence/Bayesian/Obsolete/BayesianClassifier.cs
+++ b/UtilitiesCS/EmailIntelligence/Bayesian/Obsolete/BayesianClassifier.cs
@@ -435,7 +435,10 @@ namespace UtilitiesCS.EmailIntelligence.Bayesian
         {
             token.ThrowIfCancellationRequested();
 
-            Match ??= await Corpus.SubtractAsync(Parent.SharedTokenBase, NotMatch, token, sw);
+            if (_prob is null || Match is null)
+            {
+                Match = await Corpus.SubtractAsync(Parent.SharedTokenBase, NotMatch, token, sw);
+            }
             sw?.LogDuration("Infer Negative Tokens");
 
             token.ThrowIfCancellationRequested();

--- a/UtilitiesCS/EmailIntelligence/Bayesian/Obsolete/ClassifierGroup.cs
+++ b/UtilitiesCS/EmailIntelligence/Bayesian/Obsolete/ClassifierGroup.cs
@@ -306,7 +306,10 @@ namespace UtilitiesCS.EmailIntelligence.Bayesian
             int completed = 0;
 
             var processors = Math.Max(Environment.ProcessorCount - 2, 1);
-            var chunkSize = (int)Math.Round((double)count / (double)processors, 0);
+            // Ensure chunkSize is at least 1.  Math.Round can produce 0 when the classifier
+            // count is smaller than half the processor count, which causes Chunk(0) to
+            // throw ArgumentOutOfRangeException.
+            var chunkSize = Math.Max(1, (int)Math.Round((double)count / (double)processors, 0));
             var chunks = Classifiers.Values.Chunk(chunkSize);
 
             var sw = new SegmentStopWatch();

--- a/UtilitiesCS/EmailIntelligence/Bayesian/Obsolete/ClassifierGroup.cs
+++ b/UtilitiesCS/EmailIntelligence/Bayesian/Obsolete/ClassifierGroup.cs
@@ -270,31 +270,25 @@ namespace UtilitiesCS.EmailIntelligence.Bayesian
 
         internal async Task RecalcNullProbs(CancellationToken token)
         {
-            if (Classifiers.Values.Any(x => x.Prob is null))
+            var classifiersToRecalc = Classifiers.Values.Where(x => x.Prob is null).ToArray();
+
+            if (classifiersToRecalc.Any())
             {
                 AppGlobals.AF.ProgressTracker.Report(0, "Starting to Recalculate Probabilities");
-                var count = Classifiers.Count;
+                var count = classifiersToRecalc.Length;
                 int completed = 0;
                 var sw = new SegmentStopWatch().Start();
 
-                await Classifiers
-                    .Values.ToAsyncEnumerable()
-                    .ForEachAsync(
-                        async (classifier) =>
-                        {
-                            await classifier.RecalcProbsAsync(token);
-                            Interlocked.Increment(ref completed);
-                            AppGlobals.AF.ProgressTracker.Report(
-                                (int)((double)completed / (double)count * 100),
-                                GetReportMessage(
-                                    completed,
-                                    count,
-                                    sw,
-                                    "Recalc Probabilities: Completed"
-                                )
-                            );
-                        }
+                foreach (var classifier in classifiersToRecalc)
+                {
+                    token.ThrowIfCancellationRequested();
+                    await classifier.RecalcProbsAsync(token);
+                    var current = Interlocked.Increment(ref completed);
+                    AppGlobals.AF.ProgressTracker.Report(
+                        (int)((double)current / (double)count * 100),
+                        GetReportMessage(current, count, sw, "Recalc Probabilities: Completed")
                     );
+                }
             }
         }
 
@@ -315,25 +309,26 @@ namespace UtilitiesCS.EmailIntelligence.Bayesian
             var sw = new SegmentStopWatch();
             // Start the chunked tasks to multiprocess async
             var tasks = chunks.Select(chunk =>
-                Task.Run(async () =>
-                    await chunk
-                        .ToAsyncEnumerable()
-                        .ForEachAsync(
-                            async (classifier) =>
-                            {
-                                await classifier.InferNegativeTokensAsync(token);
-                                Interlocked.Increment(ref completed);
-                                AppGlobals.AF.ProgressTracker.Report(
-                                    (int)((double)completed / (double)count * 100),
-                                    GetReportMessage(
-                                        completed,
-                                        count,
-                                        sw,
-                                        "Infer Negative Tokens: Completed"
-                                    )
-                                );
-                            }
-                        )
+                Task.Run(
+                    async () =>
+                    {
+                        foreach (var classifier in chunk)
+                        {
+                            token.ThrowIfCancellationRequested();
+                            await classifier.InferNegativeTokensAsync(token);
+                            var current = Interlocked.Increment(ref completed);
+                            AppGlobals.AF.ProgressTracker.Report(
+                                (int)((double)current / (double)count * 100),
+                                GetReportMessage(
+                                    current,
+                                    count,
+                                    sw,
+                                    "Infer Negative Tokens: Completed"
+                                )
+                            );
+                        }
+                    },
+                    token
                 )
             );
 

--- a/UtilitiesCS/ReusableTypeClasses/TimedActions/TimedBatchAction.cs
+++ b/UtilitiesCS/ReusableTypeClasses/TimedActions/TimedBatchAction.cs
@@ -14,16 +14,16 @@ namespace UtilitiesCS.HelperClasses
     public class TimedBatchAction
     {
         public TimedBatchAction(TimeSpan frequency)
-            : this(frequency, null, CreateTimer)
-        {
-        }
+            : this(frequency, null, CreateTimer) { }
 
         public TimedBatchAction(TimeSpan frequency, System.Action action)
-            : this(frequency, action, CreateTimer)
-        {
-        }
+            : this(frequency, action, CreateTimer) { }
 
-        internal TimedBatchAction(TimeSpan frequency, System.Action action, Func<TimeSpan, ITimerWrapper> timerFactory)
+        internal TimedBatchAction(
+            TimeSpan frequency,
+            System.Action action,
+            Func<TimeSpan, ITimerWrapper> timerFactory
+        )
         {
             _frequency = frequency;
             _action = action;

--- a/UtilitiesCS/ReusableTypeClasses/TimedActions/TimedBatchAction.cs
+++ b/UtilitiesCS/ReusableTypeClasses/TimedActions/TimedBatchAction.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Office.Interop.Outlook;
+using UtilitiesCS.Interfaces;
 using UtilitiesCS.Threading;
 
 namespace UtilitiesCS.HelperClasses
@@ -13,14 +14,20 @@ namespace UtilitiesCS.HelperClasses
     public class TimedBatchAction
     {
         public TimedBatchAction(TimeSpan frequency)
+            : this(frequency, null, CreateTimer)
         {
-            _frequency = frequency;
         }
 
         public TimedBatchAction(TimeSpan frequency, System.Action action)
+            : this(frequency, action, CreateTimer)
+        {
+        }
+
+        internal TimedBatchAction(TimeSpan frequency, System.Action action, Func<TimeSpan, ITimerWrapper> timerFactory)
         {
             _frequency = frequency;
             _action = action;
+            _timerFactory = timerFactory ?? throw new ArgumentNullException(nameof(timerFactory));
         }
 
         public void SetAction(System.Action action)
@@ -31,8 +38,9 @@ namespace UtilitiesCS.HelperClasses
         private System.Action _action;
 
         private TimeSpan _frequency;
+        private readonly Func<TimeSpan, ITimerWrapper> _timerFactory;
         private ThreadSafeSingleShotGuard _actionRequested = new();
-        private TimerWrapper _timer;
+        private ITimerWrapper _timer;
 
         public void ResetTimer()
         {
@@ -53,11 +61,8 @@ namespace UtilitiesCS.HelperClasses
                 {
                     throw new NullReferenceException("Action is null");
                 }
-                var action2 = ResetAfterAction(_action);
-                _timer = new TimerWrapper(_frequency);
-                _timer.Elapsed += (sender, e) => action2();
-                _timer.AutoReset = false;
-                _timer.StartTimer();
+
+                ScheduleAction(_action);
             }
         }
 
@@ -69,12 +74,18 @@ namespace UtilitiesCS.HelperClasses
                 {
                     throw new NullReferenceException("Action is null");
                 }
-                var action2 = ResetAfterAction(action);
-                _timer = new TimerWrapper(_frequency);
-                _timer.Elapsed += (sender, e) => action2();
-                _timer.AutoReset = false;
-                _timer.StartTimer();
+
+                ScheduleAction(action);
             }
+        }
+
+        private void ScheduleAction(System.Action action)
+        {
+            var actionToRun = ResetAfterAction(action);
+            _timer = _timerFactory(_frequency);
+            _timer.AutoReset = false;
+            _timer.Elapsed += (sender, e) => actionToRun();
+            _timer.StartTimer();
         }
 
         private System.Action ResetAfterAction(System.Action action)
@@ -85,5 +96,7 @@ namespace UtilitiesCS.HelperClasses
                 _actionRequested = new();
             };
         }
+
+        private static ITimerWrapper CreateTimer(TimeSpan frequency) => new TimerWrapper(frequency);
     }
 }


### PR DESCRIPTION
Stabilize conversation resolver startup and deterministic UtilitiesCS test execution

## Summary

- Defer `ConversationResolver` background initialization so `QuickFiler` data-model loading no longer requires Outlook application access up front, with regression coverage added in `QuickFiler.Test/Controllers/EfcDataModelTests.cs`.
- Tighten legacy Bayesian classifier recovery so null-probability classifiers rebuild match corpora correctly, clamp infer-negative work chunking, and report progress/cancellation more predictably.
- Make `TimedBatchAction` timer creation injectable so its behavior can be tested deterministically instead of relying on thread timing.
- Rework WinForms and dialog test coverage in `UtilitiesCS.Test` to scope STA behavior more narrowly, improve parallel-safety, and update test run settings.
- Align `ProgressViewer` and classifier-group tests with the current synchronization-context and progress-tracker behavior used at runtime.

## Why

- The PR intent and feature-doc sections are empty in the current `pr_context` artifacts, so the rationale here is inferred conservatively from the commit subjects and the changed-file clusters.
- The branch history indicates three related failure themes: eager conversation-resolver initialization, unstable STA/parallel test execution, and nondeterministic legacy classifier/timer behavior inside `UtilitiesCS`.
- The changed files suggest the goal is to remove startup-time dependencies that are not always available during loading, while making threading- and timer-sensitive tests reliable enough to run under the suite’s current execution model.

## What Changed

- Core behavior / architecture
  - Updated `QuickFiler/Helper Classes/ConversationResolver.cs`, `QuickFiler/Helper Classes/ConversationResolver.Loading.cs`, and `QuickFiler/Controllers/EfcDataModel.cs` to defer resolver background initialization during loading.
  - Updated `UtilitiesCS/EmailIntelligence/Bayesian/Obsolete/BayesianClassifier.cs` so legacy null-probability classifiers rebuild match state from the shared token base when needed.
  - Updated `UtilitiesCS/EmailIntelligence/Bayesian/Obsolete/ClassifierGroup.cs` to recalculate only affected classifiers and to process infer-negative work with explicit cancellation/progress handling.
  - Updated `UtilitiesCS/ReusableTypeClasses/TimedActions/TimedBatchAction.cs` to create timers through an injectable factory while preserving the public construction flow.

- Tooling / automation / CI / DevEx
  - Adjusted `UtilitiesCS.Test/test.runsettings` and `UtilitiesCS.Test/Properties/AssemblyInfo.cs` as part of the test-execution model changes reflected by the branch commits.

- Tests
  - Added/updated regression coverage in `QuickFiler.Test/Controllers/EfcDataModelTests.cs`.
  - Updated a broad set of `UtilitiesCS.Test` dialog, WinForms, threading, classifier, and reusable-type test files to remove timing assumptions, narrow STA scope, and improve parallel-safety.
  - Expanded timer and classifier regression coverage in `UtilitiesCS.Test/ReusableTypeClasses/TimedBatchAction_Tests.cs`, `UtilitiesCS.Test/EmailIntelligence/Bayesian/ObsoleteBayesianClassifier_Tests.cs`, and `UtilitiesCS.Test/EmailIntelligence/ClassifierGroup_Tests.cs`.

- Docs / templates / agents
  - No documentation, template, or agent files are listed as changed in the `pr_context` artifacts.

## Architecture / How It Fits Together

- `ConversationResolver` is the QuickFiler-side orchestration layer for conversation loading; `EfcDataModel` consumes that loading path. The branch changes move background initialization later in that flow so staged loading does not immediately depend on Outlook application state.
- The obsolete Bayesian classifier path is coordinated by `ClassifierGroup`, which drives negative-token inference and probability recalculation across child classifiers. `BayesianClassifier` now reconstructs missing match state when legacy probability data is absent, and `ClassifierGroup` limits recalculation to the affected subset.
- `TimedBatchAction` remains the batching entry point for delayed callback execution, but timer creation is now abstracted behind an injectable factory. That lets the test suite drive timer firing directly instead of waiting on runtime scheduling.
- The `UtilitiesCS.Test` updates reshape the test harness around those runtime changes by scoping STA-only cases, reducing cross-test synchronization coupling, and validating the synchronization-context behavior actually established during WinForms construction.

## Verification

### Completed

- Not verified in this PR (no tool outputs recorded in `pr_context.summary.txt`).
- HEAD CI status is `in_progress`.

### Recommended

- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-Restore.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform "Any CPU"`
- `dotnet tool run csharpier format .`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform "Any CPU" -EnableNETAnalyzers -EnforceCodeStyleInBuild`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform "Any CPU" -EnableNullable -TreatWarningsAsErrors`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-MSTest.ps1 -SearchRoot . -Configuration Debug`

## Backward Compatibility / Migration Notes

- No breaking API or migration requirement is called out in the `pr_context` artifacts.
- `TimedBatchAction` keeps its public construction pattern; the timer-factory seam is internal and appears to exist to support deterministic tests.
- The branch does change test execution behavior by narrowing STA handling and enabling more parallel-safe execution, so local and CI runs should use the repository’s standard test configuration.

## Risks and Mitigations

- Delaying conversation-resolver background work could move failures from construction time to later load stages.
  - Mitigation: the branch adds targeted `EfcDataModel` regression coverage around the loading path.
- Parallelizing more of the WinForms-oriented test suite can expose previously hidden thread-affinity assumptions.
  - Mitigation: the branch also scopes STA-specific behavior more narrowly and adds explicit non-parallel handling where needed.
- The Bayesian classifier changes touch legacy recovery logic and work scheduling.
  - Mitigation: the branch adds regression coverage for null probabilities, classifier-group behavior, and deterministic progress/timer infrastructure.

## Review Guide

- Start with `QuickFiler/Helper Classes/ConversationResolver.cs`, `QuickFiler/Helper Classes/ConversationResolver.Loading.cs`, and `QuickFiler/Controllers/EfcDataModel.cs` to review the startup-order change.
- Review `QuickFiler.Test/Controllers/EfcDataModelTests.cs` immediately after to confirm the intended regression coverage.
- Review `UtilitiesCS/EmailIntelligence/Bayesian/Obsolete/ClassifierGroup.cs` and `UtilitiesCS/EmailIntelligence/Bayesian/Obsolete/BayesianClassifier.cs` together because they implement the legacy-classifier recalculation path as a pair.
- Review `UtilitiesCS/ReusableTypeClasses/TimedActions/TimedBatchAction.cs` with `UtilitiesCS.Test/ReusableTypeClasses/TimedBatchAction_Tests.cs` to verify the timer-factory seam and deterministic scheduling model.
- Then scan the broader `UtilitiesCS.Test` updates, especially the threading, dialog, WinForms, and runsettings changes, as a mostly related test-harness pass rather than independent feature work.

## Follow-ups

- Confirm the in-progress CI run for HEAD completes successfully.
- If more WinForms or STA-sensitive tests remain flaky under the updated execution model, isolate them with targeted fixtures/attributes rather than restoring broader suite-wide serialization.
- Populate the PR Intent fields before future PR-context refreshes so the summary, rationale, and auto-close sections can be generated from explicit author intent instead of commit/file inference.

## GitHub Auto-close

- None (no verified closing issues listed; fill “Author-asserted autoclose issues” in PR Intent to enable auto-close)

## Related issues / PRs

- None