### PR TITLE
(fix(ienumerable-extensions)): correct progress reporting in async consumption

### DIFF
--- a/UtilitiesCS/Extensions/IEnumerableExtensions.cs
+++ b/UtilitiesCS/Extensions/IEnumerableExtensions.cs
@@ -132,10 +132,10 @@ namespace UtilitiesCS
                     _ =>
                         progress.Report(
                             completed,
-                            $"Consuming {(int)((double)completed * (double)count / 100):N0} of {count:N0}"
+                            $"Consuming {completed:N0} of {count:N0}"
                         ),
                     null,
-                    0,
+                    500,
                     500
                 )
             )


### PR DESCRIPTION
- report the completed item count directly instead of scaling it as a percentage-derived value
- delay the first throttled progress callback to reduce eager reporting during enumeration startup