### PR TITLE
feat(startup): debug-only flag-gated startup timing instrumentation (#202)

### DIFF
--- a/TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs
+++ b/TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs
@@ -1,0 +1,299 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using FluentAssertions;
+using log4net;
+using log4net.Appender;
+using log4net.Repository.Hierarchy;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using UtilitiesCS;
+using OutlookApplication = Microsoft.Office.Interop.Outlook.Application;
+
+namespace TaskMaster.Test.AppGlobals
+{
+    [TestClass]
+    public class ApplicationGlobalsStartupTimingTests
+    {
+        private bool _originalStartupTimingEnabled;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            // Save and force the diagnostic timing flag off by default so flag-dependent tests
+            // start from a known state; each test sets the value it needs explicitly.
+            _originalStartupTimingEnabled = TaskMaster
+                .Properties
+                .Settings
+                .Default
+                .StartupTimingEnabled;
+            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = false;
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            TaskMaster.Properties.Settings.Default.StartupTimingEnabled =
+                _originalStartupTimingEnabled;
+        }
+
+        // DoNotParallelize: these tests mutate the shared Settings.Default.StartupTimingEnabled
+        // singleton and attach a memory appender to the process-global ApplicationGlobals logger,
+        // so they must not run concurrently with other classes that share that global state.
+        [TestMethod]
+        [DoNotParallelize]
+        public async Task LoadAsync_WhenTimingDisabled_RecordsNothingAndEmitsNoTable()
+        {
+            // Arrange: flag off (default from TestInitialize). Capture the ApplicationGlobals
+            // logger output to confirm no [Startup timing] table is emitted.
+            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = false;
+            var sut = new TestableApplicationGlobals(CreateOutlookApplicationStub());
+            SetEnginesMock(sut);
+            var appender = AttachMemoryAppender(typeof(ApplicationGlobals));
+
+            try
+            {
+                // Act
+                await sut.LoadAsync(parallel: false);
+
+                // Assert: the no-op recorder is selected, records nothing, and emits no table.
+                sut.TimingRecorder.Should().BeOfType<NullStartupTimingRecorder>();
+                sut.TimingRecorder.FormatTable().Should().BeEmpty();
+                var timingMessages = appender
+                    .GetEvents()
+                    .Select(e => e.RenderedMessage)
+                    .Where(m => m != null && m.Contains("[Startup timing]"));
+                timingMessages
+                    .Should()
+                    .BeEmpty("no startup-timing table may be emitted when the flag is off.");
+            }
+            finally
+            {
+                DetachMemoryAppender(typeof(ApplicationGlobals), appender);
+            }
+        }
+
+        [TestMethod]
+        [DoNotParallelize]
+        public async Task LoadAsync_WhenTimingEnabled_RecordsAllPhasesInStartupOrderWithLoadBasicFirst()
+        {
+            // Arrange: flag on.
+            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = true;
+            var sut = new TestableApplicationGlobals(CreateOutlookApplicationStub());
+            SetEnginesMock(sut);
+
+            // Act
+            await sut.LoadAsync(parallel: false);
+
+            // Assert: the concrete recorder is selected and the recorded phase sequence is the
+            // seven phases in startup order, with LoadBasic first.
+            sut.TimingRecorder.Should().BeOfType<StartupTimingRecorder>();
+            var recorded = ((StartupTimingRecorder)sut.TimingRecorder).RecordedPhaseNames;
+            recorded.Should().HaveCount(7);
+            recorded[0].Should().Be("LoadBasic", "LoadBasic must be the first recorded phase.");
+            recorded
+                .Should()
+                .Equal(
+                    "LoadBasic",
+                    "IntelConfig",
+                    "OlObjects",
+                    "ToDo",
+                    "AutoFile",
+                    "Engines",
+                    "Events"
+                );
+        }
+
+        [TestMethod]
+        [DoNotParallelize]
+        public async Task LoadAsync_WhenTimingEnabled_EmitsExactlyOneTableWithPhaseNamesAndTotal()
+        {
+            // Arrange: flag on, capture the ApplicationGlobals logger output.
+            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = true;
+            var sut = new TestableApplicationGlobals(CreateOutlookApplicationStub());
+            SetEnginesMock(sut);
+            var appender = AttachMemoryAppender(typeof(ApplicationGlobals));
+
+            try
+            {
+                // Act
+                await sut.LoadAsync(parallel: false);
+
+                // Assert: exactly one [Startup timing] emission containing each phase name and a
+                // TOTAL row.
+                var timingMessages = appender
+                    .GetEvents()
+                    .Select(e => e.RenderedMessage)
+                    .Where(m => m != null && m.Contains("[Startup timing]"))
+                    .ToList();
+                timingMessages.Should().HaveCount(1, "the table must be emitted exactly once.");
+
+                var table = timingMessages[0];
+                table.Should().Contain("LoadBasic");
+                table.Should().Contain("IntelConfig");
+                table.Should().Contain("OlObjects");
+                table.Should().Contain("ToDo");
+                table.Should().Contain("AutoFile");
+                table.Should().Contain("Engines");
+                table.Should().Contain("Events");
+                table.Should().Contain("TOTAL");
+            }
+            finally
+            {
+                DetachMemoryAppender(typeof(ApplicationGlobals), appender);
+            }
+        }
+
+        [TestMethod]
+        [DoNotParallelize]
+        public async Task LoadAsync_PreservesPhaseOrderingAndYieldCount_WhenTimingOnVersusOff()
+        {
+            // Arrange + Act: drive the sequential load with timing off, then on, capturing the
+            // visited-stage sequence and yield count in each mode.
+            var visitedOff = new List<string>();
+            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = false;
+            var sutOff = new TestableApplicationGlobals(CreateOutlookApplicationStub(), visitedOff);
+            SetEnginesMock(sutOff, visitedOff);
+            await sutOff.LoadAsync(parallel: false);
+            var yieldOff = sutOff.YieldCount;
+
+            var visitedOn = new List<string>();
+            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = true;
+            var sutOn = new TestableApplicationGlobals(CreateOutlookApplicationStub(), visitedOn);
+            SetEnginesMock(sutOn, visitedOn);
+            await sutOn.LoadAsync(parallel: false);
+            var yieldOn = sutOn.YieldCount;
+
+            // Assert: the visited-stage ordering and yield count are identical in both modes, so
+            // instrumentation does not change functional startup behavior.
+            visitedOff.Should().Equal("intel", "ol", "todo", "auto", "engine", "events");
+            visitedOn.Should().Equal(visitedOff);
+            yieldOn.Should().Be(yieldOff);
+            yieldOn.Should().Be(5);
+        }
+
+        private static void SetEnginesMock(
+            TestableApplicationGlobals sut,
+            List<string> visitedStages = null
+        )
+        {
+            var engineMock = new Mock<IAppItemEngines>(MockBehavior.Strict);
+            engineMock
+                .SetupGet(x => x.InboxEngines)
+                .Returns(new ConcurrentDictionary<string, IConditionalEngine<MailItemHelper>>());
+            engineMock
+                .Setup(x => x.InitAsync())
+                .Returns(() =>
+                {
+                    visitedStages?.Add("engine");
+                    return Task.CompletedTask;
+                });
+            typeof(ApplicationGlobals)
+                .GetProperty(
+                    nameof(ApplicationGlobals.Engines),
+                    BindingFlags.Instance | BindingFlags.Public
+                )!
+                .SetValue(sut, engineMock.Object);
+        }
+
+        private static MemoryAppender AttachMemoryAppender(System.Type targetType)
+        {
+            var appender = new MemoryAppender();
+            appender.ActivateOptions();
+
+            var hierarchy = (Hierarchy)LogManager.GetRepository();
+            var logger = (Logger)hierarchy.GetLogger(targetType.FullName);
+            logger.AddAppender(appender);
+            return appender;
+        }
+
+        private static void DetachMemoryAppender(System.Type targetType, MemoryAppender appender)
+        {
+            var hierarchy = (Hierarchy)LogManager.GetRepository();
+            var logger = (Logger)hierarchy.GetLogger(targetType.FullName);
+            logger.RemoveAppender(appender);
+        }
+
+        private static OutlookApplication CreateOutlookApplicationStub()
+        {
+            return new Mock<OutlookApplication>().Object;
+        }
+
+        private sealed class TestableApplicationGlobals : ApplicationGlobals
+        {
+            private readonly IList<string>? _visitedStages;
+
+            public TestableApplicationGlobals(
+                OutlookApplication application,
+                IList<string>? visitedStages = null
+            )
+                : base(application, false)
+            {
+                _visitedStages = visitedStages;
+            }
+
+            public int YieldCount { get; private set; }
+
+            // Observation seam for the startup-timing recorder (issue #202). Reads the private
+            // _timingRecorder field selected in LoadAsync so tests can assert the chosen recorder
+            // type and the recorded phase sequence without a live Outlook process.
+            public IStartupTimingRecorder TimingRecorder =>
+                (IStartupTimingRecorder)
+                    typeof(ApplicationGlobals)
+                        .GetField(
+                            "_timingRecorder",
+                            BindingFlags.Instance | BindingFlags.NonPublic
+                        )!
+                        .GetValue(this)!;
+
+            // Deterministic test seam: skip live COM collaborator construction and set a fixed
+            // non-zero LoadBasic elapsed so the recorder captures a stable LoadBasic span when
+            // LoadAsync drives ForceBasicLoad. The Engines mock is injected separately by tests.
+            protected internal override void LoadBasicMethod()
+            {
+                typeof(ApplicationGlobals)
+                    .GetField("_loadBasicElapsed", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .SetValue(this, TimeSpan.FromMilliseconds(7));
+            }
+
+            protected internal override Task LoadIntelConfigPhaseAsync()
+            {
+                _visitedStages?.Add("intel");
+                return Task.CompletedTask;
+            }
+
+            protected internal override async Task YieldBetweenStartupPhasesAsync()
+            {
+                YieldCount++;
+                await base.YieldBetweenStartupPhasesAsync();
+            }
+
+            protected internal override Task LoadOlObjectsPhaseAsync()
+            {
+                _visitedStages?.Add("ol");
+                return Task.CompletedTask;
+            }
+
+            protected internal override Task LoadToDoPhaseAsync()
+            {
+                _visitedStages?.Add("todo");
+                return Task.CompletedTask;
+            }
+
+            protected internal override Task LoadAutoFilePhaseAsync()
+            {
+                _visitedStages?.Add("auto");
+                return Task.CompletedTask;
+            }
+
+            protected internal override Task LoadEventsPhaseAsync()
+            {
+                _visitedStages?.Add("events");
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs
+++ b/TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs
@@ -6,13 +6,8 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using log4net;
-using log4net.Appender;
-using log4net.Repository.Hierarchy;
-using Microsoft.Office.Interop.Outlook;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using UtilitiesCS;
@@ -362,183 +357,6 @@ namespace TaskMaster.Test.AppGlobals
             engineMock.Verify(x => x.InitAsync(), Times.Once);
         }
 
-        // DoNotParallelize: these tests mutate the shared Settings.Default.StartupTimingEnabled
-        // singleton and attach a memory appender to the process-global ApplicationGlobals logger,
-        // so they must not run concurrently with other classes that share that global state.
-        [TestMethod]
-        [DoNotParallelize]
-        public async Task LoadAsync_WhenTimingDisabled_RecordsNothingAndEmitsNoTable()
-        {
-            // Arrange: flag off (default from TestInitialize). Capture the ApplicationGlobals
-            // logger output to confirm no [Startup timing] table is emitted.
-            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = false;
-            var sut = new TestableApplicationGlobals(CreateOutlookApplicationStub());
-            SetEnginesMock(sut);
-            var appender = AttachMemoryAppender(typeof(ApplicationGlobals));
-
-            try
-            {
-                // Act
-                await sut.LoadAsync(parallel: false);
-
-                // Assert: the no-op recorder is selected, records nothing, and emits no table.
-                sut.TimingRecorder.Should().BeOfType<NullStartupTimingRecorder>();
-                sut.TimingRecorder.FormatTable().Should().BeEmpty();
-                var timingMessages = appender
-                    .GetEvents()
-                    .Select(e => e.RenderedMessage)
-                    .Where(m => m != null && m.Contains("[Startup timing]"));
-                timingMessages
-                    .Should()
-                    .BeEmpty("no startup-timing table may be emitted when the flag is off.");
-            }
-            finally
-            {
-                DetachMemoryAppender(typeof(ApplicationGlobals), appender);
-            }
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public async Task LoadAsync_WhenTimingEnabled_RecordsAllPhasesInStartupOrderWithLoadBasicFirst()
-        {
-            // Arrange: flag on.
-            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = true;
-            var sut = new TestableApplicationGlobals(CreateOutlookApplicationStub());
-            SetEnginesMock(sut);
-
-            // Act
-            await sut.LoadAsync(parallel: false);
-
-            // Assert: the concrete recorder is selected and the recorded phase sequence is the
-            // seven phases in startup order, with LoadBasic first.
-            sut.TimingRecorder.Should().BeOfType<StartupTimingRecorder>();
-            var recorded = ((StartupTimingRecorder)sut.TimingRecorder).RecordedPhaseNames;
-            recorded.Should().HaveCount(7);
-            recorded[0].Should().Be("LoadBasic", "LoadBasic must be the first recorded phase.");
-            recorded
-                .Should()
-                .Equal(
-                    "LoadBasic",
-                    "IntelConfig",
-                    "OlObjects",
-                    "ToDo",
-                    "AutoFile",
-                    "Engines",
-                    "Events"
-                );
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public async Task LoadAsync_WhenTimingEnabled_EmitsExactlyOneTableWithPhaseNamesAndTotal()
-        {
-            // Arrange: flag on, capture the ApplicationGlobals logger output.
-            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = true;
-            var sut = new TestableApplicationGlobals(CreateOutlookApplicationStub());
-            SetEnginesMock(sut);
-            var appender = AttachMemoryAppender(typeof(ApplicationGlobals));
-
-            try
-            {
-                // Act
-                await sut.LoadAsync(parallel: false);
-
-                // Assert: exactly one [Startup timing] emission containing each phase name and a
-                // TOTAL row.
-                var timingMessages = appender
-                    .GetEvents()
-                    .Select(e => e.RenderedMessage)
-                    .Where(m => m != null && m.Contains("[Startup timing]"))
-                    .ToList();
-                timingMessages.Should().HaveCount(1, "the table must be emitted exactly once.");
-
-                var table = timingMessages[0];
-                table.Should().Contain("LoadBasic");
-                table.Should().Contain("IntelConfig");
-                table.Should().Contain("OlObjects");
-                table.Should().Contain("ToDo");
-                table.Should().Contain("AutoFile");
-                table.Should().Contain("Engines");
-                table.Should().Contain("Events");
-                table.Should().Contain("TOTAL");
-            }
-            finally
-            {
-                DetachMemoryAppender(typeof(ApplicationGlobals), appender);
-            }
-        }
-
-        [TestMethod]
-        [DoNotParallelize]
-        public async Task LoadAsync_PreservesPhaseOrderingAndYieldCount_WhenTimingOnVersusOff()
-        {
-            // Arrange + Act: drive the sequential load with timing off, then on, capturing the
-            // visited-stage sequence and yield count in each mode.
-            var visitedOff = new List<string>();
-            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = false;
-            var sutOff = new TestableApplicationGlobals(CreateOutlookApplicationStub(), visitedOff);
-            SetEnginesMock(sutOff, visitedOff);
-            await sutOff.LoadAsync(parallel: false);
-            var yieldOff = sutOff.YieldCount;
-
-            var visitedOn = new List<string>();
-            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = true;
-            var sutOn = new TestableApplicationGlobals(CreateOutlookApplicationStub(), visitedOn);
-            SetEnginesMock(sutOn, visitedOn);
-            await sutOn.LoadAsync(parallel: false);
-            var yieldOn = sutOn.YieldCount;
-
-            // Assert: the visited-stage ordering and yield count are identical in both modes, so
-            // instrumentation does not change functional startup behavior.
-            visitedOff.Should().Equal("intel", "ol", "todo", "auto", "engine", "events");
-            visitedOn.Should().Equal(visitedOff);
-            yieldOn.Should().Be(yieldOff);
-            yieldOn.Should().Be(5);
-        }
-
-        private static void SetEnginesMock(
-            TestableApplicationGlobals sut,
-            List<string> visitedStages = null
-        )
-        {
-            var engineMock = new Mock<IAppItemEngines>(MockBehavior.Strict);
-            engineMock
-                .SetupGet(x => x.InboxEngines)
-                .Returns(new ConcurrentDictionary<string, IConditionalEngine<MailItemHelper>>());
-            engineMock
-                .Setup(x => x.InitAsync())
-                .Returns(() =>
-                {
-                    visitedStages?.Add("engine");
-                    return Task.CompletedTask;
-                });
-            typeof(ApplicationGlobals)
-                .GetProperty(
-                    nameof(ApplicationGlobals.Engines),
-                    BindingFlags.Instance | BindingFlags.Public
-                )!
-                .SetValue(sut, engineMock.Object);
-        }
-
-        private static MemoryAppender AttachMemoryAppender(System.Type targetType)
-        {
-            var appender = new MemoryAppender();
-            appender.ActivateOptions();
-
-            var hierarchy = (Hierarchy)LogManager.GetRepository();
-            var logger = (Logger)hierarchy.GetLogger(targetType.FullName);
-            logger.AddAppender(appender);
-            return appender;
-        }
-
-        private static void DetachMemoryAppender(System.Type targetType, MemoryAppender appender)
-        {
-            var hierarchy = (Hierarchy)LogManager.GetRepository();
-            var logger = (Logger)hierarchy.GetLogger(targetType.FullName);
-            logger.RemoveAppender(appender);
-        }
-
         private static string GetRepositoryRoot()
         {
             var assemblyDirectory = new DirectoryInfo(
@@ -623,29 +441,7 @@ namespace TaskMaster.Test.AppGlobals
 
             public int YieldCount { get; private set; }
 
-            // Observation seam for the startup-timing recorder (issue #202). Reads the private
-            // _timingRecorder field selected in LoadAsync so tests can assert the chosen recorder
-            // type and the recorded phase sequence without a live Outlook process.
-            public IStartupTimingRecorder TimingRecorder =>
-                (IStartupTimingRecorder)
-                    typeof(ApplicationGlobals)
-                        .GetField(
-                            "_timingRecorder",
-                            BindingFlags.Instance | BindingFlags.NonPublic
-                        )!
-                        .GetValue(this)!;
-
             public Task InvokeInitializeEnginesPhaseAsync() => InitializeEnginesPhaseAsync();
-
-            // Deterministic test seam: skip live COM collaborator construction and set a fixed
-            // non-zero LoadBasic elapsed so the recorder captures a stable LoadBasic span when
-            // LoadAsync drives ForceBasicLoad. The Engines mock is injected separately by tests.
-            protected internal override void LoadBasicMethod()
-            {
-                typeof(ApplicationGlobals)
-                    .GetField("_loadBasicElapsed", BindingFlags.Instance | BindingFlags.NonPublic)!
-                    .SetValue(this, TimeSpan.FromMilliseconds(7));
-            }
 
             protected internal override Task LoadIntelConfigPhaseAsync()
             {

--- a/TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs
+++ b/TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs
@@ -2,12 +2,16 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using log4net;
+using log4net.Appender;
+using log4net.Repository.Hierarchy;
 using Microsoft.Office.Interop.Outlook;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -20,6 +24,28 @@ namespace TaskMaster.Test.AppGlobals
     [TestClass]
     public class ApplicationGlobalsTests
     {
+        private bool _originalStartupTimingEnabled;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            // Save and force the diagnostic timing flag off by default so flag-dependent tests
+            // start from a known state; each test sets the value it needs explicitly.
+            _originalStartupTimingEnabled = TaskMaster
+                .Properties
+                .Settings
+                .Default
+                .StartupTimingEnabled;
+            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = false;
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            TaskMaster.Properties.Settings.Default.StartupTimingEnabled =
+                _originalStartupTimingEnabled;
+        }
+
         [TestMethod]
         public void Constructor_WithoutLoadBasic_DoesNotMaterializeCollaboratorsUntilForceBasicLoad()
         {
@@ -211,14 +237,36 @@ namespace TaskMaster.Test.AppGlobals
             );
             var methodBody = ExtractMethodBody(source, "public async Task LoadSequentialAsync()");
 
+            // The startup-timing instrumentation (issue #202) inserts a single per-phase
+            // RecordPhase call after each phase await, so the ToDo/yield/AutoFile awaits are no
+            // longer textually adjacent. The ordering guarantee is preserved: the ToDo phase is
+            // awaited, then the yield boundary, then the auto-file phase, with only the timing
+            // RecordPhase statement(s) interleaved. The pattern below asserts that ordering while
+            // tolerating the interleaved instrumentation.
             Regex
                 .IsMatch(
                     methodBody,
-                    @"await\s+LoadToDoPhaseAsync\(\)\s*;\s*await\s+YieldBetweenStartupPhasesAsync\(\)\s*;\s*await\s+LoadAutoFilePhaseAsync\(\)\s*;"
+                    @"await\s+LoadToDoPhaseAsync\(\)\s*;[\s\S]*?await\s+YieldBetweenStartupPhasesAsync\(\)\s*;[\s\S]*?await\s+LoadAutoFilePhaseAsync\(\)\s*;"
                 )
                 .Should()
                 .BeTrue(
                     "LoadSequentialAsync should yield after the ToDo phase and before the auto-file phase."
+                );
+            // Guard that nothing other than timing instrumentation was interleaved between the
+            // ToDo await and the yield: only a _timingRecorder.RecordPhase(...) call is allowed.
+            var toDoToYield = Regex.Match(
+                methodBody,
+                @"await\s+LoadToDoPhaseAsync\(\)\s*;(?<between>[\s\S]*?)await\s+YieldBetweenStartupPhasesAsync\(\)\s*;"
+            );
+            toDoToYield.Success.Should().BeTrue();
+            Regex
+                .IsMatch(
+                    toDoToYield.Groups["between"].Value,
+                    @"^\s*(_timingRecorder\.RecordPhase\([^;]*\);\s*)?$"
+                )
+                .Should()
+                .BeTrue(
+                    "only the startup-timing RecordPhase call may sit between the ToDo phase and the yield boundary."
                 );
         }
 
@@ -314,6 +362,183 @@ namespace TaskMaster.Test.AppGlobals
             engineMock.Verify(x => x.InitAsync(), Times.Once);
         }
 
+        // DoNotParallelize: these tests mutate the shared Settings.Default.StartupTimingEnabled
+        // singleton and attach a memory appender to the process-global ApplicationGlobals logger,
+        // so they must not run concurrently with other classes that share that global state.
+        [TestMethod]
+        [DoNotParallelize]
+        public async Task LoadAsync_WhenTimingDisabled_RecordsNothingAndEmitsNoTable()
+        {
+            // Arrange: flag off (default from TestInitialize). Capture the ApplicationGlobals
+            // logger output to confirm no [Startup timing] table is emitted.
+            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = false;
+            var sut = new TestableApplicationGlobals(CreateOutlookApplicationStub());
+            SetEnginesMock(sut);
+            var appender = AttachMemoryAppender(typeof(ApplicationGlobals));
+
+            try
+            {
+                // Act
+                await sut.LoadAsync(parallel: false);
+
+                // Assert: the no-op recorder is selected, records nothing, and emits no table.
+                sut.TimingRecorder.Should().BeOfType<NullStartupTimingRecorder>();
+                sut.TimingRecorder.FormatTable().Should().BeEmpty();
+                var timingMessages = appender
+                    .GetEvents()
+                    .Select(e => e.RenderedMessage)
+                    .Where(m => m != null && m.Contains("[Startup timing]"));
+                timingMessages
+                    .Should()
+                    .BeEmpty("no startup-timing table may be emitted when the flag is off.");
+            }
+            finally
+            {
+                DetachMemoryAppender(typeof(ApplicationGlobals), appender);
+            }
+        }
+
+        [TestMethod]
+        [DoNotParallelize]
+        public async Task LoadAsync_WhenTimingEnabled_RecordsAllPhasesInStartupOrderWithLoadBasicFirst()
+        {
+            // Arrange: flag on.
+            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = true;
+            var sut = new TestableApplicationGlobals(CreateOutlookApplicationStub());
+            SetEnginesMock(sut);
+
+            // Act
+            await sut.LoadAsync(parallel: false);
+
+            // Assert: the concrete recorder is selected and the recorded phase sequence is the
+            // seven phases in startup order, with LoadBasic first.
+            sut.TimingRecorder.Should().BeOfType<StartupTimingRecorder>();
+            var recorded = ((StartupTimingRecorder)sut.TimingRecorder).RecordedPhaseNames;
+            recorded.Should().HaveCount(7);
+            recorded[0].Should().Be("LoadBasic", "LoadBasic must be the first recorded phase.");
+            recorded
+                .Should()
+                .Equal(
+                    "LoadBasic",
+                    "IntelConfig",
+                    "OlObjects",
+                    "ToDo",
+                    "AutoFile",
+                    "Engines",
+                    "Events"
+                );
+        }
+
+        [TestMethod]
+        [DoNotParallelize]
+        public async Task LoadAsync_WhenTimingEnabled_EmitsExactlyOneTableWithPhaseNamesAndTotal()
+        {
+            // Arrange: flag on, capture the ApplicationGlobals logger output.
+            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = true;
+            var sut = new TestableApplicationGlobals(CreateOutlookApplicationStub());
+            SetEnginesMock(sut);
+            var appender = AttachMemoryAppender(typeof(ApplicationGlobals));
+
+            try
+            {
+                // Act
+                await sut.LoadAsync(parallel: false);
+
+                // Assert: exactly one [Startup timing] emission containing each phase name and a
+                // TOTAL row.
+                var timingMessages = appender
+                    .GetEvents()
+                    .Select(e => e.RenderedMessage)
+                    .Where(m => m != null && m.Contains("[Startup timing]"))
+                    .ToList();
+                timingMessages.Should().HaveCount(1, "the table must be emitted exactly once.");
+
+                var table = timingMessages[0];
+                table.Should().Contain("LoadBasic");
+                table.Should().Contain("IntelConfig");
+                table.Should().Contain("OlObjects");
+                table.Should().Contain("ToDo");
+                table.Should().Contain("AutoFile");
+                table.Should().Contain("Engines");
+                table.Should().Contain("Events");
+                table.Should().Contain("TOTAL");
+            }
+            finally
+            {
+                DetachMemoryAppender(typeof(ApplicationGlobals), appender);
+            }
+        }
+
+        [TestMethod]
+        [DoNotParallelize]
+        public async Task LoadAsync_PreservesPhaseOrderingAndYieldCount_WhenTimingOnVersusOff()
+        {
+            // Arrange + Act: drive the sequential load with timing off, then on, capturing the
+            // visited-stage sequence and yield count in each mode.
+            var visitedOff = new List<string>();
+            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = false;
+            var sutOff = new TestableApplicationGlobals(CreateOutlookApplicationStub(), visitedOff);
+            SetEnginesMock(sutOff, visitedOff);
+            await sutOff.LoadAsync(parallel: false);
+            var yieldOff = sutOff.YieldCount;
+
+            var visitedOn = new List<string>();
+            TaskMaster.Properties.Settings.Default.StartupTimingEnabled = true;
+            var sutOn = new TestableApplicationGlobals(CreateOutlookApplicationStub(), visitedOn);
+            SetEnginesMock(sutOn, visitedOn);
+            await sutOn.LoadAsync(parallel: false);
+            var yieldOn = sutOn.YieldCount;
+
+            // Assert: the visited-stage ordering and yield count are identical in both modes, so
+            // instrumentation does not change functional startup behavior.
+            visitedOff.Should().Equal("intel", "ol", "todo", "auto", "engine", "events");
+            visitedOn.Should().Equal(visitedOff);
+            yieldOn.Should().Be(yieldOff);
+            yieldOn.Should().Be(5);
+        }
+
+        private static void SetEnginesMock(
+            TestableApplicationGlobals sut,
+            List<string> visitedStages = null
+        )
+        {
+            var engineMock = new Mock<IAppItemEngines>(MockBehavior.Strict);
+            engineMock
+                .SetupGet(x => x.InboxEngines)
+                .Returns(new ConcurrentDictionary<string, IConditionalEngine<MailItemHelper>>());
+            engineMock
+                .Setup(x => x.InitAsync())
+                .Returns(() =>
+                {
+                    visitedStages?.Add("engine");
+                    return Task.CompletedTask;
+                });
+            typeof(ApplicationGlobals)
+                .GetProperty(
+                    nameof(ApplicationGlobals.Engines),
+                    BindingFlags.Instance | BindingFlags.Public
+                )!
+                .SetValue(sut, engineMock.Object);
+        }
+
+        private static MemoryAppender AttachMemoryAppender(System.Type targetType)
+        {
+            var appender = new MemoryAppender();
+            appender.ActivateOptions();
+
+            var hierarchy = (Hierarchy)LogManager.GetRepository();
+            var logger = (Logger)hierarchy.GetLogger(targetType.FullName);
+            logger.AddAppender(appender);
+            return appender;
+        }
+
+        private static void DetachMemoryAppender(System.Type targetType, MemoryAppender appender)
+        {
+            var hierarchy = (Hierarchy)LogManager.GetRepository();
+            var logger = (Logger)hierarchy.GetLogger(targetType.FullName);
+            logger.RemoveAppender(appender);
+        }
+
         private static string GetRepositoryRoot()
         {
             var assemblyDirectory = new DirectoryInfo(
@@ -398,7 +623,29 @@ namespace TaskMaster.Test.AppGlobals
 
             public int YieldCount { get; private set; }
 
+            // Observation seam for the startup-timing recorder (issue #202). Reads the private
+            // _timingRecorder field selected in LoadAsync so tests can assert the chosen recorder
+            // type and the recorded phase sequence without a live Outlook process.
+            public IStartupTimingRecorder TimingRecorder =>
+                (IStartupTimingRecorder)
+                    typeof(ApplicationGlobals)
+                        .GetField(
+                            "_timingRecorder",
+                            BindingFlags.Instance | BindingFlags.NonPublic
+                        )!
+                        .GetValue(this)!;
+
             public Task InvokeInitializeEnginesPhaseAsync() => InitializeEnginesPhaseAsync();
+
+            // Deterministic test seam: skip live COM collaborator construction and set a fixed
+            // non-zero LoadBasic elapsed so the recorder captures a stable LoadBasic span when
+            // LoadAsync drives ForceBasicLoad. The Engines mock is injected separately by tests.
+            protected internal override void LoadBasicMethod()
+            {
+                typeof(ApplicationGlobals)
+                    .GetField("_loadBasicElapsed", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .SetValue(this, TimeSpan.FromMilliseconds(7));
+            }
 
             protected internal override Task LoadIntelConfigPhaseAsync()
             {

--- a/TaskMaster.Test/AppGlobals/StartupTimingRecorderTests.cs
+++ b/TaskMaster.Test/AppGlobals/StartupTimingRecorderTests.cs
@@ -1,0 +1,184 @@
+using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace TaskMaster.Test.AppGlobals
+{
+    /// <summary>
+    /// Unit tests for <see cref="StartupTimingRecorder"/> and
+    /// <see cref="NullStartupTimingRecorder"/>. All durations are injected deterministically so
+    /// the assertions are stable; no clock, stopwatch, or external dependency is used.
+    /// </summary>
+    [TestClass]
+    public class StartupTimingRecorderTests
+    {
+        [TestMethod]
+        public void RecordPhase_WithPositiveDurations_PreservesPhaseNamesInRecordedOrder()
+        {
+            // Arrange
+            var recorder = new StartupTimingRecorder();
+            recorder.RecordPhase("IntelConfig", TimeSpan.FromMilliseconds(120));
+            recorder.RecordPhase("OlObjects", TimeSpan.FromMilliseconds(450));
+            recorder.RecordPhase("Events", TimeSpan.FromMilliseconds(75));
+
+            // Act
+            var table = recorder.FormatTable();
+
+            // Assert: every phase name appears, and they appear in the order recorded.
+            table.Should().Contain("IntelConfig");
+            table.Should().Contain("OlObjects");
+            table.Should().Contain("Events");
+            table
+                .IndexOf("IntelConfig", StringComparison.Ordinal)
+                .Should()
+                .BeLessThan(
+                    table.IndexOf("OlObjects", StringComparison.Ordinal),
+                    "phases must be rendered in the order they were recorded."
+                );
+            table
+                .IndexOf("OlObjects", StringComparison.Ordinal)
+                .Should()
+                .BeLessThan(
+                    table.IndexOf("Events", StringComparison.Ordinal),
+                    "phases must be rendered in the order they were recorded."
+                );
+        }
+
+        [TestMethod]
+        public void RecordPhase_WithZeroDuration_IsCapturedAndRenderedWithoutError()
+        {
+            // Arrange
+            var recorder = new StartupTimingRecorder();
+            recorder.RecordPhase("ToDo", TimeSpan.Zero);
+
+            // Act
+            Action act = () => recorder.FormatTable();
+
+            // Assert
+            act.Should().NotThrow();
+            recorder.FormatTable().Should().Contain("ToDo");
+        }
+
+        [TestMethod]
+        public void FormatTable_ContainsHeadersPhaseNamesAndTotalEqualToSumOfInjectedSpans()
+        {
+            // Arrange: distinct non-zero spans injected deterministically.
+            var intel = TimeSpan.FromMilliseconds(100);
+            var ol = TimeSpan.FromMilliseconds(250);
+            var events = TimeSpan.FromMilliseconds(50);
+            var recorder = new StartupTimingRecorder();
+            recorder.RecordPhase("IntelConfig", intel);
+            recorder.RecordPhase("OlObjects", ol);
+            recorder.RecordPhase("Events", events);
+
+            // Act
+            var table = recorder.FormatTable();
+
+            // Assert: headers, phase names, and a TOTAL row are present.
+            table.Should().Contain("Duration");
+            table.Should().Contain("Action");
+            table.Should().Contain("TOTAL");
+            table.Should().Contain("IntelConfig");
+            table.Should().Contain("OlObjects");
+            table.Should().Contain("Events");
+
+            // Assert: the rendered TOTAL row duration equals the sum of the injected spans and
+            // is non-zero. The duration format is "%m\:ss\.ff" (same as SegmentStopWatch).
+            var expectedTotal = intel + ol + events;
+            var expectedTotalText = expectedTotal.ToString("%m\\:ss\\.ff");
+            expectedTotal.Should().NotBe(TimeSpan.Zero);
+
+            var totalIndex = table.IndexOf("TOTAL", StringComparison.Ordinal);
+            totalIndex.Should().BeGreaterThanOrEqualTo(0);
+            var lineStart = table.LastIndexOf('\n', totalIndex) + 1;
+            var lineEnd = table.IndexOf('\n', totalIndex);
+            var totalLine =
+                lineEnd >= 0
+                    ? table.Substring(lineStart, lineEnd - lineStart)
+                    : table.Substring(lineStart);
+
+            totalLine
+                .Should()
+                .Contain(
+                    expectedTotalText,
+                    "the TOTAL row duration must equal the sum of the injected non-zero phase spans."
+                );
+        }
+
+        [TestMethod]
+        public void RecordPhase_WithNullPhaseName_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var recorder = new StartupTimingRecorder();
+
+            // Act
+            Action act = () => recorder.RecordPhase(null!, TimeSpan.FromMilliseconds(10));
+
+            // Assert
+            act.Should()
+                .Throw<ArgumentNullException>()
+                .WithParameterName(
+                    "phaseName",
+                    "RecordPhase must reject a null phase name per its contract."
+                );
+        }
+
+        [TestMethod]
+        public void EmitTable_LogsFormattedTableViaLoggerInfoWithStartupTimingPrefix()
+        {
+            // Arrange
+            var recorder = new StartupTimingRecorder();
+            recorder.RecordPhase("IntelConfig", TimeSpan.FromMilliseconds(100));
+            recorder.RecordPhase("Events", TimeSpan.FromMilliseconds(50));
+            var loggerMock = new Mock<log4net.ILog>(MockBehavior.Loose);
+            object emitted = null;
+            loggerMock.Setup(x => x.Info(It.IsAny<object>())).Callback<object>(o => emitted = o);
+
+            // Act
+            recorder.EmitTable(loggerMock.Object);
+
+            // Assert: emitted exactly once, prefixed, and containing the table contents.
+            loggerMock.Verify(x => x.Info(It.IsAny<object>()), Times.Once);
+            var text = emitted as string;
+            text.Should().NotBeNull();
+            text.Should().Contain("[Startup timing]");
+            text.Should().Contain("IntelConfig");
+            text.Should().Contain("Events");
+            text.Should().Contain("TOTAL");
+        }
+
+        [TestMethod]
+        public void EmitTable_WithNullLogger_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var recorder = new StartupTimingRecorder();
+            recorder.RecordPhase("IntelConfig", TimeSpan.FromMilliseconds(100));
+
+            // Act
+            Action act = () => recorder.EmitTable(null!);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+        }
+
+        [TestMethod]
+        public void NullStartupTimingRecorder_IsNoOp_ForFormatAndEmit()
+        {
+            // Arrange
+            IStartupTimingRecorder recorder = new NullStartupTimingRecorder();
+            var loggerMock = new Mock<log4net.ILog>(MockBehavior.Strict);
+
+            // Act
+            recorder.RecordPhase("IntelConfig", TimeSpan.FromMilliseconds(100));
+            recorder.RecordPhase("Events", TimeSpan.FromMilliseconds(200));
+            var table = recorder.FormatTable();
+            recorder.EmitTable(loggerMock.Object);
+
+            // Assert: no table content and no logger interaction (strict mock would throw on any).
+            table.Should().BeEmpty();
+            loggerMock.Verify(x => x.Info(It.IsAny<object>()), Times.Never);
+            loggerMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/TaskMaster.Test/TaskMaster.Test.csproj
+++ b/TaskMaster.Test/TaskMaster.Test.csproj
@@ -259,6 +259,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppGlobals\ApplicationGlobalsTests.cs" />
+    <Compile Include="AppGlobals\ApplicationGlobalsStartupTimingTests.cs" />
     <Compile Include="AppGlobals\StartupTimingRecorderTests.cs" />
     <Compile Include="AppGlobals\AppEventsTests.cs" />
     <Compile Include="AppGlobals\AppFileSystemFolderPathsMatchBestSpecialFolderTests.cs" />

--- a/TaskMaster.Test/TaskMaster.Test.csproj
+++ b/TaskMaster.Test/TaskMaster.Test.csproj
@@ -259,6 +259,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppGlobals\ApplicationGlobalsTests.cs" />
+    <Compile Include="AppGlobals\StartupTimingRecorderTests.cs" />
     <Compile Include="AppGlobals\AppEventsTests.cs" />
     <Compile Include="AppGlobals\AppFileSystemFolderPathsMatchBestSpecialFolderTests.cs" />
     <Compile Include="AppGlobals\AppOlObjectsCoverageTests.cs" />

--- a/TaskMaster/AppGlobals/ApplicationGlobals.cs
+++ b/TaskMaster/AppGlobals/ApplicationGlobals.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.Office.Interop.Outlook;
+using TaskMaster.Properties;
 using UtilitiesCS;
 using UtilitiesCS.EmailIntelligence;
 using UtilitiesCS.HelperClasses;
@@ -19,6 +20,14 @@ namespace TaskMaster
         );
 
         private Application _outlookApp;
+
+        // Diagnostic startup-timing instrumentation (issue #202). The recorder is selected in
+        // LoadAsync from Settings.Default.StartupTimingEnabled: the concrete recorder when
+        // enabled, the no-op recorder when disabled, so the coordinator records and emits
+        // unconditionally. _loadBasicElapsed holds the LoadBasicMethod() measurement, which is
+        // taken at construction time (via the BasicLoaded Lazy) before LoadAsync runs.
+        private IStartupTimingRecorder _timingRecorder = new NullStartupTimingRecorder();
+        private TimeSpan _loadBasicElapsed;
 
         public ApplicationGlobals(Application olApp)
         {
@@ -47,6 +56,22 @@ namespace TaskMaster
         public async Task LoadAsync(bool parallel = true)
         {
             ForceBasicLoad();
+
+            // Read the diagnostic timing flag exactly once (mirrors the Settings.Default
+            // consumption pattern used for EventsHooked). When enabled, record the
+            // construction-time LoadBasic measurement as the first phase; when disabled, the
+            // no-op recorder absorbs all recording and emission.
+            var timingEnabled = Settings.Default.StartupTimingEnabled;
+            if (timingEnabled)
+            {
+                _timingRecorder = new StartupTimingRecorder();
+                _timingRecorder.RecordPhase("LoadBasic", _loadBasicElapsed);
+            }
+            else
+            {
+                _timingRecorder = new NullStartupTimingRecorder();
+            }
+
             if (parallel)
             {
                 await LoadParallelAsync();
@@ -55,6 +80,10 @@ namespace TaskMaster
             {
                 await LoadSequentialAsync();
             }
+
+            // Emit the single [Startup timing] table at the end of startup. On the flag-off
+            // path the no-op recorder emits nothing.
+            _timingRecorder.EmitTable(logger);
         }
 
         internal Lazy<bool> BasicLoaded;
@@ -64,8 +93,18 @@ namespace TaskMaster
             _ = BasicLoaded.Value;
         }
 
-        private void LoadBasicMethod()
+        // protected internal virtual to provide a test seam: focused MSTests override this to
+        // set _loadBasicElapsed deterministically and skip live COM collaborator construction
+        // while still driving LoadAsync end-to-end. Production behavior is unchanged.
+        protected internal virtual void LoadBasicMethod()
         {
+            // The LoadBasic measurement is UNCONDITIONAL: ForceBasicLoad() runs inside the
+            // ApplicationGlobals(Application, loadBasic: true) constructor, materializing the
+            // BasicLoaded Lazy BEFORE LoadAsync runs, so measuring around ForceBasicLoad() in
+            // LoadAsync would record ~0. A single Stopwatch start/stop with no allocation is
+            // negligible overhead, satisfying the "negligible overhead when flag off" constraint.
+            // Stopwatch (hardware-counter based) is used instead of DateTime.Now/UtcNow.
+            var stopwatch = Stopwatch.StartNew();
             _fs = new AppFileSystemFolderPaths();
             _olObjects = new AppOlObjects(_outlookApp, this);
             _toDoObjects = new AppToDoObjects(this);
@@ -73,6 +112,8 @@ namespace TaskMaster
             _events = new AppEvents(this);
             _quickFilerSettings = new AppQuickFilerSettings();
             Engines = new AppItemEngines(this);
+            stopwatch.Stop();
+            _loadBasicElapsed = stopwatch.Elapsed;
         }
 
         public async Task LoadParallelAsync()
@@ -89,17 +130,39 @@ namespace TaskMaster
 
         public async Task LoadSequentialAsync()
         {
+            // Each phase keeps its existing direct await (COM-sensitive phases stay on the
+            // caller thread) and is wrapped with a Stopwatch so its elapsed time is recorded
+            // once, in startup order. The recorder is the no-op recorder unless the timing flag
+            // is on, so nothing is recorded when disabled. Yield calls are not recorded.
+            var stopwatch = Stopwatch.StartNew();
             await LoadIntelConfigPhaseAsync();
+            _timingRecorder.RecordPhase("IntelConfig", StopAndRestart(stopwatch));
             await YieldBetweenStartupPhasesAsync();
             await LoadOlObjectsPhaseAsync();
+            _timingRecorder.RecordPhase("OlObjects", StopAndRestart(stopwatch));
             await YieldBetweenStartupPhasesAsync();
             await LoadToDoPhaseAsync();
+            _timingRecorder.RecordPhase("ToDo", StopAndRestart(stopwatch));
             await YieldBetweenStartupPhasesAsync();
             await LoadAutoFilePhaseAsync();
+            _timingRecorder.RecordPhase("AutoFile", StopAndRestart(stopwatch));
             await YieldBetweenStartupPhasesAsync();
             await InitializeEnginesPhaseAsync();
+            _timingRecorder.RecordPhase("Engines", StopAndRestart(stopwatch));
             await YieldBetweenStartupPhasesAsync();
             await LoadEventsPhaseAsync();
+            _timingRecorder.RecordPhase("Events", StopAndRestart(stopwatch));
+        }
+
+        // Captures the elapsed time of the just-completed phase and resets the shared stopwatch
+        // for the next phase. The yield between phases is excluded because the stopwatch is read
+        // and restarted immediately after each phase's await completes.
+        private static TimeSpan StopAndRestart(Stopwatch stopwatch)
+        {
+            stopwatch.Stop();
+            var elapsed = stopwatch.Elapsed;
+            stopwatch.Restart();
+            return elapsed;
         }
 
         // These narrow wrappers keep production behavior unchanged while letting focused MSTests

--- a/TaskMaster/AppGlobals/IStartupTimingRecorder.cs
+++ b/TaskMaster/AppGlobals/IStartupTimingRecorder.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace TaskMaster
+{
+    /// <summary>
+    /// Records pre-measured startup phase durations and renders them as a single formatted
+    /// plain-text table for diagnostic logging.
+    /// </summary>
+    /// <remarks>
+    /// Implementations record named spans in call order and produce a deterministic table.
+    /// The contract is intentionally free of any Outlook/COM, filesystem, or network
+    /// dependency so it can be unit-tested without a live Outlook process.
+    /// </remarks>
+    internal interface IStartupTimingRecorder
+    {
+        /// <summary>
+        /// Records a single named startup phase span. Spans are retained in call order.
+        /// </summary>
+        /// <param name="phaseName">
+        /// The non-null name of the startup sub-component (for example "IntelConfig").
+        /// </param>
+        /// <param name="elapsed">The pre-measured wall-clock duration for the phase.</param>
+        void RecordPhase(string phaseName, TimeSpan elapsed);
+
+        /// <summary>
+        /// Builds the formatted plain-text table of recorded phases plus a TOTAL row whose
+        /// duration equals the sum of all recorded spans. Pure and deterministic given the
+        /// recorded spans.
+        /// </summary>
+        /// <returns>The formatted table text.</returns>
+        string FormatTable();
+
+        /// <summary>
+        /// Emits the formatted table via the supplied logger using <c>Info</c> level with the
+        /// <c>[Startup timing]</c> prefix, consistent with the prior #139/#141 timing entries.
+        /// </summary>
+        /// <param name="logger">The log4net logger used to emit the table.</param>
+        void EmitTable(log4net.ILog logger);
+    }
+}

--- a/TaskMaster/AppGlobals/StartupTimingRecorder.cs
+++ b/TaskMaster/AppGlobals/StartupTimingRecorder.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UtilitiesCS;
+
+namespace TaskMaster
+{
+    /// <summary>
+    /// Production <see cref="IStartupTimingRecorder"/> that accumulates pre-measured startup
+    /// phase spans in its own ordered collection and renders them as a single formatted table.
+    /// </summary>
+    /// <remarks>
+    /// This recorder deliberately does NOT wrap <c>UtilitiesCS.HelperClasses.SegmentStopWatch</c>:
+    /// <c>SegmentStopWatch.GetDurations()</c> derives its TOTAL row from the watch's own
+    /// <c>Elapsed</c>, which is <see cref="TimeSpan.Zero"/> when fed pre-measured (injected)
+    /// spans, so wrapping it would yield an always-zero TOTAL. Instead, the TOTAL row here is the
+    /// sum of all recorded spans. Column alignment is reused (not reimplemented) via
+    /// <c>UtilitiesCS.PrettyPrinters.ToFormattedText(string[][], ...)</c> — the same overload
+    /// <c>SegmentStopWatch.GetDurations()</c> calls.
+    /// </remarks>
+    internal sealed class StartupTimingRecorder : IStartupTimingRecorder
+    {
+        // Duration format mirrors the existing SegmentStopWatch.GetDurations() convention.
+        private const string DurationFormat = "%m\\:ss\\.ff";
+
+        private readonly List<(string PhaseName, TimeSpan Elapsed)> _phases = new();
+
+        /// <summary>
+        /// The recorded phase names in call order. Exposed for test observability of the
+        /// recording sequence; consumed only within the assembly and its test assembly.
+        /// </summary>
+        internal IReadOnlyList<string> RecordedPhaseNames =>
+            _phases.Select(p => p.PhaseName).ToList();
+
+        /// <inheritdoc />
+        public void RecordPhase(string phaseName, TimeSpan elapsed)
+        {
+            if (phaseName is null)
+            {
+                throw new ArgumentNullException(nameof(phaseName));
+            }
+
+            _phases.Add((phaseName, elapsed));
+        }
+
+        /// <inheritdoc />
+        public string FormatTable()
+        {
+            var total = TimeSpan.FromTicks(_phases.Sum(p => p.Elapsed.Ticks));
+
+            var rows = _phases
+                .Select(p => new[] { p.Elapsed.ToString(DurationFormat), p.PhaseName })
+                .Append(new[] { total.ToString(DurationFormat), "TOTAL" })
+                .ToArray();
+
+            return rows.ToFormattedText(
+                ["Duration", "Action"],
+                [Enums.Justification.Right, Enums.Justification.Left]
+            );
+        }
+
+        /// <inheritdoc />
+        public void EmitTable(log4net.ILog logger)
+        {
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            logger.Info($"[Startup timing]\n{FormatTable()}");
+        }
+    }
+
+    /// <summary>
+    /// No-op <see cref="IStartupTimingRecorder"/> used on the flag-off path so the startup
+    /// coordinator can invoke the recorder unconditionally without recording or emitting anything.
+    /// </summary>
+    internal sealed class NullStartupTimingRecorder : IStartupTimingRecorder
+    {
+        /// <inheritdoc />
+        public void RecordPhase(string phaseName, TimeSpan elapsed)
+        {
+            // Intentionally no-op: timing is disabled.
+        }
+
+        /// <inheritdoc />
+        public string FormatTable() => string.Empty;
+
+        /// <inheritdoc />
+        public void EmitTable(log4net.ILog logger)
+        {
+            // Intentionally no-op: timing is disabled.
+        }
+    }
+}

--- a/TaskMaster/Properties/Settings.Designer.cs
+++ b/TaskMaster/Properties/Settings.Designer.cs
@@ -670,5 +670,17 @@ namespace TaskMaster.Properties {
                 this["JunkPotential"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool StartupTimingEnabled {
+            get {
+                return ((bool)(this["StartupTimingEnabled"]));
+            }
+            set {
+                this["StartupTimingEnabled"] = value;
+            }
+        }
     }
 }

--- a/TaskMaster/Properties/Settings.settings
+++ b/TaskMaster/Properties/Settings.settings
@@ -167,5 +167,8 @@
     <Setting Name="JunkPotential" Type="System.String" Scope="User">
       <Value Profile="(Default)">Junk Suspects SB</Value>
     </Setting>
+    <Setting Name="StartupTimingEnabled" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/TaskMaster/TaskMaster.csproj
+++ b/TaskMaster/TaskMaster.csproj
@@ -397,6 +397,8 @@
     <Compile Include="AppGlobals\AppFileSystemFolderPaths.cs" />
     <Compile Include="AppGlobals\AppItemEngines.cs" />
     <Compile Include="AppGlobals\ApplicationGlobals.cs" />
+    <Compile Include="AppGlobals\IStartupTimingRecorder.cs" />
+    <Compile Include="AppGlobals\StartupTimingRecorder.cs" />
     <Compile Include="AppGlobals\AppOlObjects.cs" />
     <Compile Include="AppGlobals\AppQuickFilerSettings.cs" />
     <Compile Include="AppGlobals\AppStagingFilenames.cs" />

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/code-review.2026-06-15T13-29.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/code-review.2026-06-15T13-29.md
@@ -1,0 +1,108 @@
+# Code Review: debug-startup-timing-instrumentation (Issue #202)
+
+**Review Date:** 2026-06-15
+**Reviewer:** feature-reviewer agent
+**Feature Folder:** `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202`
+**Feature Folder Selection Rule:** Folder suffix `-202` matches the issue number in the branch name `feature/debug-startup-timing-instrumentation-202`; it holds the material scoping-doc changes.
+**Base Branch:** `main` (`a21d09e18dfebb9e3450c1b3322e7715c09d91e6`)
+**Head Branch:** `feature/debug-startup-timing-instrumentation-202` (`1d193d90dba55eec0a739ff13f5ecb5e3d218b99`)
+**Review Type:** Initial review
+
+---
+
+## Executive Summary
+
+This branch adds enable-on-demand startup-timing instrumentation to the TaskMaster Outlook VSTO add-in. A new `Settings.Default.StartupTimingEnabled` user setting (default `False`) gates the feature. When enabled, `ApplicationGlobals.LoadAsync(parallel: false)` measures wall-clock time for the seven established startup phase seams (LoadBasic, IntelConfig, OlObjects, ToDo, AutoFile, Engines, Events) and emits a single `[Startup timing]` table via the existing log4net logger. Recording and formatting are isolated behind a new COM-free `IStartupTimingRecorder` abstraction with a production `StartupTimingRecorder` and a `NullStartupTimingRecorder` no-op selected on the flag-off path.
+
+**What changed:**
+Six C# source files (plus two `.csproj` and one `.settings`) relative to `main`: two new recorder files, the `ApplicationGlobals` coordinator wiring, the new user setting (settings + generated designer), and two test files (one new recorder test file, one extended wiring test file). Net +1685/-2 lines, dominated by tests and documentation. The implementation reuses `UtilitiesCS.PrettyPrinters.ToFormattedText` for column alignment and uses `Stopwatch` (avoiding the banned `DateTime.Now`/`UtcNow`). The toolchain (CSharpier, analyzer build, nullable/TreatWarningsAsErrors build, MSTest+coverage over 7 assemblies) is recorded EXIT_CODE 0 with 4194/4194 tests passing.
+
+**Top 3 risks:**
+1. The modified test file `ApplicationGlobalsTests.cs` is 687 lines, exceeding the repository 500-line file-size limit (Major; policy violation).
+2. The wiring tests mutate the process-global `Settings.Default` singleton and attach an appender to the process-global log4net logger; correctness depends on the `[DoNotParallelize]` markers and save/restore being respected across the whole test process (mitigated, but a shared-global-state pattern to watch).
+3. The canonical C# coverage artifact `artifacts/csharp/coverage.xml` named by the workflow is absent; coverage was verified from `TestResults/final-full.cobertura.xml` instead (Minor/process).
+
+**PR readiness recommendation:** **Needs Revision** — The implementation is correct and well-tested, but the 500-line test-file limit must be resolved before merge.
+
+---
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Major | `TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` | whole file (687 lines) | File exceeds the repository 500-line limit (baseline 440 -> 687). | Move the four startup-timing wiring tests and their helpers (`AttachMemoryAppender`, `DetachMemoryAppender`, `SetEnginesMock`, the timing-related `TestableApplicationGlobals` members) into a new file, e.g. `ApplicationGlobalsStartupTimingTests.cs`, keeping each file under 500 lines. | General Code Change Policy §4 / `.claude/rules/general-code-change.md` applies the 500-line limit to test code. | `awk 'END{print NR}'` = 687; baseline `git show a21d09e1:...` = 440. |
+| Minor | (build/process) | `artifacts/csharp/coverage.xml` | Canonical C# coverage artifact path expected by the feature-review-workflow is absent. | Emit or copy the merged Cobertura output to `artifacts/csharp/coverage.xml` so the workflow's artifact contract is satisfied. | Workflow names this artifact for C# coverage verification; absence forces fallback parsing. | `ls artifacts/csharp/` -> no such directory; data exists at `TestResults/final-full.cobertura.xml`. |
+| Info | `TaskMaster/AppGlobals/ApplicationGlobals.cs` | `LoadAsync` parallel branch | On the `parallel: true` path only LoadBasic is recorded (no per-phase spans); `EmitTable` would emit a single-row table when the flag is on. | None required — `LoadAsync(parallel: true)` / `LoadParallelAsync` instrumentation is an explicit user-story Non-Goal; the startup entry point uses `parallel: false`. Optionally document that a parallel-path table is LoadBasic-only. | Confirms scope boundary is intentional, not an oversight. | `user-story.md` Non-Goals; diff of `LoadParallelAsync` (unchanged). |
+| Info | `TaskMaster/AppGlobals/ApplicationGlobals.cs` | `protected internal virtual LoadBasicMethod` | Visibility widened from `private` to `protected internal virtual` to provide a test seam. | None — minimal, documented seam; production behavior unchanged. | Confirms the API-surface change is a deliberate, narrow test seam. | Diff + inline comment; `TestableApplicationGlobals` override. |
+
+No Blocker findings.
+
+---
+
+## Implementation Audit
+
+### C# implementation audit
+
+#### What changed well
+
+- Clean separation of concerns: pure recording/formatting (`StartupTimingRecorder`) is fully decoupled from the COM-bound `ApplicationGlobals` coordinator and has no Outlook/COM/filesystem/network dependency, making it unit-testable without a live Outlook process.
+- The recorder deliberately does not wrap `SegmentStopWatch.GetDurations()` and documents why (its TOTAL derives from the watch's own `Elapsed`, which is zero for injected spans), while still reusing the existing `PrettyPrinters.ToFormattedText` alignment primitive rather than reimplementing column layout. This is a good reuse-vs-correctness tradeoff with a clear rationale comment.
+- The Null Object pattern (`NullStartupTimingRecorder`) lets the coordinator record and emit unconditionally, keeping the flag-off path branch-free at the call sites and guaranteeing zero output when disabled.
+- `Stopwatch` is used for measurement, explicitly avoiding the BannedApiAnalyzers `DateTime.Now`/`UtcNow` rule, and the shared-stopwatch `StopAndRestart` helper cleanly excludes the inter-phase yields from per-phase timing.
+- The LoadBasic-at-construction measurement subtlety (the `BasicLoaded` Lazy materializes before `LoadAsync`) is correctly handled by measuring inside `LoadBasicMethod` and recording the stored elapsed as the first phase, with a comment explaining why measuring in `LoadAsync` would record ~0.
+
+#### Type safety and API notes
+
+- Nullable reference types respected; `RecordPhase` and `EmitTable` guard null inputs with `ArgumentNullException` and explicit `nameof`. The nullable/TreatWarningsAsErrors build passes (EXIT_CODE 0).
+- New public-ish surface is minimized: recorder types are `internal sealed`, exposed to tests only via the existing `InternalsVisibleTo`. The one widened member (`LoadBasicMethod` to `protected internal virtual`) is a documented test seam.
+- XML doc comments on the interface and classes state contracts and the COM-free guarantee.
+
+#### Error handling and logging
+
+- Logging uses the existing `ApplicationGlobals` log4net logger via `logger.Info(...)` with the `[Startup timing]` prefix, consistent with the prior #139/#141 entries and the single-channel decision recorded in evidence. No new logging channel introduced.
+- Fail-fast on null arguments; no broad catches added. The emission is a single `Info` call at end of `LoadAsync`, so a flag-on run produces exactly one table.
+
+---
+
+## Test Quality Audit
+
+The change is covered by 11 new MSTest tests (7 recorder, 4 wiring) using MSTest + Moq + FluentAssertions per the C# Unit Test Policy. Recorder tests inject deterministic spans (no clock/sleep). Wiring tests drive `LoadAsync` end-to-end through `TestableApplicationGlobals`, asserting flag-off no-emit, flag-on phase order with LoadBasic first, exactly-one-table emission with all phase names and TOTAL, and ordering/yield-count parity between flag on and off. New-code line coverage is 100%; the modified `ApplicationGlobals` improved from 60.75% to 73.88% aggregate with no regression on changed lines.
+
+### Reviewed test and QA artifacts
+
+- `TaskMaster.Test/AppGlobals/StartupTimingRecorderTests.cs` — recorder ordering, zero-duration, summed TOTAL, null-name/null-logger throws, emit prefix, null-recorder no-op. Deterministic, isolated.
+- `TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` — flag-on/off wiring via a process-local `MemoryAppender`; `[DoNotParallelize]` + settings save/restore. Correct but pushes the file over the 500-line limit.
+- `evidence/qa-gates/coverage-delta.2026-06-15T12-15.md` — baseline-vs-post comparison, new-code 100%, no regression.
+- `evidence/qa-gates/final-test-coverage.2026-06-15T12-15.md` — 4194/4194 pass; numeric coverage.
+- `TestResults/final-full.cobertura.xml` — parsed directly: root line-rate 0.7636; new recorder classes line-rate 1.0; `ApplicationGlobals` class line-rate 0.776.
+
+### Quality assessment prompts
+
+- **Determinism:** No real clock or sleep; all spans injected; appender read in-process.
+- **Isolation:** Each test targets one behavior; shared-global tests marked `[DoNotParallelize]` and restore state.
+- **Speed:** No timing waits; full suite reported green with EXIT_CODE 0.
+- **Diagnostics:** FluentAssertions with `because` rationale strings yield actionable failure messages.
+
+---
+
+## Security / Correctness Checks
+
+| Check | Status | Evidence |
+|---|---|---|
+| No secrets in code | ✅ PASS | Diff inspection: no credentials, tokens, or connection strings. |
+| No unsafe subprocess or command construction | ✅ PASS | No process invocation introduced. |
+| Input validation at boundaries | ✅ PASS | `RecordPhase`/`EmitTable` validate null arguments and throw. |
+| Error handling remains explicit | ✅ PASS | Fail-fast null guards; no broad catches; single explicit log emission. |
+| Configuration / path handling is safe | ✅ PASS | New setting is a typed boolean user setting (default False); no path construction. |
+
+---
+
+## Research Log
+
+No external research was required. The review relied on the branch diff, the feature-folder evidence artifacts, the parsed Cobertura coverage file, and the repository policy documents (CLAUDE.md, `.claude/rules/*`).
+
+---
+
+## Verdict
+
+The implementation is correct, well-structured, well-documented, and well-tested: COM-free recorder abstraction, Null Object for the flag-off path, deliberate formatter reuse, banned-API avoidance, 100% new-code coverage, and no coverage regression, with a clean four-step toolchain pass. One Major policy violation prevents normal PR flow: the modified test file `ApplicationGlobalsTests.cs` (687 lines) exceeds the 500-line file-size limit and must be split. A Minor process gap (absent canonical `artifacts/csharp/coverage.xml`) should be resolved but does not affect coverage verdicts. Recommendation: **Needs Revision** — address the test-file size violation, then this change is ready for normal PR flow.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/code-review.2026-06-15T14-07.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/code-review.2026-06-15T14-07.md
@@ -1,0 +1,118 @@
+# Code Review: debug-startup-timing-instrumentation (Issue #202)
+
+**Review Date:** 2026-06-15
+**Reviewer:** feature-reviewer agent
+**Feature Folder:** `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202`
+**Feature Folder Selection Rule:** Folder suffix `-202` matches the issue number in the branch name `feature/debug-startup-timing-instrumentation-202`; it holds the material scoping-doc changes.
+**Base Branch:** `main` (`a21d09e18dfebb9e3450c1b3322e7715c09d91e6`)
+**Head Branch:** `feature/debug-startup-timing-instrumentation-202` (`253270ac6dbc94bd5b97de1d98a79938f9575040`)
+**Review Type:** Cycle-exit re-review (after remediation cycle that split the over-limit test file)
+
+---
+
+## Executive Summary
+
+This branch adds enable-on-demand startup-timing instrumentation to the TaskMaster Outlook VSTO add-in. A new `Settings.Default.StartupTimingEnabled` user setting (default `False`) gates the feature. When enabled, `ApplicationGlobals.LoadAsync(parallel: false)` measures wall-clock time for the seven established startup phase seams (LoadBasic, IntelConfig, OlObjects, ToDo, AutoFile, Engines, Events) and emits a single `[Startup timing]` table via the existing log4net logger. Recording and formatting are isolated behind a new COM-free `IStartupTimingRecorder` abstraction with a production `StartupTimingRecorder` and a `NullStartupTimingRecorder` no-op selected on the flag-off path.
+
+**What changed since the prior review:**
+This is the re-review after a remediation cycle. The prior cycle's single Major finding — `ApplicationGlobalsTests.cs` at 687 lines, over the 500-line limit — has been remediated by extracting the four startup-timing wiring tests and their helpers into a new file, `ApplicationGlobalsStartupTimingTests.cs`. At HEAD, `ApplicationGlobalsTests.cs` is 483 lines and `ApplicationGlobalsStartupTimingTests.cs` is 299 lines, both under the limit. The prior cycle's Minor process finding — the absent canonical `artifacts/csharp/coverage.xml` — is also resolved; the artifact is present and was parsed for this review. The split was a pure move (no test removed or weakened); the toolchain re-ran clean (CSharpier, analyzer build, nullable build, MSTest+coverage over 7 assemblies) with 4194/4194 tests passing.
+
+**Scope:** Seven C# source files (plus two `.csproj` and one `.settings`) relative to `main`: two new recorder files, the `ApplicationGlobals` coordinator wiring, the new user setting (settings + generated designer), and three test files (one new recorder test file, the reduced wiring test file, and the new split-out startup-timing wiring test file). The implementation reuses `UtilitiesCS.PrettyPrinters.ToFormattedText` for column alignment and uses `Stopwatch` (avoiding the banned `DateTime.Now`/`UtcNow`).
+
+**Top risks (residual):**
+1. The wiring tests mutate the process-global `Settings.Default` singleton and attach an appender to the process-global log4net logger; correctness depends on the `[DoNotParallelize]` markers and save/restore being respected across the whole test process. This is mitigated (markers and save/restore are preserved in the split file) but remains a shared-global-state pattern to watch (Minor; informational).
+2. On the `parallel: true` path only LoadBasic is recorded; this is an explicit user-story Non-Goal, not an oversight (Info).
+
+No Blocker findings. No Major findings. No remaining policy violations.
+
+**PR readiness recommendation:** **Ready for merge** — Both prior findings are resolved; the implementation is correct, well-tested, toolchain-clean, and policy-compliant.
+
+---
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Resolved | `TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` | whole file | Prior-cycle Major (687 lines, over 500-line limit) is resolved by the remediation split: now 483 lines. | None — resolved. | General Code Change Policy §4 500-line limit now satisfied. | `awk 'END{print NR}'` at HEAD = 483; new split file `ApplicationGlobalsStartupTimingTests.cs` = 299; `evidence/qa-gates/post-split-linecounts.2026-06-15T13-29.md`. |
+| Resolved | (build/process) | `artifacts/csharp/coverage.xml` | Prior-cycle Minor (canonical C# coverage artifact absent) is resolved; the artifact is present. | None — resolved. | Workflow names this artifact; it now exists and parses to the verified figures. | `ls -la artifacts/csharp/coverage.xml` -> present (21,499,084 bytes); `evidence/qa-gates/coverage-artifact-copy.2026-06-15T13-29.md`. |
+| Minor | `TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs` | `[DoNotParallelize]` wiring tests | Tests mutate process-global `Settings.Default.StartupTimingEnabled` and attach an appender to the process-global log4net logger. | None required — `[DoNotParallelize]` markers and `[TestInitialize]`/`[TestCleanup]` save/restore are preserved in the split file, isolating the global state. Keep this pattern intact in future edits. | Shared-global-state pattern; mitigated but worth noting. | Lines 21-41, 43-47 of the split file; `DetachMemoryAppender` in `finally` blocks. |
+| Info | `TaskMaster/AppGlobals/ApplicationGlobals.cs` | `LoadAsync` parallel branch | On the `parallel: true` path only LoadBasic is recorded; `EmitTable` would emit a single-row table when the flag is on. | None required — `LoadAsync(parallel: true)` / `LoadParallelAsync` instrumentation is an explicit user-story Non-Goal; the startup entry point uses `parallel: false`. | Confirms scope boundary is intentional. | `user-story.md` Non-Goals; diff of `LoadParallelAsync` (unchanged). |
+| Info | `TaskMaster/AppGlobals/ApplicationGlobals.cs` | `protected internal virtual LoadBasicMethod` | Visibility widened from `private` to `protected internal virtual` to provide a test seam. | None — minimal, documented seam; production behavior unchanged. | Confirms the API-surface change is a deliberate, narrow test seam. | Diff + inline comment; `TestableApplicationGlobals` override in the split file. |
+
+No Blocker findings. No Major findings.
+
+---
+
+## Implementation Audit
+
+### C# implementation audit
+
+#### What changed well
+
+- Clean separation of concerns: pure recording/formatting (`StartupTimingRecorder`) is fully decoupled from the COM-bound `ApplicationGlobals` coordinator and has no Outlook/COM/filesystem/network dependency, making it unit-testable without a live Outlook process.
+- The recorder deliberately does not wrap `SegmentStopWatch.GetDurations()` and documents why (its TOTAL derives from the watch's own `Elapsed`, which is zero for injected spans), while still reusing the existing `PrettyPrinters.ToFormattedText` alignment primitive rather than reimplementing column layout. This is a sound reuse-vs-correctness tradeoff with a clear rationale comment.
+- The Null Object pattern (`NullStartupTimingRecorder`) lets the coordinator record and emit unconditionally, keeping the flag-off path branch-free at the call sites and guaranteeing zero output when disabled.
+- `Stopwatch` is used for measurement, explicitly avoiding the BannedApiAnalyzers `DateTime.Now`/`UtcNow` rule, and the shared-stopwatch `StopAndRestart` helper cleanly excludes the inter-phase yields from per-phase timing.
+- The LoadBasic-at-construction measurement subtlety (the `BasicLoaded` Lazy materializes before `LoadAsync`) is correctly handled by measuring inside `LoadBasicMethod` and recording the stored elapsed as the first phase, with a comment explaining why measuring in `LoadAsync` would record ~0.
+
+#### Remediation quality (this cycle)
+
+- The test-file split is a pure move: the four `[DoNotParallelize]` wiring tests plus the helpers `SetEnginesMock`, `AttachMemoryAppender`, `DetachMemoryAppender`, and the timing-only members of `TestableApplicationGlobals` (the `TimingRecorder` observation seam and the `LoadBasicMethod` override) were moved into the new file, and the now-unused `using` directives were removed from the original. The original retained tests use `LoadSequentialAsync`/`InitializeEnginesPhaseAsync` rather than `LoadAsync`, so the moved seam members were genuinely unused there. The split file re-establishes the necessary `using` directives, the settings save/restore, and the `[DoNotParallelize]` markers. No test was deleted or weakened; the suite count remains 4194 (`qa-test.2026-06-15T13-29.md`).
+
+#### Type safety and API notes
+
+- Nullable reference types respected; `RecordPhase` and `EmitTable` guard null inputs with `ArgumentNullException` and explicit `nameof`. The nullable/TreatWarningsAsErrors build passes (EXIT_CODE 0).
+- New public-ish surface is minimized: recorder types are `internal sealed`, exposed to tests only via the existing `InternalsVisibleTo`. The one widened member (`LoadBasicMethod` to `protected internal virtual`) is a documented test seam.
+- XML doc comments on the interface and classes state contracts and the COM-free guarantee.
+
+#### Error handling and logging
+
+- Logging uses the existing `ApplicationGlobals` log4net logger via `logger.Info(...)` with the `[Startup timing]` prefix, consistent with the prior #139/#141 entries. No new logging channel introduced.
+- Fail-fast on null arguments; no broad catches added. The emission is a single `Info` call at end of `LoadAsync`, so a flag-on run produces exactly one table.
+
+---
+
+## Test Quality Audit
+
+The change is covered by 11 MSTest tests (7 recorder, 4 wiring) using MSTest + Moq + FluentAssertions per the C# Unit Test Policy. Recorder tests inject deterministic spans (no clock/sleep). Wiring tests drive `LoadAsync` end-to-end through `TestableApplicationGlobals`, asserting flag-off no-emit, flag-on phase order with LoadBasic first, exactly-one-table emission with all phase names and TOTAL, and ordering/yield-count parity between flag on and off. New-code line coverage is 100%; the modified `ApplicationGlobals` class improved from 74.4% (99/133) baseline to 77.9% (120/154) with no regression on changed lines.
+
+### Reviewed test and QA artifacts
+
+- `TaskMaster.Test/AppGlobals/StartupTimingRecorderTests.cs` (184 lines) — recorder ordering, zero-duration, summed TOTAL, null-name/null-logger throws, emit prefix, null-recorder no-op. Deterministic, isolated.
+- `TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` (483 lines) — retained pre-existing tests; reduced below the 500-line limit by the split.
+- `TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs` (299 lines) — flag-on/off wiring via a process-local `MemoryAppender`; `[DoNotParallelize]` + settings save/restore. Correct and within the size limit.
+- `evidence/qa-gates/qa-test.2026-06-15T13-29.md` — 4194/4194 pass; numeric coverage; confirms the four wiring tests pass under the new class.
+- `evidence/qa-gates/coverage-delta.2026-06-15T13-29.md` — split did not reduce coverage; figures equal baseline within rounding.
+- `artifacts/csharp/coverage.xml` — parsed directly: root line-rate 0.7637; new recorder classes 100% (48/48, 10/10); `ApplicationGlobals` class 120/154.
+
+### Quality assessment prompts
+
+- **Determinism:** No real clock or sleep; all spans injected; appender read in-process.
+- **Isolation:** Each test targets one behavior; shared-global tests marked `[DoNotParallelize]` and restore state.
+- **Speed:** No timing waits; full suite reported green with EXIT_CODE 0 (~48 s).
+- **Diagnostics:** FluentAssertions with `because` rationale strings yield actionable failure messages.
+
+---
+
+## Security / Correctness Checks
+
+| Check | Status | Evidence |
+|---|---|---|
+| No secrets in code | PASS | Diff inspection: no credentials, tokens, or connection strings. |
+| No unsafe subprocess or command construction | PASS | No process invocation introduced. |
+| Input validation at boundaries | PASS | `RecordPhase`/`EmitTable` validate null arguments and throw. |
+| Error handling remains explicit | PASS | Fail-fast null guards; no broad catches; single explicit log emission. |
+| Configuration / path handling is safe | PASS | New setting is a typed boolean user setting (default False); no path construction. |
+| Banned-API compliance | PASS | `Stopwatch` used; no `DateTime.Now`/`UtcNow`/`Random.Shared`/`Thread.Sleep`/`Task.Delay` call sites introduced (diff scan matched only a comment). |
+
+---
+
+## Research Log
+
+No external research was required. The review relied on the branch diff, the feature-folder evidence artifacts, the parsed canonical Cobertura artifact `artifacts/csharp/coverage.xml`, the baseline `TestResults/baseline-full.cobertura.xml`, the prior-cycle review artifacts, and the repository policy documents (CLAUDE.md, `.claude/rules/*`).
+
+---
+
+## Verdict
+
+The implementation is correct, well-structured, well-documented, and well-tested: COM-free recorder abstraction, Null Object for the flag-off path, deliberate formatter reuse, banned-API avoidance, 100% new-code coverage, and no coverage regression, with a clean four-step toolchain pass. Both findings from the prior review are resolved: the test-file size violation is fixed by a pure split (483 + 299 lines, both under 500), and the canonical `artifacts/csharp/coverage.xml` is present. No Blocker or Major findings remain; the two residual items are Minor/Info and require no action. Recommendation: **Ready for merge.**

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/analyzer-baseline.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/analyzer-baseline.2026-06-15T12-15.md
@@ -1,0 +1,15 @@
+# Phase 0 — Analyzer (Lint) Build Baseline (Issue #202)
+
+Timestamp: 2026-06-15T12-15
+
+Command: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
+
+EXIT_CODE: 0
+
+Output Summary: Build succeeded. 0 Error(s), 62 Warning(s). A NuGet package restore was
+required first (`nuget restore TaskMaster.sln`; 168 packages installed to `packages/`) because
+the worktree had no restored packages; restore is environment setup, not a source change. The
+62 warnings are pre-existing baseline diagnostics, predominantly CS8632 (nullable annotation
+outside a `#nullable` context) and CS0067 (unused event) in the test projects (notably
+`UtilitiesCS.Test`). These warnings are not promoted to errors in this analyzer-only build
+(no `TreatWarningsAsErrors`). Baseline build state: PASS with pre-existing warnings.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/format-baseline.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/format-baseline.2026-06-15T12-15.md
@@ -1,0 +1,9 @@
+# Phase 0 — CSharpier Format Baseline (Issue #202)
+
+Timestamp: 2026-06-15T12-15
+
+Command: `csharpier check .` (CSharpier v1.3.0; plan prose names `--check`, which maps to the `check` subcommand in this CSharpier version)
+
+EXIT_CODE: 0
+
+Output Summary: Clean. `Checked 1054 files in 1535ms.` No formatting differences reported; the working tree is already CSharpier-clean. No source files were modified by this task.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/phase0-instructions-read.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/phase0-instructions-read.2026-06-15T12-15.md
@@ -1,0 +1,18 @@
+# Phase 0 — Policy Read Evidence (Issue #202)
+
+Timestamp: 2026-06-15T12-15
+
+Policy Order: Applied per `.claude/skills/policy-compliance-order/SKILL.md`, in the
+mandatory precedence order for C# work in this repository.
+
+Files read in order:
+
+1. `CLAUDE.md` (standing instructions, always loaded) — project guidelines, policy compliance order, General Code Change Policy, General Unit Test Policy, C# Code Change Policy, C# Unit Test Policy, tone policy, C# toolchain order.
+2. `.claude/rules/general-code-change.md` — cross-language code change policy (design principles, mandatory toolchain loop, 500-line file limit, error handling, naming, I/O boundaries).
+3. `.claude/rules/general-unit-test.md` — cross-language unit test policy (independence, isolation, determinism, coverage floors 80% repo / 90% new code, AAA structure, no temp files, no external deps).
+4. `.claude/rules/csharp.md` — C# toolchain (csharpier, msbuild analyzers, nullable/TreatWarningsAsErrors, vstest /EnableCodeCoverage), coding standards, testing standards (MSTest + Moq + FluentAssertions), analyzer stack (Issue #181), banned APIs (DateTime.Now, DateTime.UtcNow, Random.Shared, Thread.Sleep, Task.Delay), prohibited behaviors.
+
+Supporting feature inputs reviewed: `spec.md`, `issue.md`, `user-story.md`, and the plan
+`plan.2026-06-15T12-15.md`.
+
+No production code was modified before this task completed.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/phase0-instructions-read.2026-06-15T13-29.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/phase0-instructions-read.2026-06-15T13-29.md
@@ -1,0 +1,22 @@
+# Phase 0 — Policy Read Evidence (Issue #202, Remediation Cycle 2026-06-15T13-29)
+
+Timestamp: 2026-06-15T13-29
+
+Policy Order: per `policy-compliance-order` — (1) CLAUDE.md, (2) `.claude/rules/general-code-change.md`, (3) `.claude/rules/general-unit-test.md`, (4) language-specific `.claude/rules/csharp.md`.
+
+Files read (in mandatory order):
+
+1. `CLAUDE.md`
+2. `.claude/rules/general-code-change.md`
+3. `.claude/rules/general-unit-test.md`
+4. `.claude/rules/csharp.md`
+
+Summary: All four policy files were read in the mandatory order before any execution.
+This remediation cycle performs a pure mechanical test-file split (no production-code
+change, no assertion or test-intent change) plus a non-blocking coverage-artifact copy.
+Applicable constraints: 500-line file-size limit (General Code Change Policy §4),
+CSharpier-only formatting, .NET analyzers + nullable/TreatWarningsAsErrors gates,
+MSTest + Moq + FluentAssertions, vstest with `/EnableCodeCoverage`, banned APIs
+(`DateTime.Now/UtcNow`, `Thread.Sleep`, `Task.Delay`, `Random.Shared`), no temp files
+in tests, preserve `[DoNotParallelize]` and `Settings.Default.StartupTimingEnabled`
+save/restore.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/test-coverage-baseline.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/test-coverage-baseline.2026-06-15T12-15.md
@@ -1,0 +1,37 @@
+# Phase 0 — MSTest Test + Coverage Baseline (Issue #202)
+
+Timestamp: 2026-06-15T12-15
+
+Command: `vstest.console.exe UtilitiesCS.Test\bin\Debug\UtilitiesCS.Test.dll TaskMaster.Test\bin\Debug\TaskMaster.Test.dll QuickFiler.Test\bin\Debug\QuickFiler.Test.dll Tags.Test\bin\Debug\Tags.Test.dll TaskVisualization.Test\bin\Debug\TaskVisualization.Test.dll ToDoModel.Test\bin\Debug\ToDoModel.Test.dll VBFunctions.Test\bin\Debug\VBFunctions.Test.dll /Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation /ResultsDirectory:TestResults/baseline-full`
+
+EXIT_CODE: 0
+
+Output Summary:
+
+- Total tests: 4183. Passed: 4183. Failed: 0.
+- The plan (P0-T5) requires "at minimum the TaskMaster.Test assembly". All seven first-party
+  test assemblies were run together so the repository-wide line-coverage figure is meaningful
+  and directly comparable to the Phase 5 post-change run. (A TaskMaster.Test-only run was also
+  executed and passed: 91/91.)
+- `/InIsolation` was used because the Moq-based test assemblies require the isolated test host
+  (prior incident: STTE Setup FileNotFound without `/InIsolation`).
+
+Numeric coverage (from merged Cobertura `TestResults/baseline-full.cobertura.xml`,
+computed with `scripts/temp-cov-202.ps1` / `scripts/temp-cov-file-202.ps1`):
+
+- Raw overall Cobertura line-rate (all packages incl. third-party + vendored + test assemblies):
+  76.30% (lines-covered 96957 / lines-valid 127076). This raw figure is not the policy metric;
+  it is recorded for traceability only.
+- First-party production-only line coverage (packages QuickFiler, Tags, TaskMaster,
+  TaskVisualization, ToDoModel, UtilitiesCS, VBFunctions; deduped by file+line; excludes test
+  assemblies and the vendored SVGControl / Swordfish.NET.General packages): 75.08%
+  (36372 / 48447 lines). Note: this denominator still INCLUDES the COM/VSTO/WinForms-bound and
+  `[ExcludeFromCodeCoverage]`-exempt classes that CLAUDE.md formally exempts from the 80% floor;
+  the policy floor applies to the testable denominator after those exemptions. This baseline
+  figure is recorded as the comparison point for no-regression on changed lines.
+- `ApplicationGlobals` primary class line-rate: 74.24% (Cobertura `line-rate` on
+  `TaskMaster.ApplicationGlobals`).
+- `ApplicationGlobals.cs` aggregate line coverage (primary class + compiler-generated async
+  state machines in the same file, deduped by line): 60.75% (65 / 107 lines).
+
+All coverage values are numeric (no placeholders). Baseline test state: PASS.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/typecheck-baseline.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/typecheck-baseline.2026-06-15T12-15.md
@@ -1,0 +1,13 @@
+# Phase 0 — Nullable / TreatWarningsAsErrors Type-Check Baseline (Issue #202)
+
+Timestamp: 2026-06-15T12-15
+
+Command: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`
+
+EXIT_CODE: 0
+
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). No nullable-flow or other
+diagnostics were promoted to errors under `/p:TreatWarningsAsErrors=true`. The protected
+nullable gate is green on the unmodified baseline. (This was an incremental build on top of
+the analyzer-baseline output; the first-party projects compiled clean under the nullable gate.)
+Baseline type-check state: PASS.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/issue-updates/ac-checkoff.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/issue-updates/ac-checkoff.2026-06-15T12-15.md
@@ -1,0 +1,49 @@
+# Phase 5 — Acceptance Criteria Check-off Mapping (Issue #202)
+
+Timestamp: 2026-06-15T12-15
+
+AC sources (Work Mode: full-feature): `spec.md` and `user-story.md` `## Acceptance Criteria`
+sections (mirrored from `issue.md` `## Acceptance Criteria (early draft)`).
+
+Each AC is marked PASS only when its implementation and verification tasks completed and the
+corresponding evidence exists.
+
+## AC-to-task mapping
+
+| AC | Description | Impl tasks | Verify tasks | Status |
+|---|---|---|---|---|
+| AC1 | Flag enables/disables; no change when off | P1-T1, P1-T2, P3-T3, P3-T4, P3-T6 | P4-T2, P4-T5 | PASS |
+| AC2 | Per-sub-component elapsed captured when on | P3-T4, P3-T5 | P4-T3 | PASS |
+| AC3 | Formatted table with TOTAL emitted after startup | P2-T2, P3-T6 | P2-T7, P4-T4 | PASS |
+| AC4 | Testable recorder, >= 90% new-code coverage | P2-T1, P2-T2, P2-T3 | P2-T4..P2-T8, P5-T4, P5-T5 | PASS |
+| AC5 | Existing logging/deps only, no functional change | P2-T2, P3-T6 | P4-T5, P5-T2, P5-T3 | PASS |
+
+## Evidence per AC
+
+- AC1: `StartupTimingEnabled` setting added (`Settings.settings` / `Settings.Designer.cs`);
+  `ApplicationGlobals.LoadAsync` reads the flag once and selects concrete vs no-op recorder
+  (phase3-toolchain artifact). Verified by `LoadAsync_WhenTimingDisabled_RecordsNothingAndEmitsNoTable`
+  and `LoadAsync_PreservesPhaseOrderingAndYieldCount_WhenTimingOnVersusOff`
+  (phase4-toolchain artifact). PASS.
+- AC2: LoadBasic measured via Stopwatch; six sequential phases measured/recorded in order
+  (phase3-toolchain). Verified by
+  `LoadAsync_WhenTimingEnabled_RecordsAllPhasesInStartupOrderWithLoadBasicFirst` asserting the
+  recorded sequence `["LoadBasic","IntelConfig","OlObjects","ToDo","AutoFile","Engines","Events"]`
+  (phase4-toolchain). PASS.
+- AC3: `StartupTimingRecorder.FormatTable` builds the table via `PrettyPrinters.ToFormattedText`
+  with a summed TOTAL row; `EmitTable` logs it with the `[Startup timing]` prefix at the end of
+  `LoadAsync` (phase2/phase3 artifacts). Verified by
+  `FormatTable_ContainsHeadersPhaseNamesAndTotalEqualToSumOfInjectedSpans` and
+  `LoadAsync_WhenTimingEnabled_EmitsExactlyOneTableWithPhaseNamesAndTotal`
+  (phase2/phase4 artifacts). PASS.
+- AC4: Recorder is a pure unit with no Outlook/COM/filesystem/network dependency; 7 recorder
+  tests; new-code coverage 100% (>= 90%) per final-test-coverage and coverage-delta artifacts.
+  PASS.
+- AC5: Uses existing `log4net` logger, `PrettyPrinters.ToFormattedText`, and
+  `System.Diagnostics.Stopwatch` (no new dependencies); no `DateTime.Now`/`UtcNow`/`Thread.Sleep`/
+  `Task.Delay`/`Random.Shared`. No functional startup change verified by the phase-ordering /
+  yield-count regression guard `LoadAsync_PreservesPhaseOrderingAndYieldCount_WhenTimingOnVersusOff`
+  and the unchanged source-text COM-thread / yield regression tests, plus green analyzer
+  (final-analyzer) and nullable (final-typecheck) gates. PASS.
+
+All five acceptance criteria: PASS.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/issue-updates/issue-202.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/issue-updates/issue-202.2026-06-15T12-15.md
@@ -1,0 +1,44 @@
+# Issue Update Mirror — #202 Acceptance Criteria Verified
+
+Timestamp: 2026-06-15T12-15
+
+PostedAs: unknown
+
+Note: This is a local mirror of the acceptance-criteria status update produced during plan
+execution. It was not posted to GitHub by the executor (no posting step is in the plan; posting
+is a downstream orchestration/PR step). If/when posted, update `PostedAs` and the GitHub URL.
+
+## Acceptance Criteria — Verified Status
+
+All five acceptance criteria are verified and checked off in `issue.md`, `spec.md`, and
+`user-story.md`:
+
+- [x] AC1 — A flag exists that enables or disables startup timing instrumentation; when disabled
+  there is no behavioral or output change to startup.
+- [x] AC2 — When enabled, each startup sub-component's elapsed wall-clock time is captured during
+  startup.
+- [x] AC3 — When enabled, a formatted plain-text table of sub-component names and elapsed times
+  (plus a total row) is emitted after startup completes.
+- [x] AC4 — The timing recorder/formatter is a testable unit (no Outlook/COM dependency) with
+  MSTest coverage meeting the repository floor for new code (100% >= 90%).
+- [x] AC5 — Instrumentation uses existing logging/output infrastructure and existing approved
+  dependencies; it does not change functional startup behavior.
+
+## Implementation summary
+
+- New user setting `StartupTimingEnabled` (default `False`).
+- New internal `IStartupTimingRecorder` with `StartupTimingRecorder` (own ordered span
+  collection; reuses `PrettyPrinters.ToFormattedText`; summed TOTAL) and `NullStartupTimingRecorder`.
+- `ApplicationGlobals.LoadAsync` reads the flag once, records `LoadBasic` (Stopwatch-measured at
+  construction) plus the six sequential phases, and emits one `[Startup timing]` table via the
+  log4net logger at the end of startup. No parallel-path instrumentation (out of scope).
+
+## Verification
+
+- Final toolchain (single clean pass): csharpier check (0), analyzer build (0 errors), nullable
+  + TreatWarningsAsErrors build (0/0), full test suite 4194/4194 with coverage.
+- New-code coverage 100% (>= 90%); repo-wide first-party coverage 75.12% (baseline 75.08%, no
+  regression; metric below 80% reflects pre-existing COM/VSTO-exempt denominator per CLAUDE.md).
+
+See: `evidence/qa-gates/final-*.2026-06-15T12-15.md`, `evidence/qa-gates/coverage-delta.2026-06-15T12-15.md`,
+`evidence/issue-updates/ac-checkoff.2026-06-15T12-15.md`.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/other/timing-recorder-format-reuse.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/other/timing-recorder-format-reuse.2026-06-15T12-15.md
@@ -1,0 +1,56 @@
+# Design Resolution — Startup Timing Recorder Table-Format Reuse (Issue #202)
+
+Timestamp: 2026-06-15T12-15
+
+Preconditions reviewed:
+- `UtilitiesCS/HelperClasses/SegmentStopWatch.cs` (reviewed)
+- `UtilitiesCS/HelperClasses/PrettyPrint.cs` (reviewed)
+
+## Selected design (no alternatives)
+
+`StartupTimingRecorder` maintains its OWN ordered collection of
+`(string phaseName, TimeSpan elapsed)` pairs in insertion order. It does NOT wrap or call
+`SegmentStopWatch`.
+
+## Verified reason for not wrapping SegmentStopWatch
+
+`SegmentStopWatch.GetDurations()` (`UtilitiesCS/HelperClasses/SegmentStopWatch.cs` line 90)
+builds the TOTAL row from the watch's own `this.Elapsed`:
+
+```csharp
+_durations.Push(("TOTAL", this.Elapsed));
+```
+
+`this.Elapsed` is the elapsed time of the `Stopwatch` base class. For a recorder that is fed
+PRE-MEASURED, injected `TimeSpan` spans (as required for deterministic unit testing without a
+live Outlook process), the watch is never started/stopped, so `this.Elapsed` is
+`TimeSpan.Zero`. Wrapping `SegmentStopWatch` for injected spans would therefore yield an
+always-zero TOTAL row, which is unsatisfiable against AC3 (TOTAL must reflect aggregate
+elapsed time) and P2-T7 (TOTAL must equal the sum of injected spans). The recorder instead
+computes its TOTAL as the SUM of all recorded spans.
+
+## Reused formatting primitive (genuinely reusable)
+
+`UtilitiesCS.HelperClasses.PrettyPrinters.ToFormattedText(this string[][] jagged, string[] headers = null, Enums.Justification[] justifications = default, string title = null)`
+defined in `UtilitiesCS/HelperClasses/PrettyPrint.cs` lines 179-184.
+
+This is the same jagged `string[][]` overload that `SegmentStopWatch.GetDurations` calls
+(`SegmentStopWatch.cs` lines 103-107). The recorder reuses this primitive for column
+alignment and does NOT reimplement column alignment.
+
+Note on resolved namespace: although `PrettyPrinters` is documented in some prose with a
+`UtilitiesCS.HelperClasses` label, the class is actually declared in `namespace UtilitiesCS`
+(see `PrettyPrint.cs` line 7). The extension method resolves via `using UtilitiesCS;`. The
+`Enums.Justification` enum is `UtilitiesCS.Enums.Justification` (`UtilitiesCS/Interfaces/Enums.cs`).
+
+## Call convention
+
+`FormatTable()` invokes the primitive with:
+- headers: `["Duration", "Action"]`
+- justifications: `[Enums.Justification.Right, Enums.Justification.Left]`
+
+consistent with the existing `SegmentStopWatch.GetDurations` convention. One row is emitted per
+recorded phase, followed by a final `TOTAL` row whose duration equals the SUM of all recorded
+spans.
+
+No production code was modified by this task.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/coverage-artifact-copy.2026-06-15T13-29.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/coverage-artifact-copy.2026-06-15T13-29.md
@@ -1,0 +1,25 @@
+# Coverage Artifact Copy (Finding 2, Non-Blocking) (Issue #202, P3-T1/P3-T2)
+
+Timestamp: 2026-06-15T13-29
+
+Command: `cp TestResults/remed-final.cobertura.xml artifacts/csharp/coverage.xml`
+
+EXIT_CODE: 0
+
+Output Summary:
+
+- Source: `TestResults/remed-final.cobertura.xml` (the merged Cobertura produced from the P2-T4
+  test run via `dotnet-coverage merge -f cobertura`).
+- Destination: `artifacts/csharp/coverage.xml` (workflow process artifact consumed by the
+  feature-review-workflow contract; `artifacts/` is gitignored, so this file is for local /
+  process use only and is not committed).
+- Figure parity confirmed: the destination parses to the same figures recorded in P2-T4 —
+  raw overall line-rate 76.37%, `TaskMaster.ApplicationGlobals` 77.63%,
+  `TaskMaster.StartupTimingRecorder` 100%, `TaskMaster.NullStartupTimingRecorder` 100%.
+
+Note on evidence path: `artifacts/csharp/coverage.xml` is a workflow report file, not an
+evidence artifact under the `<FEATURE>/evidence/` scheme; per the plan's Evidence Location
+Notice it is written to its workflow-named location. This recording of the copy action is the
+canonical evidence artifact and resides under `<FEATURE>/evidence/qa-gates/`.
+
+Finding 2 (non-blocking) is closed.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/coverage-delta.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/coverage-delta.2026-06-15T12-15.md
@@ -1,0 +1,47 @@
+# Phase 5 — Coverage Delta / Threshold Verification (Issue #202)
+
+Timestamp: 2026-06-15T12-15
+
+Sources:
+- Baseline: `evidence/baseline/test-coverage-baseline.2026-06-15T12-15.md`
+  (Cobertura `TestResults/baseline-full.cobertura.xml`)
+- Post-change: `evidence/qa-gates/final-test-coverage.2026-06-15T12-15.md`
+  (Cobertura `TestResults/final-full.cobertura.xml`)
+
+Both runs used the identical set of all seven first-party test assemblies under
+`/Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation`, so the figures are directly
+comparable.
+
+## Coverage comparison
+
+| Metric | Baseline | Post-change | Delta |
+|---|---|---|---|
+| Tests passed | 4183 / 4183 | 4194 / 4194 | +11 tests, 0 failures |
+| Raw overall line-rate (all packages) | 76.30% | 76.36% | +0.06 |
+| First-party production-only line coverage | 75.08% (36372/48447) | 75.12% (36436/48504) | +0.04 |
+| New recorder `StartupTimingRecorder.cs` | n/a (new) | 100% (30/30) | — |
+| `ApplicationGlobals.cs` aggregate (full suite) | 60.75% (65/107) | 73.88% (99/134) | +13.13 |
+
+## Threshold checks
+
+- Repository-wide line coverage remains within the established repo state. The first-party
+  production-only figure is 75.12%, IMPROVED from the 75.08% baseline (delta +0.04). This metric
+  is below the literal 80% number, but the denominator INCLUDES the COM/VSTO/WinForms-bound and
+  `[ExcludeFromCodeCoverage]`-exempt classes that CLAUDE.md formally exempts from the 80% floor
+  (the floor applies to the testable denominator after exemptions). This is a PRE-EXISTING repo
+  condition, not introduced or worsened by #202; the feature improves the figure. Outcome: NO
+  REGRESSION.
+- New recorder classes (`StartupTimingRecorder`, `NullStartupTimingRecorder`) reach 100% line
+  coverage, exceeding the >= 90% new-code floor. PASS.
+- Changed `ApplicationGlobals` lines show NO coverage regression: aggregate file coverage rose
+  from 60.75% to 73.88%. Every NEW timing-instrumentation line (flag read, recorder selection,
+  LoadBasic Stopwatch measurement, per-phase recording in LoadSequentialAsync, StopAndRestart
+  helper, EmitTable call) is covered by the new tests. The only uncovered lines in the changed
+  region are the PRE-EXISTING parallel-startup branch and `LoadParallelAsync` body, which are
+  explicitly OUT OF SCOPE (user-story Non-Goals) and were uncovered in the baseline. PASS.
+
+## Outcome
+
+PASS. New-code coverage floor met (100% >= 90%); repository-wide coverage not regressed
+(+0.04 first-party, +0.06 raw); changed-line coverage not regressed (improved). All required
+numeric values are present (no placeholders).

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/coverage-delta.2026-06-15T13-29.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/coverage-delta.2026-06-15T13-29.md
@@ -1,0 +1,27 @@
+# Coverage Delta Verification (Issue #202, P2-T5)
+
+Timestamp: 2026-06-15T13-29
+
+Comparison of Phase 0 baseline (P0-T4) vs Phase 2 post-change (P2-T4). This cycle is a pure
+mechanical test-file split with no production-code change, so coverage is expected to be
+identical within rounding.
+
+| Metric | Baseline (P0-T4) | Post-change (P2-T4) | Delta | Determination |
+|---|---|---|---|---|
+| Raw overall Cobertura line-rate | 76.36% | 76.37% | +0.01 | PASS (no regression) |
+| First-party production-only deduped | 75.12% (36436/48504) | 75.12% (36436/48504) | 0.00 | PASS (no regression) |
+| `TaskMaster.ApplicationGlobals` class | 77.63% | 77.63% | 0.00 | PASS |
+| New-code `StartupTimingRecorder` | 100% | 100% | 0.00 | PASS (>= 90%) |
+| New-code `NullStartupTimingRecorder` | 100% | 100% | 0.00 | PASS (>= 90%) |
+| Passing test count | 4194 | 4194 | 0 | PASS (>= 4194) |
+
+Threshold checks:
+- Repo-wide coverage >= 80% (against the CLAUDE.md exempt-adjusted testable denominator):
+  unchanged from baseline; the feature did not alter the exempt-adjusted figure and this cycle
+  changed only test files. The raw first-party figure (75.12%) is identical to baseline; the
+  COM/VSTO/WinForms-exempt-adjusted denominator is the policy floor target and is not regressed.
+- No regression on changed lines: the only changed lines are test-file relocations; production
+  line coverage is byte-for-byte identical (same covered/total line set, 36436/48504).
+- New-code coverage >= 90%: recorded 100% for both recorder classes.
+
+DETERMINATION: PASS. No regression. New-code floor met. Phase 1 rework not required.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/final-analyzer.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/final-analyzer.2026-06-15T12-15.md
@@ -1,0 +1,14 @@
+# Phase 5 — Final Analyzer Gate (Issue #202)
+
+Timestamp: 2026-06-15T12-15
+
+Command: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
+
+EXIT_CODE: 0
+
+Output Summary: Build succeeded. 0 Error(s). No new analyzer regressions introduced by the
+feature. The new production files (`IStartupTimingRecorder.cs`, `StartupTimingRecorder.cs`) and
+the wired `ApplicationGlobals.cs` produce zero analyzer diagnostics (verified across the phase
+gates). The only residual diagnostics anywhere in the touched test file are two pre-existing
+CS8632 warnings on the original `TestableApplicationGlobals` `IList<string>?` declarations, which
+predate this feature and are warnings (not errors) under the analyzer build. Analyzer gate green.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/final-format.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/final-format.2026-06-15T12-15.md
@@ -1,0 +1,12 @@
+# Phase 5 — Final Format Gate (Issue #202)
+
+Timestamp: 2026-06-15T12-15
+
+Command: `csharpier check .` (CSharpier v1.3.0; the policy `dotnet tool run csharpier .` maps to
+the globally-installed `csharpier` per the project's `.config/dotnet-tools.json` absence; the
+`check` subcommand is the v1.3.0 verification mode)
+
+EXIT_CODE: 0
+
+Output Summary: `Checked 1057 files`. No formatting differences; no files changed by the final
+run. Formatting gate green.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/final-test-coverage.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/final-test-coverage.2026-06-15T12-15.md
@@ -1,0 +1,36 @@
+# Phase 5 — Final Test + Coverage Gate (Issue #202)
+
+Timestamp: 2026-06-15T12-15
+
+Command: `vstest.console.exe UtilitiesCS.Test\bin\Debug\UtilitiesCS.Test.dll TaskMaster.Test\bin\Debug\TaskMaster.Test.dll QuickFiler.Test\bin\Debug\QuickFiler.Test.dll Tags.Test\bin\Debug\Tags.Test.dll TaskVisualization.Test\bin\Debug\TaskVisualization.Test.dll ToDoModel.Test\bin\Debug\ToDoModel.Test.dll VBFunctions.Test\bin\Debug\VBFunctions.Test.dll /Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation /ResultsDirectory:TestResults/final-full`
+
+EXIT_CODE: 0
+
+Output Summary:
+
+- Total tests: 4194. Passed: 4194. Failed: 0 (baseline 4183 + 11 new: 7 recorder tests + 4
+  wiring tests).
+- All seven first-party test assemblies were run together so the repository-wide coverage figure
+  is directly comparable to the Phase 0 baseline.
+
+Numeric coverage (from merged Cobertura `TestResults/final-full.cobertura.xml`):
+
+- Raw overall Cobertura line-rate (all packages incl. third-party + vendored + test assemblies):
+  76.36% (97291 / 127403). Baseline 76.30%. Delta +0.06. (Recorded for traceability; not the
+  policy metric.)
+- First-party production-only line coverage (packages QuickFiler, Tags, TaskMaster,
+  TaskVisualization, ToDoModel, UtilitiesCS, VBFunctions; deduped by file+line; excludes test
+  assemblies and vendored SVGControl / Swordfish.NET.General): 75.12% (36436 / 48504).
+  Baseline 75.08%. Delta +0.04 (no regression). This denominator still INCLUDES the
+  COM/VSTO/WinForms-bound classes that CLAUDE.md formally exempts from the 80% floor; the
+  exempt-adjusted testable denominator is not separately recomputed here, but the figure is
+  not regressed by this feature.
+- New recorder `StartupTimingRecorder.cs` line coverage: 100% (30 / 30). Meets the >= 90%
+  new-code floor.
+- `ApplicationGlobals.cs` aggregate line coverage (full suite): 73.88% (99 / 134). Baseline
+  (full suite) 60.75% (65 / 107). Up +13.13 points. (The TaskMaster.Test-only post-change figure
+  was 70.9%; the full suite additionally exercises the parallel-path async state machines.)
+- `TaskMaster.ApplicationGlobals` aggregate-by-name (includes nested compiler-generated types):
+  90.19% (570 / 632) per the name-aggregate computation.
+
+Test gate green; coverage thresholds for new code met; no repo-wide regression.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/final-typecheck.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/final-typecheck.2026-06-15T12-15.md
@@ -1,0 +1,15 @@
+# Phase 5 — Final Type-Check (Nullable) Gate (Issue #202)
+
+Timestamp: 2026-06-15T12-15
+
+Command: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`
+
+EXIT_CODE: 0
+
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). No promoted-warning errors. Run in the
+established way for this repo's legacy toolchain (a plain Debug build keeps all project outputs
+current so the global `/p:Nullable=enable` override is not force-applied to legacy/vendored
+projects that do not opt into nullable; the incremental nullable Build then validates and passes
+0/0). Diagnostic force-recompiles during the implementation phases confirmed every NEW file
+(`IStartupTimingRecorder.cs`, `StartupTimingRecorder.cs`) and the wired `ApplicationGlobals.cs`
+are nullable-clean (zero CS8xxx). Type-check gate green.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/phase1-toolchain.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/phase1-toolchain.2026-06-15T12-15.md
@@ -1,0 +1,35 @@
+# Phase 1 — Toolchain Gate (Settings Flag) (Issue #202)
+
+Timestamp: 2026-06-15T12-15
+
+All four steps passed in a single pass (no restart required).
+
+## Step 1 — Format
+
+Command: `csharpier format .` (CSharpier v1.3.0)
+EXIT_CODE: 0
+Output Summary: `Formatted 1054 files in 1723ms.` Re-run `csharpier check .` returned clean
+(`Checked 1054 files`, EXIT 0), confirming idempotence. The only source delta is the added
+`StartupTimingEnabled` generated property (12 insertions in `Settings.Designer.cs`).
+
+## Step 2 — Analyzer (Lint) Build
+
+Command: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
+EXIT_CODE: 0
+Output Summary: Build succeeded. 0 Error(s), 31 Warning(s) (pre-existing baseline diagnostics,
+unchanged in kind from the Phase 0 analyzer baseline).
+
+## Step 3 — Nullable / TreatWarningsAsErrors Build
+
+Command: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`
+EXIT_CODE: 0
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). Protected nullable gate green.
+
+## Step 4 — Test + Coverage
+
+Command: `vstest.console.exe TaskMaster.Test\bin\Debug\TaskMaster.Test.dll /Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation /ResultsDirectory:TestResults/p1`
+EXIT_CODE: 0
+Output Summary: Total tests 91, Passed 91, Failed 0. The Phase 1 change is settings-only
+(new `StartupTimingEnabled` user setting + generated property); no new production logic is
+introduced in this phase, so no new tests are added here. Recorder/wiring coverage is delivered
+in Phases 2 and 4.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/phase2-toolchain.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/phase2-toolchain.2026-06-15T12-15.md
@@ -1,0 +1,55 @@
+# Phase 2 — Toolchain Gate (Recorder Abstraction) (Issue #202)
+
+Timestamp: 2026-06-15T12-15
+
+All four steps passed in a single final pass. The loop was restarted twice earlier in the
+phase: once after adding production-`EmitTable`/null-guard tests to lift new-code coverage to
+the >= 90% floor, and once after removing a `object?` nullable annotation that triggered CS8632
+in the non-nullable test project. The values below are from the final clean pass.
+
+## Step 1 — Format
+
+Command: `csharpier format .` (CSharpier v1.3.0)
+EXIT_CODE: 0
+Output Summary: `Formatted 1057 files`. Re-run `csharpier check .` returned clean (EXIT 0),
+confirming idempotence. New files: `TaskMaster/AppGlobals/IStartupTimingRecorder.cs`,
+`TaskMaster/AppGlobals/StartupTimingRecorder.cs` (contains `NullStartupTimingRecorder`),
+`TaskMaster.Test/AppGlobals/StartupTimingRecorderTests.cs`.
+
+## Step 2 — Analyzer (Lint) Build
+
+Command: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
+EXIT_CODE: 0
+Output Summary: Build succeeded. 0 Error(s). No analyzer diagnostics from the new recorder or
+test files (verified by grepping the verbose log for `StartupTimingRecorder`).
+
+## Step 3 — Nullable / TreatWarningsAsErrors Build
+
+Command: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`
+EXIT_CODE: 0
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s).
+
+Environment note (important): the policy nullable gate uses `/t:Build` (incremental). When the
+TaskMaster or vendored projects are FORCED to recompile under the global `/p:Nullable=enable`
+override, hundreds of PRE-EXISTING nullable violations surface across legacy code
+(AppOlObjects.cs, RibbonController.cs, etc.) and the vendored SVGControl / UtilitiesSwordfish
+projects that do not opt into nullable. These are pre-existing and out of scope for #202. A
+diagnostic force-recompile of the TaskMaster project confirmed the NEW recorder files
+(`IStartupTimingRecorder.cs`, `StartupTimingRecorder.cs`) produce ZERO nullable
+errors/warnings. The gate is run in the established way: a plain Debug build keeps all outputs
+current, then the nullable Build validates incrementally and passes 0/0.
+
+## Step 4 — Test + Coverage
+
+Command: `vstest.console.exe TaskMaster.Test\bin\Debug\TaskMaster.Test.dll /Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation /ResultsDirectory:TestResults/p2full`
+EXIT_CODE: 0
+Output Summary: Total tests 98, Passed 98, Failed 0 (91 pre-existing + 7 new recorder tests).
+
+New recorder classes' line coverage (from merged Cobertura `TestResults/p2.cobertura.xml`):
+
+- `StartupTimingRecorder.cs` aggregate (production `StartupTimingRecorder` +
+  `NullStartupTimingRecorder` + compiler-generated lambda class, deduped by line):
+  100% (29 / 29 lines). Target >= 90% met.
+- `TaskMaster.StartupTimingRecorder` class line-rate: 1.0 (100%).
+- `TaskMaster.NullStartupTimingRecorder` class line-rate: 1.0 (100%).
+- `IStartupTimingRecorder.cs`: interface declaration only; no executable lines.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/phase3-toolchain.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/phase3-toolchain.2026-06-15T12-15.md
@@ -1,0 +1,64 @@
+# Phase 3 — Toolchain Gate (ApplicationGlobals Wiring) (Issue #202)
+
+Timestamp: 2026-06-15T12-15
+
+All four steps passed in a single final pass.
+
+## Step 1 — Format
+
+Command: `csharpier format .` (CSharpier v1.3.0)
+EXIT_CODE: 0
+Output Summary: `Formatted 1057 files`. `csharpier check .` clean (EXIT 0). `ApplicationGlobals.cs`
+is 244 lines (< 500, satisfies P3-T7).
+
+## Step 2 — Analyzer (Lint) Build
+
+Command: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
+EXIT_CODE: 0
+Output Summary: Build succeeded. 0 Error(s). No analyzer diagnostics from the wired
+`ApplicationGlobals.cs` (verified by grepping the verbose log).
+
+## Step 3 — Nullable / TreatWarningsAsErrors Build
+
+Command: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`
+EXIT_CODE: 0
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). A diagnostic force-recompile of the
+TaskMaster project confirmed the wired `ApplicationGlobals.cs` produces ZERO nullable
+errors/warnings. Gate run in the established way (plain Debug build keeps outputs current, then
+incremental nullable Build passes 0/0).
+
+## Step 4 — Test + Coverage
+
+Command: `vstest.console.exe TaskMaster.Test\bin\Debug\TaskMaster.Test.dll /Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation /ResultsDirectory:TestResults/p3`
+EXIT_CODE: 0
+Output Summary: Total tests 98, Passed 98, Failed 0. The pre-existing source-text regression
+tests `LoadSequentialAsync_KeepsComPhasesOnCallerThreadAndYieldsBetweenHeavyPhases` and
+`LoadSequentialAsync_YieldsBeforeAutoFilePhase` both pass, as does the real-coordinator
+sequence test `LoadSequentialAsync_ExecutesRealCoordinatorSequenceThroughPhaseWrappers`.
+
+## Implementation notes (wiring)
+
+- `using TaskMaster.Properties;` added (P3-T1).
+- Private fields `_timingRecorder` (default `NullStartupTimingRecorder`) and `_loadBasicElapsed`
+  added (P3-T2).
+- `LoadAsync` reads `Settings.Default.StartupTimingEnabled` exactly once before the
+  sequential/parallel branch and selects the concrete recorder (recording `("LoadBasic",
+  _loadBasicElapsed)` first) or the no-op recorder; emits the table once via
+  `_timingRecorder.EmitTable(logger)` at the end of `LoadAsync` (P3-T3, P3-T4, P3-T6).
+- `LoadBasicMethod()` is instrumented unconditionally with a single `Stopwatch`, storing into
+  `_loadBasicElapsed` (P3-T4). Rationale documented in-code: the construction-time `BasicLoaded`
+  Lazy runs before `LoadAsync`.
+- `LoadSequentialAsync` records each of the six phases (IntelConfig, OlObjects, ToDo, AutoFile,
+  Engines, Events) in order via a shared `Stopwatch` (`StopAndRestart` helper) after each phase
+  await; yields are not recorded (P3-T5).
+
+### Pre-existing test adaptation (mechanically necessary for P3-T5)
+
+`LoadSequentialAsync_YieldsBeforeAutoFilePhase` previously asserted strict TEXTUAL adjacency of
+`await LoadToDoPhaseAsync(); await YieldBetweenStartupPhasesAsync(); await LoadAutoFilePhaseAsync();`.
+The planned per-phase instrumentation inserts a single `_timingRecorder.RecordPhase(...)` call
+after the ToDo await, which breaks textual adjacency without changing the ORDERING guarantee.
+The test's regex was updated to assert the same ToDo -> yield -> AutoFile ordering while
+tolerating the interleaved RecordPhase, and a tightened guard now asserts that ONLY a
+`_timingRecorder.RecordPhase(...)` statement may appear between the ToDo await and the yield.
+The behavioral intent (yield between ToDo and AutoFile) is preserved, not weakened.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/phase4-toolchain.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/phase4-toolchain.2026-06-15T12-15.md
@@ -1,0 +1,71 @@
+# Phase 4 — Toolchain Gate (ApplicationGlobals Wiring Tests) (Issue #202)
+
+Timestamp: 2026-06-15T12-15
+
+All four steps passed in a single final pass. The loop was restarted earlier in the phase to
+(a) add `using System.Linq;`, (b) remove a new `object?`/`List<string>?` nullable annotation that
+triggered CS8632, (c) add a `protected internal virtual LoadBasicMethod()` test seam so
+`LoadAsync` can be driven deterministically without live COM collaborator construction, and
+(d) add `[DoNotParallelize]` to the four new flag-mutating tests to remove a rare cross-class
+flake caused by the shared `Settings.Default` singleton and the process-global `ApplicationGlobals`
+log4net logger. Values below are from the final clean pass.
+
+## Step 1 — Format
+
+Command: `csharpier format .` (CSharpier v1.3.0)
+EXIT_CODE: 0
+Output Summary: `Formatted 1057 files`. `csharpier check .` clean (EXIT 0).
+
+## Step 2 — Analyzer (Lint) Build
+
+Command: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
+EXIT_CODE: 0
+Output Summary: Build succeeded. 0 Error(s). The only residual analyzer diagnostics in the test
+file are two PRE-EXISTING CS8632 warnings on the original `TestableApplicationGlobals`
+`IList<string>?` declarations (lines 606, 610), which predate #202. The new test code adds zero
+diagnostics.
+
+## Step 3 — Nullable / TreatWarningsAsErrors Build
+
+Command: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`
+EXIT_CODE: 0
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). Run in the established way (plain
+Debug build keeps outputs current, then incremental nullable Build passes 0/0).
+
+## Step 4 — Test + Coverage
+
+Command: `vstest.console.exe TaskMaster.Test\bin\Debug\TaskMaster.Test.dll /Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation /ResultsDirectory:TestResults/p4c`
+EXIT_CODE: 0
+Output Summary: Total tests 102, Passed 102, Failed 0 (98 + 4 new wiring tests). Determinism
+confirmed by three additional runs (102/102 each).
+
+New wiring tests (all pass):
+- `LoadAsync_WhenTimingDisabled_RecordsNothingAndEmitsNoTable` (P4-T2)
+- `LoadAsync_WhenTimingEnabled_RecordsAllPhasesInStartupOrderWithLoadBasicFirst` (P4-T3)
+- `LoadAsync_WhenTimingEnabled_EmitsExactlyOneTableWithPhaseNamesAndTotal` (P4-T4)
+- `LoadAsync_PreservesPhaseOrderingAndYieldCount_WhenTimingOnVersusOff` (P4-T5)
+
+Post-change `ApplicationGlobals` coverage (from merged Cobertura `TestResults/p4.cobertura.xml`):
+
+- `ApplicationGlobals.cs` aggregate line coverage (primary class + async state machines, deduped
+  by line): 70.9% (95 / 134 lines), UP from the baseline 60.75% (65 / 107).
+- `TaskMaster.ApplicationGlobals` primary class line-rate: 72.37% (baseline 74.24%). The nominal
+  primary-class line-rate dip is a denominator effect (new instrumented lines added); the
+  CHANGED lines are covered.
+- New recorder `StartupTimingRecorder.cs`: 100% (30 / 30 lines).
+
+Changed-line coverage check: the only uncovered lines within the changed region are the
+PRE-EXISTING parallel-startup branch (`if (parallel) { await LoadParallelAsync(); }`) and the
+`LoadParallelAsync` body, which are explicitly OUT OF SCOPE (user-story Non-Goals: parallel path
+not instrumented) and were uncovered in the baseline as well. Every NEW timing-instrumentation
+line (flag read, recorder selection, LoadBasic Stopwatch, per-phase recording, StopAndRestart,
+EmitTable call) is covered. No coverage regression on changed lines.
+
+## Implementation notes
+
+- `TestableApplicationGlobals` gained: a `TimingRecorder` observation property (reads private
+  `_timingRecorder`), and an overridden `LoadBasicMethod()` that sets `_loadBasicElapsed`
+  deterministically and skips live COM construction (P4-T1 seam).
+- `StartupTimingRecorder` gained an internal `RecordedPhaseNames` accessor for test observation.
+- `ApplicationGlobals.LoadBasicMethod()` changed from `private` to `protected internal virtual`
+  to provide the test seam; production behavior unchanged.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/post-split-linecounts.2026-06-15T13-29.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/post-split-linecounts.2026-06-15T13-29.md
@@ -1,0 +1,27 @@
+# Post-Split Line Counts (Issue #202, P1-T7)
+
+Timestamp: 2026-06-15T13-29
+
+Command: `awk 'END{print NR}' TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` and `awk 'END{print NR}' TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs`
+
+EXIT_CODE: 0
+
+Output Summary (post-CSharpier format):
+
+- `TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs`: 483 lines (was 687). Strictly < 500.
+- `TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs`: 299 lines (new file). Strictly < 500.
+
+Deterministic reduction applied to the original to reach < 500:
+- Moved the four `[DoNotParallelize]` startup-timing wiring tests and the explanatory comment
+  block to the new file.
+- Removed three private static helpers used only by the moved tests
+  (`SetEnginesMock`, `AttachMemoryAppender`, `DetachMemoryAppender`).
+- Removed the `TimingRecorder` observation seam and the `LoadBasicMethod` override from the
+  original's nested `TestableApplicationGlobals` (both consumed only by the moved timing tests;
+  retained tests use `LoadSequentialAsync`/`InitializeEnginesPhaseAsync`, not `LoadAsync`).
+- Removed now-unused `using` directives from the original: `System.Threading`, `log4net`,
+  `log4net.Appender`, `log4net.Repository.Hierarchy`, and the bare
+  `Microsoft.Office.Interop.Outlook` (the `OutlookApplication` alias is retained).
+
+CSharpier produced no further line-count change. Both files are strictly < 500 lines.
+No escalation required.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/qa-analyze.2026-06-15T13-29.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/qa-analyze.2026-06-15T13-29.md
@@ -1,0 +1,22 @@
+# QA Gate — Analyze (.NET Analyzers) (Issue #202, P2-T2)
+
+Timestamp: 2026-06-15T13-29
+
+Command: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
+
+EXIT_CODE: 0
+
+Output Summary:
+
+- Build succeeded (MSBUILD exit 0). Solution compiled with analyzers enabled.
+- No analyzer diagnostics were introduced by the split. Specifically: zero IDE0005/CS8019
+  unused-using diagnostics and zero unused-private-member diagnostics in either
+  `ApplicationGlobalsTests.cs` or `ApplicationGlobalsStartupTimingTests.cs`.
+- The only warnings touching the two AppGlobals test files are CS8632 ("nullable annotation
+  outside a #nullable context") on the `IList<string>?` field/parameter annotations in
+  `TestableApplicationGlobals`. These are pre-existing: they were present on the original
+  file's `TestableApplicationGlobals` before the split and were carried verbatim into the new
+  file. They are warnings (not errors) under the analyze gate, the build passed, and they do
+  not represent a new diagnostic class. Under the nullable gate (P2-T3, `/p:Nullable=enable`)
+  the `#nullable` context is enabled, so CS8632 does not fire there (verified in P2-T3).
+- No errors anywhere in the solution build.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/qa-format.2026-06-15T13-29.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/qa-format.2026-06-15T13-29.md
@@ -1,0 +1,18 @@
+# QA Gate — Format (CSharpier) (Issue #202, P2-T1)
+
+Timestamp: 2026-06-15T13-29
+
+Command: `csharpier format .`
+
+EXIT_CODE: 0
+
+Output Summary:
+
+- `Formatted 1058 files in 747ms.` EXIT_CODE 0.
+- `git status --short` confirms only the two intended C# files are modified
+  (`TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs`,
+  `TaskMaster.Test/TaskMaster.Test.csproj`) plus the new untracked
+  `TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs`. CSharpier did not
+  rewrite any other tracked source file.
+- The two split files were already CSharpier-clean from the targeted format run; the full-repo
+  pass produced no further change to them. No loop restart required.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/qa-nullable.2026-06-15T13-29.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/qa-nullable.2026-06-15T13-29.md
@@ -1,0 +1,16 @@
+# QA Gate — Type-check / Nullable (TreatWarningsAsErrors) (Issue #202, P2-T3)
+
+Timestamp: 2026-06-15T13-29
+
+Command: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`
+
+EXIT_CODE: 0
+
+Output Summary:
+
+- Build succeeded (MSBUILD exit 0) with `/p:Nullable=enable /p:TreatWarningsAsErrors=true`.
+- Zero errors across the solution; zero warnings-as-errors.
+- No nullable or warning-as-error diagnostics in either `ApplicationGlobalsTests.cs` or
+  `ApplicationGlobalsStartupTimingTests.cs`. With the nullable context enabled, the CS8632
+  annotations observed under the analyze gate are valid and do not fire here, confirming the
+  split introduces no new type-safety regression.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/qa-test.2026-06-15T13-29.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/qa-test.2026-06-15T13-29.md
@@ -1,0 +1,31 @@
+# QA Gate — Test + Coverage (Issue #202, P2-T4)
+
+Timestamp: 2026-06-15T13-29
+
+Command: `vstest.console.exe TaskMaster.Test/bin/Debug/TaskMaster.Test.dll UtilitiesCS.Test/bin/Debug/UtilitiesCS.Test.dll QuickFiler.Test/bin/Debug/QuickFiler.Test.dll Tags.Test/bin/Debug/Tags.Test.dll TaskVisualization.Test/bin/Debug/TaskVisualization.Test.dll ToDoModel.Test/bin/Debug/ToDoModel.Test.dll VBFunctions.Test/bin/Debug/VBFunctions.Test.dll /Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation /ResultsDirectory:TestResults/remed-final`
+
+EXIT_CODE: 0
+
+Output Summary:
+
+- Total tests: 4194. Passed: 4194. Failed: 0. Total time: ~48 s. Test Run Successful. (>= 4194
+  required; no test lost.)
+- The four `[DoNotParallelize]` startup-timing wiring tests all passed under the new class
+  `ApplicationGlobalsStartupTimingTests`:
+  - `LoadAsync_WhenTimingDisabled_RecordsNothingAndEmitsNoTable` — Passed
+  - `LoadAsync_WhenTimingEnabled_RecordsAllPhasesInStartupOrderWithLoadBasicFirst` — Passed
+  - `LoadAsync_WhenTimingEnabled_EmitsExactlyOneTableWithPhaseNamesAndTotal` — Passed
+  - `LoadAsync_PreservesPhaseOrderingAndYieldCount_WhenTimingOnVersusOff` — Passed
+
+Numeric coverage (`.coverage` merged to `TestResults/remed-final.cobertura.xml`):
+
+- Raw overall Cobertura line-rate: 76.37% (baseline 76.36%). Delta +0.01 (no regression).
+- First-party production-only deduped line coverage (QuickFiler, Tags, TaskMaster,
+  TaskVisualization, ToDoModel, UtilitiesCS, VBFunctions; excludes test + vendored):
+  75.12% (36436 / 48504). Identical to baseline (36436 / 48504). No regression. >= 80% applies
+  to the exempt-adjusted testable denominator; this raw first-party figure is unchanged.
+- `TaskMaster.ApplicationGlobals` (primary class) line-rate: 77.63%. Identical to baseline.
+- New-code recorder coverage: `TaskMaster.StartupTimingRecorder` 100%;
+  `TaskMaster.NullStartupTimingRecorder` 100%. New-code floor (>= 90%) preserved.
+
+A pure move/split did not reduce coverage; all figures equal baseline within rounding.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/verification-summary.2026-06-15T13-29.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/verification-summary.2026-06-15T13-29.md
@@ -1,0 +1,61 @@
+# Verification Summary (Issue #202, Phase 4)
+
+Timestamp: 2026-06-15T13-29
+
+## P4-T1 — File-size finding closed
+
+Post-split line counts (post-CSharpier, from P1-T7):
+- `TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs`: 483 lines (< 500).
+- `TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs`: 299 lines (< 500).
+
+Both files are strictly under the 500-line limit. Finding 1 (BLOCKING) is closed.
+
+## P4-T2 — No test loss
+
+- Phase 2 post-change passing count (P2-T4): 4194 / 4194 (>= 4194 required). Failed: 0.
+- The four `[DoNotParallelize]` startup-timing wiring tests all appear in the run results under
+  the new `ApplicationGlobalsStartupTimingTests` class and all passed:
+  `LoadAsync_WhenTimingDisabled_RecordsNothingAndEmitsNoTable`,
+  `LoadAsync_WhenTimingEnabled_RecordsAllPhasesInStartupOrderWithLoadBasicFirst`,
+  `LoadAsync_WhenTimingEnabled_EmitsExactlyOneTableWithPhaseNamesAndTotal`,
+  `LoadAsync_PreservesPhaseOrderingAndYieldCount_WhenTimingOnVersusOff`.
+- The new file retains all four `[DoNotParallelize]` markers (4) and the
+  `Settings.Default.StartupTimingEnabled` save/restore lifecycle; the original retains 0.
+
+## P4-T3 — Assertion / intent parity
+
+- `git diff` of the original `ApplicationGlobalsTests.cs` is pure deletions: 204 deletions, 0
+  insertions. No assertion, attribute, or comment in the retained tests was altered.
+- A line-by-line diff of the moved region (git HEAD original lines 365-498) against the moved
+  test methods in the new file shows the bodies are byte-identical; the only difference is one
+  trailing closing brace captured by the extraction window. The only cross-file differences are
+  file relocation, the new class name, and the necessarily-duplicated helpers
+  (`SetEnginesMock`, `AttachMemoryAppender`, `DetachMemoryAppender`, `CreateOutlookApplicationStub`,
+  and the nested `TestableApplicationGlobals` with its `TimingRecorder` seam / `LoadBasicMethod`
+  override / phase overrides / `YieldCount`). No assertion text changed.
+
+## P4-T4 — Coverage floors and AC validity
+
+- Repo-wide / first-party production-only deduped coverage: 75.12% (36436/48504) post-change,
+  identical to baseline. No regression on changed lines (changed lines are test-file
+  relocations only).
+- New-code coverage: `StartupTimingRecorder` 100%, `NullStartupTimingRecorder` 100% (>= 90%).
+- All five acceptance criteria in `spec.md` (lines 91-95) and `user-story.md` (lines 50-54)
+  remain `[x]` and PASS; the mechanical split does not affect AC delivery. No checkbox change
+  required.
+
+## P4-T5 — Findings addressed
+
+- Finding 1 (BLOCKING — test-file > 500 lines): CLOSED. Both files < 500 lines after the split.
+- Finding 2 (NON-BLOCKING — missing `artifacts/csharp/coverage.xml`): CLOSED. The merged
+  Cobertura was copied to `artifacts/csharp/coverage.xml` (P3) and parses to the P2-T4 figures.
+- Blocking-finding count after remediation: 0.
+
+## Final Toolchain Result (single clean pass)
+
+1. Format (`csharpier format .`): EXIT_CODE 0.
+2. Analyze (`msbuild ... /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`): EXIT_CODE 0.
+3. Type-check/nullable (`msbuild ... /p:Nullable=enable /p:TreatWarningsAsErrors=true`): EXIT_CODE 0.
+4. Test+coverage (`vstest.console.exe ... /EnableCodeCoverage /InIsolation`): EXIT_CODE 0, 4194/4194.
+
+No step changed files or failed; the loop completed in a single pass.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/remediation-baseline/baseline-linecounts.2026-06-15T13-29.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/remediation-baseline/baseline-linecounts.2026-06-15T13-29.md
@@ -1,0 +1,22 @@
+# Remediation Baseline — Line Counts and Target-File Absence (Issue #202)
+
+Timestamp: 2026-06-15T13-29
+
+## [P0-T2] Baseline line count of affected test file
+
+Command: `awk 'END{print NR}' TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs`
+
+EXIT_CODE: 0
+
+Output Summary: 687 lines. This exceeds the 500-line file-size limit (Finding 1, BLOCKING),
+matching the expected baseline of 687.
+
+## [P0-T3] New target file absence confirmation
+
+Command: `test -f TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs; echo $?`
+
+EXIT_CODE: 1 (file absent)
+
+Output Summary: The new target file
+`TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs` does not exist before
+the split (`test -f` returned exit code 1). The split will create it.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/remediation-baseline/baseline-test.2026-06-15T13-29.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/remediation-baseline/baseline-test.2026-06-15T13-29.md
@@ -1,0 +1,28 @@
+# Remediation Baseline — Test + Coverage (Issue #202)
+
+Timestamp: 2026-06-15T13-29
+
+Command: `vstest.console.exe TaskMaster.Test/bin/Debug/TaskMaster.Test.dll UtilitiesCS.Test/bin/Debug/UtilitiesCS.Test.dll QuickFiler.Test/bin/Debug/QuickFiler.Test.dll Tags.Test/bin/Debug/Tags.Test.dll TaskVisualization.Test/bin/Debug/TaskVisualization.Test.dll ToDoModel.Test/bin/Debug/ToDoModel.Test.dll VBFunctions.Test/bin/Debug/VBFunctions.Test.dll /Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation /ResultsDirectory:TestResults/remed-baseline`
+
+EXIT_CODE: 0
+
+Output Summary:
+
+- Total tests: 4194. Passed: 4194. Failed: 0. Total time: ~50 s. (Build at current HEAD,
+  before any remediation change.)
+- All seven first-party test assemblies run together so the repository-wide coverage figure is
+  comparable to the post-change run.
+
+Numeric coverage (from `.coverage` merged to `TestResults/remed-baseline.cobertura.xml` via
+`dotnet-coverage merge -f cobertura`):
+
+- Raw overall Cobertura line-rate (all packages incl. third-party + vendored + test
+  assemblies): 76.36%. (Recorded for traceability; not the policy metric.)
+- First-party production-only line coverage (packages QuickFiler, Tags, TaskMaster,
+  TaskVisualization, ToDoModel, UtilitiesCS, VBFunctions; deduped by file+line; excludes test
+  assemblies and vendored SVGControl / Swordfish.NET.General): 75.12% (36436 / 48504).
+- `TaskMaster.ApplicationGlobals` (primary class) line-rate: 77.63%.
+- New-code recorder coverage: `TaskMaster.StartupTimingRecorder` line-rate 100%;
+  `TaskMaster.NullStartupTimingRecorder` line-rate 100%. Meets the >= 90% new-code floor.
+
+Baseline established: 4194 passing, EXIT_CODE 0, numeric coverage recorded (no placeholders).

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/feature-audit.2026-06-15T13-29.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/feature-audit.2026-06-15T13-29.md
@@ -1,0 +1,100 @@
+# Feature Audit: debug-startup-timing-instrumentation (Issue #202)
+
+**Audit Date:** 2026-06-15
+**Feature Folder:** `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202`
+**Base Branch:** `main`
+**Head Branch:** `feature/debug-startup-timing-instrumentation-202`
+**Work Mode:** `full-feature`
+**Audit Type:** Initial acceptance review
+
+---
+
+## Scope and Baseline
+
+- **Base branch:** `main` (commit `a21d09e18dfebb9e3450c1b3322e7715c09d91e6`)
+- **Head branch/commit:** `feature/debug-startup-timing-instrumentation-202` (commit `1d193d90dba55eec0a739ff13f5ecb5e3d218b99`)
+- **Merge base:** `a21d09e18dfebb9e3450c1b3322e7715c09d91e6`
+- **Evidence sources:**
+  - Primary: `artifacts/pr_context.summary.txt`
+  - Secondary baseline diff: `artifacts/pr_context.appendix.txt`
+  - Feature evidence: `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/**`
+  - Additional evidence: `git diff a21d09e1..1d193d90` (source/test diff) and `TestResults/final-full.cobertura.xml`
+- **Feature folder used:** `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202`
+- **Requirements source:** `spec.md` and `user-story.md` (full-feature work mode)
+- **Work mode resolution note:** `issue.md` contains `- Work Mode: full-feature`, so the authoritative AC sources are `spec.md` and `user-story.md`. The two files carry identical AC text.
+- **Scope note:** Audit scope is the full branch diff vs the merge-base. The PR-context summary reports "Core logic changes: 0 files," which is a misclassification of the C# source changes; scope was therefore taken from the actual git diff (6 changed `.cs` files plus build/settings/docs). No caller scope-narrowing was applied.
+
+---
+
+## Acceptance Criteria Inventory
+
+**Authoritative AC source files for this run:**
+- `spec.md` — primary source (full-feature)
+- `user-story.md` — primary source (full-feature)
+
+The AC text is identical in both files.
+
+### Acceptance criteria
+
+1. A flag exists that enables or disables startup timing instrumentation; when disabled there is no behavioral or output change to startup.
+2. When enabled, each startup sub-component's elapsed wall-clock time is captured during startup.
+3. When enabled, a formatted plain-text table of sub-component names and elapsed times (plus a total row) is written to the output screen after startup completes.
+4. The timing recorder/formatter is a testable unit (no Outlook/COM dependency) with MSTest coverage meeting the repository floor for new code.
+5. Instrumentation uses existing logging/output infrastructure and existing approved dependencies; it does not change functional startup behavior.
+
+---
+
+## Acceptance Criteria Evaluation
+
+| # | Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|-----------|--------|----------|--------------------------|-------|
+| 1 | Flag enables/disables; disabled = no behavioral/output change | PASS | New `StartupTimingEnabled` user setting (default `False`) in `Settings.settings`/`Settings.Designer.cs`. `LoadAsync` selects `NullStartupTimingRecorder` when off (records/emits nothing). Tests `LoadAsync_WhenTimingDisabled_RecordsNothingAndEmitsNoTable` and `LoadAsync_PreservesPhaseOrderingAndYieldCount_WhenTimingOnVersusOff` (identical visited-stage order and yield count = 5 in both modes). | `git diff a21d09e1..1d193d90 -- TaskMaster/AppGlobals/ApplicationGlobals.cs TaskMaster/Properties/Settings.settings` | Default-off and no-output-when-off both verified by test assertions. |
+| 2 | Each sub-component elapsed wall-clock time captured when enabled | PASS | `LoadSequentialAsync` wraps each phase await with a shared `Stopwatch`/`StopAndRestart`; LoadBasic measured in `LoadBasicMethod`. Test `LoadAsync_WhenTimingEnabled_RecordsAllPhasesInStartupOrderWithLoadBasicFirst` asserts the seven phases recorded in order: LoadBasic, IntelConfig, OlObjects, ToDo, AutoFile, Engines, Events. | `vstest.console.exe TaskMaster.Test\bin\Debug\TaskMaster.Test.dll ...` | Seven established phase seams captured per spec. |
+| 3 | Formatted plain-text table (sub-components + total row) written after startup | PASS | `StartupTimingRecorder.FormatTable` renders `Duration`/`Action` columns via `PrettyPrinters.ToFormattedText` plus a summed TOTAL row; `EmitTable` logs once with `[Startup timing]` prefix at end of `LoadAsync`. Test `LoadAsync_WhenTimingEnabled_EmitsExactlyOneTableWithPhaseNamesAndTotal` asserts exactly one emission containing all phase names and TOTAL; recorder test asserts TOTAL equals the sum of injected spans. | `vstest.console.exe ... /EnableCodeCoverage` | "Output screen" is realized as the existing log4net channel (spec/user-story document this as the single channel used by #139/#141). |
+| 4 | Recorder/formatter is a testable unit (no Outlook/COM) with MSTest coverage meeting new-code floor | PASS | `IStartupTimingRecorder`/`StartupTimingRecorder`/`NullStartupTimingRecorder` have no Outlook/COM/IO dependency. 7 recorder unit tests inject deterministic spans. New-code line coverage 100% (>= 90% floor): `TaskMaster.StartupTimingRecorder` and `TaskMaster.NullStartupTimingRecorder` both `line-rate="1"`. | `grep -oE '<class line-rate="[0-9.]*"[^>]* name="TaskMaster\.(StartupTimingRecorder\|NullStartupTimingRecorder)"' TestResults/final-full.cobertura.xml` | Meets the >= 90% new-code floor with margin. |
+| 5 | Uses existing logging/output + approved deps; does not change functional startup behavior | PASS | Uses existing `ApplicationGlobals` log4net logger (`logger.Info`), `Stopwatch`, and `UtilitiesCS.PrettyPrinters` — all already present/approved; no new dependency. Ordering/yield-count parity test confirms unchanged functional startup behavior. No COM-thread or async-restructuring change. | `git diff a21d09e1..1d193d90 -- TaskMaster/AppGlobals/ApplicationGlobals.cs` | Banned-API rule respected (Stopwatch instead of DateTime.Now/UtcNow). |
+
+---
+
+## Summary
+
+**Overall Feature Readiness:** NEEDS REVISION
+
+All five acceptance criteria are functionally satisfied and verified by tests and coverage evidence. Feature readiness is held at NEEDS REVISION (rather than PASS) because of a policy violation outside the acceptance criteria themselves: the modified test file `TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` is 687 lines, exceeding the repository 500-line file-size limit (documented in `policy-audit.2026-06-15T13-29.md` and `code-review.2026-06-15T13-29.md`). The acceptance criteria are all PASS; the blocking item is a separable, mechanical refactor (split the test file).
+
+**Criteria summary:**
+- **PASS:** 5 criteria
+- **PARTIAL:** 0 criteria
+- **UNVERIFIED:** 0 criteria
+- **FAIL:** 0 criteria
+
+**Top gaps preventing PASS:**
+
+1. Test-file size violation: `ApplicationGlobalsTests.cs` (687 lines) exceeds the 500-line limit. This is a policy gap, not an acceptance-criteria gap.
+2. Canonical C# coverage artifact `artifacts/csharp/coverage.xml` is absent (Minor/process; coverage verified from `TestResults/final-full.cobertura.xml`).
+
+**Recommended follow-up verification steps:**
+
+1. Split the startup-timing wiring tests and helpers into a new test file so each file is under 500 lines, then re-run the C# toolchain (format -> analyze -> nullable -> test+coverage).
+2. Emit/copy the merged Cobertura output to `artifacts/csharp/coverage.xml` to satisfy the workflow artifact contract.
+
+---
+
+## Acceptance Criteria Check-off
+
+Per the acceptance-criteria tracking rules, all five criteria evaluate PASS and are represented as markdown checkboxes in `spec.md` and `user-story.md`. They were already checked off `[x]` by the implementing agent during execution; this audit confirms each check-off is supported by evidence. No further checkbox change was required (all items already `[x]` and verified PASS).
+
+### AC Status Summary
+
+- Source: `spec.md`, `user-story.md`
+- Total AC items: 5 (per file)
+- Checked off (delivered): 5 (per file)
+- Remaining (unchecked): 0
+- Items remaining: None.
+
+| Source File | Total AC | Checked (PASS) | Unchecked | Notes |
+|-------------|----------|----------------|-----------|-------|
+| `spec.md` | 5 | 5 | 0 | Checkbox-backed; all already `[x]` and confirmed PASS |
+| `user-story.md` | 5 | 5 | 0 | Checkbox-backed; all already `[x]` and confirmed PASS |
+
+No source-file checkbox change was made because all AC items were already checked off and each is supported by inspected evidence.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/feature-audit.2026-06-15T14-07.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/feature-audit.2026-06-15T14-07.md
@@ -1,0 +1,101 @@
+# Feature Audit: debug-startup-timing-instrumentation (Issue #202)
+
+**Audit Date:** 2026-06-15
+**Feature Folder:** `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202`
+**Base Branch:** `main`
+**Head Branch:** `feature/debug-startup-timing-instrumentation-202`
+**Work Mode:** `full-feature`
+**Audit Type:** Cycle-exit acceptance re-review (after remediation cycle that split the over-limit test file)
+
+---
+
+## Scope and Baseline
+
+- **Base branch:** `main` (commit `a21d09e18dfebb9e3450c1b3322e7715c09d91e6`)
+- **Head branch/commit:** `feature/debug-startup-timing-instrumentation-202` (commit `253270ac6dbc94bd5b97de1d98a79938f9575040`)
+- **Merge base:** `a21d09e18dfebb9e3450c1b3322e7715c09d91e6`
+- **Evidence sources:**
+  - Primary: `artifacts/pr_context.summary.txt`
+  - Secondary baseline diff: `artifacts/pr_context.appendix.txt`
+  - Feature evidence: `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/**`
+  - Additional evidence: `git diff a21d09e1..253270ac` (source/test diff), `artifacts/csharp/coverage.xml` (canonical, present this cycle), and `TestResults/baseline-full.cobertura.xml`
+- **Feature folder used:** `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202`
+- **Requirements source:** `spec.md` and `user-story.md` (full-feature work mode)
+- **Work mode resolution note:** `issue.md` contains `- Work Mode: full-feature`, so the authoritative AC sources are `spec.md` and `user-story.md`. The two files carry identical AC text.
+- **Scope note:** Audit scope is the full branch diff vs the merge-base. The PR-context summary reports "Core logic changes: 0 files," which is a misclassification of the C# source changes; scope was therefore taken from the actual git diff (7 changed `.cs` files plus build/settings/docs). No caller scope-narrowing was applied.
+- **Cycle note:** This is the re-audit after a remediation cycle. The prior cycle held feature readiness at NEEDS REVISION solely because of a policy violation outside the acceptance criteria (a test file exceeding the 500-line limit). That violation is resolved this cycle by a test-file split (`ApplicationGlobalsTests.cs` 483 lines + new `ApplicationGlobalsStartupTimingTests.cs` 299 lines, both under 500). The acceptance criteria were all PASS in the prior cycle and remain PASS.
+
+---
+
+## Acceptance Criteria Inventory
+
+**Authoritative AC source files for this run:**
+- `spec.md` — primary source (full-feature)
+- `user-story.md` — primary source (full-feature)
+
+The AC text is identical in both files.
+
+### Acceptance criteria
+
+1. A flag exists that enables or disables startup timing instrumentation; when disabled there is no behavioral or output change to startup.
+2. When enabled, each startup sub-component's elapsed wall-clock time is captured during startup.
+3. When enabled, a formatted plain-text table of sub-component names and elapsed times (plus a total row) is written to the output screen after startup completes.
+4. The timing recorder/formatter is a testable unit (no Outlook/COM dependency) with MSTest coverage meeting the repository floor for new code.
+5. Instrumentation uses existing logging/output infrastructure and existing approved dependencies; it does not change functional startup behavior.
+
+---
+
+## Acceptance Criteria Evaluation
+
+| # | Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|-----------|--------|----------|--------------------------|-------|
+| 1 | Flag enables/disables; disabled = no behavioral/output change | PASS | New `StartupTimingEnabled` user setting (default `False`) in `Settings.settings`/`Settings.Designer.cs`. `LoadAsync` selects `NullStartupTimingRecorder` when off (records/emits nothing). Tests `LoadAsync_WhenTimingDisabled_RecordsNothingAndEmitsNoTable` and `LoadAsync_PreservesPhaseOrderingAndYieldCount_WhenTimingOnVersusOff` (identical visited-stage order and yield count = 5 in both modes), now in `ApplicationGlobalsStartupTimingTests.cs`. | `git diff a21d09e1..253270ac -- TaskMaster/AppGlobals/ApplicationGlobals.cs TaskMaster/Properties/Settings.settings` | Default-off and no-output-when-off both verified by test assertions. |
+| 2 | Each sub-component elapsed wall-clock time captured when enabled | PASS | `LoadSequentialAsync` wraps each phase await with a shared `Stopwatch`/`StopAndRestart`; LoadBasic measured in `LoadBasicMethod`. Test `LoadAsync_WhenTimingEnabled_RecordsAllPhasesInStartupOrderWithLoadBasicFirst` asserts the seven phases recorded in order: LoadBasic, IntelConfig, OlObjects, ToDo, AutoFile, Engines, Events. | `vstest.console.exe TaskMaster.Test\bin\Debug\TaskMaster.Test.dll ...` | Seven established phase seams captured per spec. |
+| 3 | Formatted plain-text table (sub-components + total row) written after startup | PASS | `StartupTimingRecorder.FormatTable` renders `Duration`/`Action` columns via `PrettyPrinters.ToFormattedText` plus a summed TOTAL row; `EmitTable` logs once with `[Startup timing]` prefix at end of `LoadAsync`. Test `LoadAsync_WhenTimingEnabled_EmitsExactlyOneTableWithPhaseNamesAndTotal` asserts exactly one emission containing all phase names and TOTAL; recorder test asserts TOTAL equals the sum of injected spans. | `vstest.console.exe ... /EnableCodeCoverage` | "Output screen" is realized as the existing log4net channel (spec/user-story document this as the single channel used by #139/#141). |
+| 4 | Recorder/formatter is a testable unit (no Outlook/COM) with MSTest coverage meeting new-code floor | PASS | `IStartupTimingRecorder`/`StartupTimingRecorder`/`NullStartupTimingRecorder` have no Outlook/COM/IO dependency. 7 recorder unit tests inject deterministic spans. New-code line coverage 100% (>= 90% floor): `TaskMaster.StartupTimingRecorder` 48/48 lines and `TaskMaster.NullStartupTimingRecorder` 10/10 lines covered. | Parse `artifacts/csharp/coverage.xml` for `TaskMaster.StartupTimingRecorder` and `TaskMaster.NullStartupTimingRecorder` line hits. | Meets the >= 90% new-code floor (100%). |
+| 5 | Uses existing logging/output + approved deps; does not change functional startup behavior | PASS | Uses existing `ApplicationGlobals` log4net logger (`logger.Info`), `Stopwatch`, and `UtilitiesCS.PrettyPrinters` — all already present/approved; no new dependency. Ordering/yield-count parity test confirms unchanged functional startup behavior. No COM-thread or async-restructuring change. | `git diff a21d09e1..253270ac -- TaskMaster/AppGlobals/ApplicationGlobals.cs` | Banned-API rule respected (Stopwatch instead of DateTime.Now/UtcNow). |
+
+---
+
+## Summary
+
+**Overall Feature Readiness:** PASS
+
+All five acceptance criteria are functionally satisfied and verified by tests and coverage evidence, and the policy violation that held the prior cycle at NEEDS REVISION (a test file exceeding the 500-line limit) is now resolved. The remediation split reduced `ApplicationGlobalsTests.cs` to 483 lines and placed the four startup-timing wiring tests in the new `ApplicationGlobalsStartupTimingTests.cs` (299 lines), both under the limit, with no test removed or weakened and 4194/4194 tests passing. The prior Minor process gap (absent canonical `artifacts/csharp/coverage.xml`) is also resolved. New-code coverage is 100%; the modified `ApplicationGlobals` class improved from 74.4% to 77.9% (no regression).
+
+**Criteria summary:**
+- **PASS:** 5 criteria
+- **PARTIAL:** 0 criteria
+- **UNVERIFIED:** 0 criteria
+- **FAIL:** 0 criteria
+
+**Top gaps preventing PASS:**
+
+None. Both items that prevented a clean PASS in the prior cycle are resolved:
+1. Test-file size violation (`ApplicationGlobalsTests.cs`): resolved by the split; all changed files under 500 lines at HEAD.
+2. Canonical C# coverage artifact `artifacts/csharp/coverage.xml`: present and parsed this cycle.
+
+**Recommended follow-up verification steps:**
+
+None required for merge. Optional follow-up (not blocking): a project-direction decision on the repo-wide raw C# coverage figure (76.37%, below the literal 80% number) is a pre-existing, exemption-consistent condition, not a regression introduced by #202.
+
+---
+
+## Acceptance Criteria Check-off
+
+Per the acceptance-criteria tracking rules, all five criteria evaluate PASS and are represented as markdown checkboxes in `spec.md` and `user-story.md`. They were already checked off `[x]` by the implementing agent during execution; this audit confirms each check-off is supported by evidence at HEAD. No further checkbox change was required (all items already `[x]` and verified PASS).
+
+### AC Status Summary
+
+- Source: `spec.md`, `user-story.md`
+- Total AC items: 5 (per file)
+- Checked off (delivered): 5 (per file)
+- Remaining (unchecked): 0
+- Items remaining: None.
+
+| Source File | Total AC | Checked (PASS) | Unchecked | Notes |
+|-------------|----------|----------------|-----------|-------|
+| `spec.md` | 5 | 5 | 0 | Checkbox-backed; all already `[x]` and confirmed PASS |
+| `user-story.md` | 5 | 5 | 0 | Checkbox-backed; all already `[x]` and confirmed PASS |
+
+No source-file checkbox change was made because all AC items were already checked off and each is supported by inspected evidence at HEAD.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/issue.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/issue.md
@@ -1,0 +1,50 @@
+# debug-startup-timing-instrumentation (Issue #202)
+
+- Date captured: 2026-06-15
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/debug-startup-timing-instrumentation/ (Issue #202)
+
+- Issue: #202
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/202
+- Last Updated: 2026-06-15
+- Work Mode: full-feature
+
+## Problem / Why
+
+TaskMaster's Outlook add-in startup continues to lock up the UI for an extended period. Prior work (#139, #141) added targeted log4net `[Startup timing]` entries around the store-rewire COM path, but there is no enable-on-demand, whole-of-startup view that attributes wall-clock time to each startup sub-component. Without a per-sub-component breakdown surfaced in a single readable table, diagnosing which sub-component dominates startup remains a manual log-correlation task.
+
+## Proposed Behavior
+
+Add debug-only timing instrumentation to the add-in startup path that:
+
+- Is gated behind a flag that can be turned on/off so the instrumentation has no effect on normal (non-diagnostic) runs.
+- Measures the wall-clock time spent in each startup sub-component during `ApplicationGlobals` load (the IntelConfig, OlObjects, ToDo, AutoFile, Engines, and Events phases at minimum), plus the total startup wall-clock time.
+- Emits a formatted plain-text table to the output screen (the debug output window the add-in already writes to via `DebugTextWriter`/`Console`) listing each sub-component and its elapsed time.
+- Does not alter functional startup behavior when the flag is off, and adds only measurement/formatting overhead when on.
+
+## Acceptance Criteria (early draft)
+
+- [x] A flag exists that enables or disables startup timing instrumentation; when disabled there is no behavioral or output change to startup.
+- [x] When enabled, each startup sub-component's elapsed wall-clock time is captured during startup.
+- [x] When enabled, a formatted plain-text table of sub-component names and elapsed times (plus a total row) is written to the output screen after startup completes.
+- [x] The timing recorder/formatter is a testable unit (no Outlook/COM dependency) with MSTest coverage meeting the repository floor for new code.
+- [x] Instrumentation uses existing logging/output infrastructure and existing approved dependencies; it does not change functional startup behavior.
+
+## Constraints & Risks
+
+- The add-in runs as a .NET Framework VSTO add-in on the Outlook main STA thread; instrumentation must not introduce COM-thread affinity changes or additional async restructuring of the startup path.
+- The flag mechanism must be simple to toggle and must default to off.
+- New production code must meet the repository coverage floor (>= 90% for new modules/classes); the recorder and table formatter must be designed with a seam so they can be unit-tested without a live Outlook process.
+- Measurement overhead must be negligible when the flag is off.
+
+## Test Conditions to Consider
+
+- [ ] Recorder captures named spans and computes elapsed time correctly (positive, zero-duration, and ordering cases).
+- [ ] Table formatter renders aligned plain-text columns deterministically for representative inputs and an empty input.
+- [ ] Flag off => no spans recorded and no table emitted; flag on => spans recorded and table emitted.
+- [ ] Wiring into the startup phase sequence preserves existing phase ordering and behavior.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (feature request template)
+- [ ] Create `docs/features/active/debug-startup-timing-instrumentation/` folder from the template

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/plan.2026-06-15T12-15.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/plan.2026-06-15T12-15.md
@@ -1,0 +1,219 @@
+# debug-startup-timing-instrumentation — Plan
+
+- **Issue:** #202
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-15T12-15
+- **Status:** Ready for Execution
+- **Version:** 1.0
+- **Work Mode:** full-feature
+- **Plan file (in place, all revisions):** `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/plan.2026-06-15T12-15.md`
+
+## Required References
+
+Apply repository policies in the order defined by `policy-compliance-order`:
+
+1. `CLAUDE.md` (standing instructions)
+2. `.claude/rules/general-code-change.md`
+3. `.claude/rules/general-unit-test.md`
+4. `.claude/rules/csharp.md` (C# toolchain, analyzer stack, banned APIs, coverage floors)
+
+Authoritative inputs:
+- Spec: `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/spec.md`
+- Issue / Acceptance Criteria: `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/issue.md`
+- User story: `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/user-story.md`
+- Research: `artifacts/research/2026-06-15T14-00-startup-timing-instrumentation-202.md`
+
+**All work must comply with these policies; do not duplicate their content here.**
+
+## Evidence Location Invariant
+
+All evidence artifacts MUST be written under the canonical feature evidence root:
+`docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/<kind>/`
+where `<kind>` is one of `baseline/`, `qa-gates/`, `regression-testing/`, `issue-updates/`, `other/`.
+
+Writing evidence to `artifacts/baselines/`, `artifacts/qa/`, `artifacts/coverage/`, or any other
+non-canonical location is a policy violation per `evidence-and-timestamp-conventions` and is rejected
+by the `enforce-evidence-locations.ps1` PreToolUse hook. Timestamps use `yyyy-MM-ddTHH-mm`.
+
+EVIDENCE_LOCATION_OVERRIDE_REJECTED note: the legacy stub referenced `artifacts/` evidence paths; this
+plan substitutes the canonical `<FEATURE>/evidence/<kind>/` scheme for all evidence tasks.
+
+## Acceptance Criteria (source: issue.md `## Acceptance Criteria (early draft)` reconciled with spec/user-story)
+
+- **AC1** — A flag exists that enables or disables startup timing instrumentation; when disabled there is no behavioral or output change to startup.
+- **AC2** — When enabled, each startup sub-component's elapsed wall-clock time is captured during startup.
+- **AC3** — When enabled, a formatted plain-text table of sub-component names and elapsed times (plus a total row) is emitted to the output after startup completes.
+- **AC4** — The timing recorder/formatter is a testable unit (no Outlook/COM dependency) with MSTest coverage meeting the repository floor for new code (>= 90%).
+- **AC5** — Instrumentation uses existing logging/output infrastructure and existing approved dependencies; it does not change functional startup behavior.
+
+AC-to-task map is maintained in the final QA phase (Phase 5).
+
+---
+
+## Implementation Plan (Atomic Tasks)
+
+### Phase 0 — Baseline Capture & Policy Read
+
+- [x] [P0-T1] Record the policy-read evidence artifact at `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/phase0-instructions-read.2026-06-15T12-15.md`
+  - Acceptance: Artifact contains `Timestamp:`, `Policy Order:`, and an explicit list of files read in order: `CLAUDE.md`, `.claude/rules/general-code-change.md`, `.claude/rules/general-unit-test.md`, `.claude/rules/csharp.md`. No code is modified before this task completes.
+
+- [x] [P0-T2] Capture the CSharpier formatting baseline by running `dotnet tool run csharpier --check .` and writing the result to `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/format-baseline.2026-06-15T12-15.md`
+  - Acceptance: Artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (clean-or-dirty status). No source files are modified by this task.
+
+- [x] [P0-T3] Capture the analyzer (lint) build baseline by running `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true` and writing the result to `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/analyzer-baseline.2026-06-15T12-15.md`
+  - Acceptance: Artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (build pass/fail and analyzer warning count).
+
+- [x] [P0-T4] Capture the nullable/TreatWarningsAsErrors type-check baseline by running `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true` and writing the result to `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/typecheck-baseline.2026-06-15T12-15.md`
+  - Acceptance: Artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (pass/fail and any promoted-warning errors).
+
+- [x] [P0-T5] Capture the MSTest test + coverage baseline by running `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage` (include at minimum the `TaskMaster.Test` assembly) and writing the result to `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/test-coverage-baseline.2026-06-15T12-15.md`
+  - Acceptance: Artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` including numeric values: total tests passed/failed, repository-wide line coverage percent, and the current `ApplicationGlobals` line coverage percent. Coverage values must be numeric (not placeholders).
+
+- [x] [P0-T6] Record a design-resolution note for the startup timing recorder's table-formatting reuse at `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/other/timing-recorder-format-reuse.2026-06-15T12-15.md`
+  - Preconditions: `UtilitiesCS/HelperClasses/SegmentStopWatch.cs` and `UtilitiesCS/HelperClasses/PrettyPrint.cs` reviewed.
+  - Acceptance: Note records the selected design (no alternatives): `StartupTimingRecorder` maintains its OWN ordered collection of `(string phaseName, TimeSpan elapsed)` pairs in insertion order and does NOT wrap or call `SegmentStopWatch`. The note states the verified reason: `SegmentStopWatch.GetDurations()` (`UtilitiesCS/HelperClasses/SegmentStopWatch.cs` line 90) builds the TOTAL row from the watch's own `this.Elapsed`, which is `TimeSpan.Zero` for an injected-span watch, so wrapping `SegmentStopWatch` for injected spans yields an always-zero TOTAL and is unsatisfiable. The note records the genuinely reusable formatting primitive to call: `UtilitiesCS.HelperClasses.PrettyPrinters.ToFormattedText(this string[][] jagged, string[] headers = null, Enums.Justification[] justifications = default, string title = null)` defined in `UtilitiesCS/HelperClasses/PrettyPrint.cs` lines 179-184 (the same jagged `string[][]` overload `SegmentStopWatch.GetDurations` calls), invoked with headers `["Duration", "Action"]` and justifications `[Enums.Justification.Right, Enums.Justification.Left]` consistent with the existing convention. The note states the recorder computes a TOTAL row whose duration equals the SUM of all recorded spans (no reimplementation of column alignment). No production code is modified by this task.
+
+### Phase 1 — Settings Flag
+
+- [x] [P1-T1] Add the `StartupTimingEnabled` boolean user setting (default `False`) to `TaskMaster/Properties/Settings.settings`
+  - Acceptance: `Settings.settings` contains a `<Setting Name="StartupTimingEnabled" Type="System.Boolean" Scope="User">` entry with `<Value Profile="(Default)">False</Value>`, following the existing `EventsHooked` entry pattern.
+
+- [x] [P1-T2] Add the generated `StartupTimingEnabled` property (default `False`, `[UserScopedSetting]`, `[DefaultSettingValue("False")]`) to `TaskMaster/Properties/Settings.Designer.cs`
+  - Acceptance: `Settings.Designer.cs` exposes `public bool StartupTimingEnabled { get; set; }` consistent with the existing generated boolean settings; the generated value matches the `.settings` entry.
+
+- [x] [P1-T3] Run the full C# toolchain loop for Phase 1 in order and record the gate artifact at `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/phase1-toolchain.2026-06-15T12-15.md`
+  - Steps in order: (1) `dotnet tool run csharpier .`; (2) `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`; (3) `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`; (4) `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage`. Restart from step 1 if any step fails or changes files.
+  - Acceptance: Artifact records each step's `Command:`, `EXIT_CODE:`, and `Output Summary:`; final pass shows all four steps clean in a single pass.
+
+### Phase 2 — Recorder Abstraction
+
+- [x] [P2-T1] Create the internal recorder interface `internal interface IStartupTimingRecorder` in new file `TaskMaster/AppGlobals/IStartupTimingRecorder.cs`
+  - Acceptance: Interface declares `void RecordPhase(string phaseName, TimeSpan elapsed)`, `string FormatTable()`, and `void EmitTable(log4net.ILog logger)` with XML doc comments stating contracts (non-null `phaseName`, call-order recording, pure deterministic `FormatTable`, `[Startup timing]`-prefixed emission). File is < 500 lines.
+
+- [x] [P2-T2] Create `internal sealed class StartupTimingRecorder : IStartupTimingRecorder` in new file `TaskMaster/AppGlobals/StartupTimingRecorder.cs` that maintains its OWN ordered `(string phaseName, TimeSpan elapsed)` collection (does NOT wrap or call `SegmentStopWatch`)
+  - Preconditions: Design note from P0-T6.
+  - Acceptance: `RecordPhase(string phaseName, TimeSpan elapsed)` appends the supplied pre-measured pair to an internal ordered collection in insertion order. `FormatTable()` builds the table by reusing the existing public formatting primitive `UtilitiesCS.HelperClasses.PrettyPrinters.ToFormattedText(this string[][] jagged, string[] headers = null, Enums.Justification[] justifications = default, string title = null)` (`UtilitiesCS/HelperClasses/PrettyPrint.cs` lines 179-184) — reuse this primitive; do not reimplement column alignment. `FormatTable()` passes headers `["Duration", "Action"]` and justifications `[Enums.Justification.Right, Enums.Justification.Left]` consistent with the existing convention, one row per recorded phase, and a final `TOTAL` row whose duration equals the SUM of all recorded spans (not `TimeSpan.Zero`). `EmitTable` emits the formatted table via `logger.Info(...)` with the `[Startup timing]` prefix. No Outlook/COM, filesystem, or network access. File is < 500 lines.
+
+- [x] [P2-T3] Create `internal sealed class NullStartupTimingRecorder : IStartupTimingRecorder` (co-located in `TaskMaster/AppGlobals/StartupTimingRecorder.cs` or a separate `NullStartupTimingRecorder.cs`)
+  - Acceptance: `RecordPhase` returns immediately, `FormatTable` returns `string.Empty`, `EmitTable` emits nothing. No external dependencies. File(s) remain < 500 lines.
+
+- [x] [P2-T4] Create the recorder unit test class `StartupTimingRecorderTests` at `TaskMaster.Test/AppGlobals/StartupTimingRecorderTests.cs` (MSTest, FluentAssertions; AAA structure)
+  - Acceptance: New test file exists with `[TestClass]`/`[TestMethod]` and no temp files or external dependencies.
+
+- [x] [P2-T5] Add a `StartupTimingRecorder` test verifying named-span capture for positive durations and call ordering
+  - Acceptance: Test records multiple phases with distinct positive `TimeSpan` values; `FormatTable()` output contains each phase name in recorded order. Asserted with FluentAssertions; clear failure messages.
+
+- [x] [P2-T6] Add a `StartupTimingRecorder` test verifying zero-duration span handling
+  - Acceptance: Recording a phase with `TimeSpan.Zero` is captured and rendered without error; the phase name appears in `FormatTable()` output. Asserted with FluentAssertions.
+
+- [x] [P2-T7] Add a `StartupTimingRecorder` test verifying the formatted table contains the `Duration` and `Action` column headers, each phase name, and a `TOTAL` row whose duration equals the sum of the injected spans
+  - Acceptance: After recording multiple phases with distinct non-zero `TimeSpan` values injected deterministically, `FormatTable()` output contains the strings `Duration`, `Action`, and `TOTAL`, and contains each recorded phase name. The test parses/asserts the rendered TOTAL row duration and verifies it is non-zero and equals the sum of the injected non-zero phase spans (TOTAL reflects aggregate elapsed time). Because spans are injected deterministically (no `Stopwatch` in the recorder), this assertion is deterministic. Asserted with FluentAssertions.
+
+- [x] [P2-T8] Add a `NullStartupTimingRecorder` test verifying no-op behavior
+  - Acceptance: After `RecordPhase` calls, `FormatTable()` returns an empty string and `EmitTable(...)` produces no logged table (verified via a captured/mocked `log4net.ILog` confirming no `Info` table emission). Asserted with FluentAssertions/Moq.
+
+- [x] [P2-T9] Run the full C# toolchain loop for Phase 2 in order and record the gate artifact at `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/phase2-toolchain.2026-06-15T12-15.md`
+  - Steps in order: (1) `dotnet tool run csharpier .`; (2) analyzer msbuild; (3) nullable/TreatWarningsAsErrors msbuild; (4) `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage`. Restart from step 1 if any step fails or changes files.
+  - Acceptance: Artifact records each step's `Command:`, `EXIT_CODE:`, `Output Summary:`; `Output Summary:` includes the new recorder classes' line coverage percent (target >= 90%). All four steps clean in the final single pass.
+
+### Phase 3 — ApplicationGlobals Wiring
+
+- [x] [P3-T1] Add `using TaskMaster.Properties;` to `TaskMaster/AppGlobals/ApplicationGlobals.cs`
+  - Acceptance: The directive is present; the file compiles in the Phase 3 toolchain run.
+
+- [x] [P3-T2] Add the private field `private IStartupTimingRecorder _timingRecorder;` (or nullable equivalent) to `ApplicationGlobals`
+  - Acceptance: Field is declared as a private instance member; nullable-state is consistent with the C# nullable gate.
+
+- [x] [P3-T3] In `ApplicationGlobals.LoadAsync`, read `Settings.Default.StartupTimingEnabled` once before the sequential/parallel branch and assign `_timingRecorder` to a `StartupTimingRecorder` when enabled or a `NullStartupTimingRecorder` when disabled
+  - Preconditions: P3-T2.
+  - Acceptance: The flag is read exactly once in `LoadAsync`; on the disabled path `_timingRecorder` is the no-op recorder and no spans are recorded; follows the `Settings.Default.EventsHooked` consumption pattern. Parallel path behavior is unchanged.
+
+- [x] [P3-T4] Instrument `LoadBasicMethod()` itself with a single `System.Diagnostics.Stopwatch` (start at method entry, stop after the last assignment) and store the measured elapsed into a new private field `private TimeSpan _loadBasicElapsed;` on `ApplicationGlobals`; then, when the recorder is initialized in `LoadAsync` (flag on), record `("LoadBasic", _loadBasicElapsed)` as the FIRST phase before the six sequential phases
+  - Preconditions: P3-T3. `ApplicationGlobals.cs` constructor/`BasicLoaded` Lazy reviewed.
+  - Acceptance: `LoadBasicMethod()` measurement is UNCONDITIONAL (it does not branch on the flag) because the verified construction path runs `ForceBasicLoad()` inside the `ApplicationGlobals(Application, loadBasic: true)` constructor (line 43), materializing the `BasicLoaded` `Lazy<bool>` BEFORE `LoadAsync` runs; measuring around `ForceBasicLoad()` inside `LoadAsync` would record ~0. A single `Stopwatch` start/stop with no allocation is negligible overhead and satisfies the "negligible overhead when flag off" constraint — state this rationale in the implementation. When the flag is on, `("LoadBasic", _loadBasicElapsed)` is recorded exactly once as the FIRST recorded phase and reflects real construction time; when off, the no-op recorder is used and nothing is recorded. No COM-thread affinity or async restructuring is introduced. Uses `System.Diagnostics.Stopwatch` (not `DateTime.Now`/`UtcNow`).
+
+- [x] [P3-T5] In `LoadSequentialAsync`, record each of the six awaited phases (`IntelConfig`, `OlObjects`, `ToDo`, `AutoFile`, `Engines`, `Events`) by measuring elapsed time around each `await ...PhaseAsync()` and calling `_timingRecorder.RecordPhase(<phaseName>, elapsed)` after the await
+  - Preconditions: P3-T3, P3-T4 (the `LoadBasic` phase is recorded first; these six follow it in order).
+  - Acceptance: Each of the six phases records exactly one span, in startup order, after the `LoadBasic` phase from P3-T4; `YieldBetweenStartupPhasesAsync` calls are not recorded; phase ordering and existing functional behavior are unchanged. Timing uses `Stopwatch`. The recorder reference is invoked unconditionally (no-op recorder absorbs the flag-off case).
+
+- [x] [P3-T6] At the end of `LoadAsync` (after the sequential coordinator returns), emit the table once via `_timingRecorder.EmitTable(logger)`
+  - Acceptance: On the flag-on sequential path, exactly one `[Startup timing]` table is emitted via the `ApplicationGlobals` log4net `logger`; on the flag-off path nothing is emitted (no-op recorder). The parallel path emits via the same `EmitTable` call without new phase instrumentation (parallel phase recording is out of scope per the user story Non-Goals).
+
+- [x] [P3-T7] Verify `ApplicationGlobals.cs` remains under the 500-line file-size limit
+  - Acceptance: File line count is < 500.
+
+- [x] [P3-T8] Run the full C# toolchain loop for Phase 3 in order and record the gate artifact at `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/phase3-toolchain.2026-06-15T12-15.md`
+  - Steps in order: (1) csharpier; (2) analyzer msbuild; (3) nullable/TreatWarningsAsErrors msbuild; (4) `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage`. Restart from step 1 if any step fails or changes files.
+  - Acceptance: Artifact records each step's `Command:`, `EXIT_CODE:`, `Output Summary:`; all four steps clean in the final single pass.
+
+### Phase 4 — ApplicationGlobals Wiring Tests
+
+- [x] [P4-T1] Extend `TestableApplicationGlobals` in `TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` to expose a seam that lets tests inject/observe `_timingRecorder` and drive `LoadAsync`/`LoadSequentialAsync` deterministically without a live Outlook process
+  - Preconditions: Existing `TestableApplicationGlobals` override pattern (visited-stages) at lines ~386–438.
+  - Acceptance: The test double supports observing recorded phase names/order and the chosen recorder type, reusing the existing per-phase override seam; no temp files, no external dependencies, deterministic.
+
+- [x] [P4-T2] Add a test verifying the flag-off path records nothing and emits no table
+  - Acceptance: With `StartupTimingEnabled` resolved to off, after driving the sequential load no spans are recorded and no `[Startup timing]` table is emitted (verified via mocked/captured `log4net.ILog` or the observed recorder). Asserted with FluentAssertions/Moq. AAA structure.
+
+- [x] [P4-T3] Add a test verifying the flag-on path records all instrumented phases in startup order, with `LoadBasic` first
+  - Preconditions: P3-T4 (LoadBasic recorded first), P3-T5.
+  - Acceptance: With the flag on, the recorded phase sequence equals `["LoadBasic", "IntelConfig", "OlObjects", "ToDo", "AutoFile", "Engines", "Events"]` (or the subset driven by the sequential overrides, but always with `LoadBasic` as the first element), in order. The test explicitly asserts the first recorded phase name is `LoadBasic`. Asserted with FluentAssertions.
+
+- [x] [P4-T4] Add a test verifying the flag-on path emits exactly one formatted table containing each phase name and a TOTAL row
+  - Acceptance: After the flag-on sequential load, the captured `[Startup timing]` emission occurs once and its text contains each recorded phase name and `TOTAL`. Asserted with FluentAssertions.
+
+- [x] [P4-T5] Add a test verifying instrumentation preserves existing phase ordering and behavior (regression guard)
+  - Acceptance: The existing phase-visit ordering and yield-count behavior are unchanged when timing is on versus off; the test asserts the visited-stages sequence is identical in both modes. Asserted with FluentAssertions.
+
+- [x] [P4-T6] Run the full C# toolchain loop for Phase 4 in order and record the gate artifact at `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/phase4-toolchain.2026-06-15T12-15.md`
+  - Steps in order: (1) csharpier; (2) analyzer msbuild; (3) nullable/TreatWarningsAsErrors msbuild; (4) `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage`. Restart from step 1 if any step fails or changes files.
+  - Acceptance: Artifact records each step's `Command:`, `EXIT_CODE:`, `Output Summary:`; `Output Summary:` includes the post-change `ApplicationGlobals` line coverage percent. All four steps clean in the final single pass.
+
+### Phase 5 — Final QA Loop, Coverage Verification & AC Check-off
+
+- [x] [P5-T1] Run the final formatting gate `dotnet tool run csharpier .` and record `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/final-format.2026-06-15T12-15.md`
+  - Acceptance: Artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`; no files changed by the final run.
+
+- [x] [P5-T2] Run the final analyzer gate `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true` and record `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/final-analyzer.2026-06-15T12-15.md`
+  - Acceptance: Artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`; build passes with no new analyzer regressions.
+
+- [x] [P5-T3] Run the final type-check gate `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true` and record `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/final-typecheck.2026-06-15T12-15.md`
+  - Acceptance: Artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`; build passes with no promoted-warning errors.
+
+- [x] [P5-T4] Run the final test+coverage gate `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage` and record `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/final-test-coverage.2026-06-15T12-15.md`
+  - Acceptance: Artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` with numeric values: all tests pass, repository-wide line coverage percent, new recorder classes' coverage percent, and post-change `ApplicationGlobals` coverage percent.
+  - Note: If any of P5-T1..P5-T4 changes files or fails, restart the loop from P5-T1 per the toolchain restart rule.
+
+- [x] [P5-T5] Record the coverage delta/threshold verification at `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/coverage-delta.2026-06-15T12-15.md`
+  - Preconditions: P0-T5 (baseline) and P5-T4 (post-change).
+  - Acceptance: Artifact reports baseline coverage, post-change coverage, and new/changed-code coverage; confirms repository-wide line coverage remains >= 80%, new recorder classes reach >= 90%, and changed `ApplicationGlobals` lines show no coverage regression. If any required value is unavailable or a threshold is unmet, the outcome is recorded as remediation-required (not PASS).
+
+- [x] [P5-T6] Map each acceptance criterion to its implementing/verifying tasks per `acceptance-criteria-tracking` and record `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/issue-updates/ac-checkoff.2026-06-15T12-15.md`
+  - Acceptance: Artifact contains the AC-to-task mapping below with each AC marked PASS only when its verification task and evidence exist:
+    - AC1 (flag on/off, no change when off) → P1-T1, P1-T2, P3-T3, P3-T4, P3-T6 (impl); P4-T2, P4-T5 (verify)
+    - AC2 (per-sub-component elapsed captured when on) → P3-T4, P3-T5 (impl); P4-T3 (verify)
+    - AC3 (formatted table with TOTAL emitted after startup) → P2-T2, P3-T6 (impl); P2-T7, P4-T4 (verify)
+    - AC4 (testable recorder, >= 90% new-code coverage) → P2-T1, P2-T2, P2-T3 (impl); P2-T4..P2-T8, P5-T4, P5-T5 (verify)
+    - AC5 (existing logging/deps only, no functional change) → P2-T2, P3-T6 (impl); P4-T5, P5-T2, P5-T3 (verify)
+
+- [x] [P5-T7] Update the feature `issue.md` and `spec.md` acceptance-criteria checkboxes to reflect verified status and mirror the update per `evidence-and-timestamp-conventions`
+  - Acceptance: `issue.md` and `spec.md` AC checkboxes reflect the verified state from P5-T6; a mirror artifact exists under `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/issue-updates/`.
+
+## Test Plan
+
+- Unit (recorder): `TaskMaster.Test/AppGlobals/StartupTimingRecorderTests.cs` — named-span capture (positive, zero-duration, ordering), table format (headers + TOTAL), null recorder no-op. MSTest + Moq + FluentAssertions.
+- Unit (wiring): `TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` (extend `TestableApplicationGlobals`) — flag-off records nothing/emits nothing, flag-on records all phases in order, single-table emission with phase names + TOTAL, phase-ordering regression guard.
+- Integration: not applicable (no live Outlook process; COM-bound paths are stubbed via existing seams).
+- Manual/CLI: none (feature has no CLI surface).
+- Coverage evidence:
+  - Baseline: `evidence/baseline/test-coverage-baseline.2026-06-15T12-15.md`
+  - Post-change: `evidence/qa-gates/final-test-coverage.2026-06-15T12-15.md`
+  - Comparison: `evidence/qa-gates/coverage-delta.2026-06-15T12-15.md`
+
+## Open Questions / Notes
+
+- Selected design (no alternatives): `StartupTimingRecorder` maintains its OWN ordered `(string phaseName, TimeSpan elapsed)` collection and does NOT wrap `SegmentStopWatch`. Verified reason: `SegmentStopWatch.GetDurations()` (`UtilitiesCS/HelperClasses/SegmentStopWatch.cs` line 90) builds the TOTAL row from the watch's own `this.Elapsed`, which is `TimeSpan.Zero` for an injected-span watch, making the wrapping approach yield an always-zero TOTAL. The recorder instead reuses the genuinely reusable formatting primitive `UtilitiesCS.HelperClasses.PrettyPrinters.ToFormattedText(this string[][] jagged, ...)` (`UtilitiesCS/HelperClasses/PrettyPrint.cs` lines 179-184) — the same overload `GetDurations` calls — with headers `["Duration", "Action"]` and right/left justifications, and computes a summed TOTAL row. Captured in design-resolution task P0-T6; constrains P2-T2 and P2-T7.
+- LoadBasic measurement is taken inside `LoadBasicMethod()` (not around `ForceBasicLoad()` in `LoadAsync`). Verified reason: when `ApplicationGlobals` is constructed with `loadBasic: true`, `ForceBasicLoad()` runs in the constructor (`ApplicationGlobals.cs` line 43) and materializes the `BasicLoaded` `Lazy<bool>` before `LoadAsync` executes, so measuring inside `LoadAsync` records ~0. The recorder records `("LoadBasic", _loadBasicElapsed)` as the first phase when the flag is on. Captured in P3-T4; P3-T5 and P4-T3 depend on LoadBasic being first.
+- Parallel path (`LoadParallelAsync`) phase recording is out of scope (user-story Non-Goals). `EmitTable` is still called at the end of `LoadAsync`; on the parallel path no sequential phase spans are recorded, so the emitted table contains the `LoadBasic` row (recorded unconditionally) plus a summed TOTAL row when the flag is on.
+- No new dependencies: `PrettyPrinters.ToFormattedText`, `Stopwatch`, and `log4net` are already approved and present. `Stopwatch`-based timing does not trigger the BannedApiAnalyzers `DateTime.Now`/`UtcNow` rule.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/policy-audit.2026-06-15T13-29.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/policy-audit.2026-06-15T13-29.md
@@ -1,0 +1,466 @@
+# Policy Compliance Audit: debug-startup-timing-instrumentation (Issue #202)
+
+**Audit Date:** 2026-06-15
+**Code Under Test:** Branch `feature/debug-startup-timing-instrumentation-202` @ `1d193d90` vs base `main` @ `a21d09e1` (merge-base `a21d09e18dfebb9e3450c1b3322e7715c09d91e6`)
+
+Files modified (source/test/build, all C#):
+- `TaskMaster/AppGlobals/IStartupTimingRecorder.cs` (NEW, 40 lines)
+- `TaskMaster/AppGlobals/StartupTimingRecorder.cs` (NEW, 95 lines)
+- `TaskMaster/AppGlobals/ApplicationGlobals.cs` (MODIFIED, 247 lines)
+- `TaskMaster/Properties/Settings.settings` (MODIFIED)
+- `TaskMaster/Properties/Settings.Designer.cs` (MODIFIED, generated)
+- `TaskMaster/TaskMaster.csproj` (MODIFIED, +2 Compile includes)
+- `TaskMaster.Test/AppGlobals/StartupTimingRecorderTests.cs` (NEW, 184 lines)
+- `TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` (MODIFIED, 687 lines; baseline 440)
+- `TaskMaster.Test/TaskMaster.Test.csproj` (MODIFIED, +1 Compile include)
+
+Documentation/evidence (non-code): 21 files under `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/**` (scoping docs, plan, evidence artifacts).
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| C# | 9 files (6 .cs, 2 .csproj, 1 .settings) | 4194 tests | ✅ 4194 pass, 0 fail | 75.08% first-party prod lines (76.30% raw) | 75.12% first-party prod lines (76.36% raw) | 100% (StartupTimingRecorder + NullStartupTimingRecorder) |
+
+**Note:** C# is the only language with changed files in the branch diff. TypeScript, Python, PowerShell, Bash, and JSON have zero changed files and are therefore N/A for coverage.
+
+### Coverage Evidence Checklist
+
+- TypeScript baseline coverage artifact: `N/A - out of scope` (no TypeScript files changed)
+- TypeScript post-change coverage artifact: `N/A - out of scope` (no TypeScript files changed)
+- PowerShell baseline coverage artifact: `N/A - out of scope` (no PowerShell files changed)
+- PowerShell post-change coverage artifact: `N/A - out of scope` (no PowerShell files changed)
+- Per-language comparison summary: see Section 1.2.1 below; underlying data `TestResults/final-full.cobertura.xml` and `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/coverage-delta.2026-06-15T12-15.md`
+
+**Non-negotiable verdict rule:** Numeric baseline and post-change coverage metrics are present for the single in-scope language (C#), plus new-code coverage.
+
+**Fail-closed rule:** Verifiable Cobertura coverage data exists at `TestResults/final-full.cobertura.xml` and was parsed directly for this audit. The canonical artifact path `artifacts/csharp/coverage.xml` named by the feature-review-workflow is absent; this is recorded as a Minor process finding (Section 8), not a coverage-data gap, because the equivalent Cobertura data was located and verified.
+
+**Evidence rule:** All coverage figures below were read directly from `TestResults/final-full.cobertura.xml` (root `line-rate`, and per-class `line-rate` for the new and modified classes) and cross-checked against the executor's `coverage-delta` and `final-test-coverage` evidence artifacts. No figures were synthesized.
+
+---
+
+## Executive Summary
+
+This branch adds enable-on-demand startup-timing instrumentation to the TaskMaster Outlook VSTO add-in (issue #202). The change is gated behind a new `Settings.Default.StartupTimingEnabled` user setting (default `False`). When enabled, `ApplicationGlobals.LoadAsync(parallel: false)` records wall-clock spans for the seven established phase seams (LoadBasic, IntelConfig, OlObjects, ToDo, AutoFile, Engines, Events) and emits one formatted `[Startup timing]` table via the existing log4net logger. Recording and formatting logic is isolated in a new, COM-free `IStartupTimingRecorder` abstraction with a production `StartupTimingRecorder` and a `NullStartupTimingRecorder` no-op used on the flag-off path.
+
+The implementation is well-structured, separates pure formatting logic from the COM-bound startup coordinator, reuses the existing `PrettyPrinters.ToFormattedText` primitive, uses `Stopwatch` (avoiding the banned `DateTime.Now`/`UtcNow` API), and is covered by 11 new MSTest tests (7 recorder, 4 wiring). New-code coverage is 100% and the modified `ApplicationGlobals` shows no coverage regression (improved). The toolchain (CSharpier, analyzer build, nullable/TreatWarningsAsErrors build, MSTest+coverage) was executed by the implementing agent and recorded as EXIT_CODE 0 in feature evidence.
+
+One FAIL-level policy finding was identified: `TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` grew from 440 to 687 lines, exceeding the repository 500-line file-size limit (General Code Change Policy §4 / `.claude/rules/general-code-change.md`). One Minor process finding: the canonical C# coverage artifact `artifacts/csharp/coverage.xml` is absent (equivalent Cobertura data exists and was verified).
+
+**Policy documents evaluated:**
+- ✅ `CLAUDE.md` general code-change and unit-test policies
+- ✅ `.claude/rules/general-code-change.md`
+- ✅ `.claude/rules/general-unit-test.md`
+
+**Language-specific policies evaluated:**
+- N/A `python-code-change` + `python-unit-test` (no Python files changed)
+- N/A `powershell-code-change` + `powershell-unit-test` (no PowerShell files changed)
+- N/A Bash (no Bash files changed)
+- N/A JSON (no governed JSON files changed)
+- ✅ C# Code Change Policy + C# Unit Test Policy (CLAUDE.md C#1–C#7, CUT1–CUT3)
+
+**Temporary artifacts cleanup:**
+- ✅ No temporary/one-time scripts were introduced by this branch (diff is source/test/build/docs only).
+- N/A No ongoing tooling scripts added.
+
+---
+
+## Rejected Scope Narrowing
+
+The caller prompt supplied the base branch, merge-base SHA, head SHA, and feature folder, and explicitly instructed: "Determine review scope yourself from the branch diff against the merge-base and execute the full SKILL contract." No instruction attempted to narrow scope to a plan/task/phase subset, to a subset of changed files, or to mark any language as out of scope. No scope-narrowing was detected; none was rejected.
+
+Note on PR-context misclassification: `artifacts/pr_context.summary.txt` reports "Core logic changes: 0 files" and classifies all changes as "Docs/templates/agents/tooling." This is a misclassification of the C# source changes. The audit scope was taken from the actual `git diff a21d09e1..1d193d90`, which contains 6 changed `.cs` files plus build/settings files, not from the summary's overview counters.
+
+---
+
+## Evidence Location Compliance
+
+Scanned the branch diff for files written under `artifacts/baselines/`, `artifacts/qa/`, `artifacts/evidence/`, or `artifacts/coverage/`:
+
+```
+git diff --name-only a21d09e1..1d193d90 | grep -E "^artifacts/(baselines|qa|evidence|coverage)/"
+```
+
+Result: NONE. All evidence artifacts produced by the implementing agent are written to the canonical `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/<kind>/` layout (`baseline/`, `qa-gates/`, `issue-updates/`, `other/`). No non-canonical evidence-location violations found. Disposition: PASS.
+
+(The repository does not ship a `validate_evidence_locations.py` script; verification was performed by direct diff scan.)
+
+---
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Independence** - Tests run in any order | ✅ PASS | New recorder tests inject deterministic spans and share no state. Wiring tests in `ApplicationGlobalsTests.cs` save/restore `Settings.Default.StartupTimingEnabled` in `[TestInitialize]`/`[TestCleanup]` and are marked `[DoNotParallelize]` because they mutate the process-global settings singleton and the process-global log4net logger. |
+| **Isolation** - Each test targets single behavior | ✅ PASS | Recorder tests target one behavior each (ordering, zero-duration, total sum, null-name throw, emit prefix, null-logger throw, null recorder no-op). Wiring tests target flag-off no-emit, flag-on phase order, single-table emission, and ordering/yield-count parity. |
+| **Fast Execution** - Tests complete quickly | ✅ PASS | All durations injected; no real timing waits. Full suite of 4194 tests reported green (EXIT_CODE 0) in `final-test-coverage.2026-06-15T12-15.md`. |
+| **Determinism** - Consistent results | ✅ PASS | No clock, no sleep, no filesystem, no network. `TestableApplicationGlobals.LoadBasicMethod` sets a fixed `TimeSpan.FromMilliseconds(7)`; recorder tests inject fixed spans. |
+| **Readability & Maintainability** - Clear structure | ⚠️ PARTIAL | Test names are descriptive and AAA-structured with intent comments. However `ApplicationGlobalsTests.cs` is 687 lines, exceeding the 500-line limit (see Section 2.3 and Section 8). |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Baseline Coverage Documented** | ✅ PASS | **Baseline:** 75.08% first-party production lines (36372/48447); 76.30% raw. **Command:** `vstest.console.exe <7 assemblies> /Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation`. **Timestamp:** 2026-06-15 12:15. Source: `evidence/baseline/test-coverage-baseline.2026-06-15T12-15.md`. |
+| **No Coverage Regression** | ✅ PASS | **Post-change:** 75.12% first-party production lines (36436/48504); 76.36% raw. **Change:** +0.04 first-party, +0.06 raw. **Status:** No regression (improved). Verified from `TestResults/final-full.cobertura.xml` root `line-rate="0.7636476378107266"`. |
+| **New Code Coverage >=90%** | ✅ PASS | **New files:** `StartupTimingRecorder.cs`. **New code coverage:** 100%. Verified directly: `TaskMaster.StartupTimingRecorder` `line-rate="1"` and `TaskMaster.NullStartupTimingRecorder` `line-rate="1"` in `final-full.cobertura.xml`. |
+| **Comprehensive Coverage** | ✅ PASS | `StartupTimingRecorder.RecordPhase/FormatTable/EmitTable` and `NullStartupTimingRecorder` are exercised; `ApplicationGlobals` flag read, recorder selection, LoadBasic Stopwatch, per-phase recording, `StopAndRestart`, and `EmitTable` call are all covered. Uncovered remainder of `ApplicationGlobals` is the pre-existing, out-of-scope parallel path (user-story Non-Goal). |
+| **Positive Flows** - Valid inputs | ✅ PASS | `RecordPhase_WithPositiveDurations_...`, `FormatTable_ContainsHeaders...`, `LoadAsync_WhenTimingEnabled_RecordsAllPhasesInStartupOrder...`, `..._EmitsExactlyOneTableWithPhaseNamesAndTotal`. |
+| **Negative Flows** - Invalid inputs | ✅ PASS | `RecordPhase_WithNullPhaseName_ThrowsArgumentNullException`, `EmitTable_WithNullLogger_ThrowsArgumentNullException`. |
+| **Edge Cases** - Boundary conditions | ✅ PASS | `RecordPhase_WithZeroDuration_IsCapturedAndRenderedWithoutError`; null recorder empty-table case. |
+| **Error Handling** - Error paths | ✅ PASS | Null-argument throws verified with `WithParameterName`. |
+| **Concurrency** - If applicable | ✅ PASS | Shared-global tests marked `[DoNotParallelize]` to avoid cross-class interference on the settings singleton and log4net logger. |
+| **State Transitions** - If applicable | ✅ PASS | Recorder accumulates spans in call order; ordering asserted in `RecordedPhaseNames` and rendered output. |
+
+### 1.2.1 Per-Language Coverage Comparison
+
+- C#: Baseline: 75.08% first-party production lines -> Post-change: 75.12% first-party production lines. Change: +0.04% line delta. New/changed-code coverage: 100%. Disposition: PASS. Evidence: `TestResults/final-full.cobertura.xml`, `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/coverage-delta.2026-06-15T12-15.md`, `.../evidence/qa-gates/final-test-coverage.2026-06-15T12-15.md`.
+- TypeScript: Baseline: N/A% lines -> Post-change: N/A% lines. Change: N/A% line delta. New/changed-code coverage: `N/A - out of scope`. Disposition: N/A. Evidence: `N/A - out of scope` (no TypeScript files changed in branch diff).
+- PowerShell: Baseline: N/A% lines -> Post-change: N/A% lines. Change: N/A% line delta. New/changed-code coverage: `N/A - out of scope`. Disposition: N/A. Evidence: `N/A - out of scope` (no PowerShell files changed in branch diff).
+- Python: Baseline: N/A% lines -> Post-change: N/A% lines. Change: N/A% line delta. New/changed-code coverage: `N/A - out of scope`. Disposition: N/A. Evidence: `N/A - out of scope` (no Python files changed in branch diff).
+
+Repo-wide C# note: the 75.12% first-party production-only figure is below the literal 80% number, but the denominator includes the COM/VSTO/WinForms-bound and `[ExcludeFromCodeCoverage]`-exempt classes that CLAUDE.md formally exempts from the 80% floor (the floor applies to the testable denominator after exemptions). This is a pre-existing repository condition not introduced or worsened by #202; the feature improves the figure by +0.04. Disposition for the repo-wide gate: no regression; consistent with documented exemption.
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clear Failure Messages** | ✅ PASS | FluentAssertions with `because` rationale strings throughout (e.g., "phases must be rendered in the order they were recorded."). |
+| **Arrange-Act-Assert Pattern** | ✅ PASS | Each test uses explicit Arrange/Act/Assert comment sections. |
+| **Document Intent** | ✅ PASS | Descriptive `MethodUnderTest_Condition_Expectation` names plus class/test docstrings. |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Avoid External Dependencies** | ✅ PASS | No database/network/process. log4net `MemoryAppender` is attached in-process for assertion; no live Outlook/COM. |
+| **Use Mocks/Stubs** | ✅ PASS | Moq used for `IAppItemEngines` and `log4net.ILog`; `TestableApplicationGlobals` stubs COM collaborator construction via overridable seams. MSTest + Moq + FluentAssertions per CUT1/CUT2. |
+| **Environment Stability** | ✅ PASS | No temporary files created. Settings singleton mutation is saved/restored per test; tests marked `[DoNotParallelize]` to isolate global state. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Pre-submission Review** | ✅ PASS | This document is the required policy review. Outstanding item: 500-line test-file limit (Section 8). |
+
+---
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clarify the objective** | ✅ PASS | Objective documented in `issue.md`, `spec.md`, `user-story.md` (issue #202). |
+| **Read existing change plans** | ✅ PASS | `plan.2026-06-15T12-15.md` present with phased tasks and Phase 0 policy-read evidence. |
+| **Document the plan** | ✅ PASS | Atomic plan plus per-phase toolchain gate evidence under `evidence/qa-gates/`. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Simplicity first** | ✅ PASS | A small interface plus two implementations; a single shared `Stopwatch` with a `StopAndRestart` helper. No deep indirection. |
+| **Reusability** | ✅ PASS | Reuses `UtilitiesCS.PrettyPrinters.ToFormattedText` (the same overload `SegmentStopWatch.GetDurations()` uses) rather than reimplementing column alignment. |
+| **Extensibility** | ✅ PASS | `IStartupTimingRecorder` interface enables alternative implementations; flag selects concrete vs no-op. |
+| **Separation of concerns** | ✅ PASS | Pure recording/formatting logic isolated from the COM-bound startup coordinator; recorder has no Outlook/COM/IO dependency. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive modules** | ✅ PASS | Interface, recorder+null-recorder, and coordinator wiring are each in cohesive files. |
+| **Under 500 lines** | ❌ FAIL | `IStartupTimingRecorder.cs` 40, `StartupTimingRecorder.cs` 95, `ApplicationGlobals.cs` 247, `StartupTimingRecorderTests.cs` 184 are within limit. `ApplicationGlobalsTests.cs` is **687 lines** (baseline 440), exceeding the 500-line limit. The General Code Change Policy applies the limit to test code; the markdown/fixture exceptions do not apply. Remediation required (Section 8). |
+| **Public vs internal** | ✅ PASS | Recorder types are `internal sealed`; consumed by tests via existing `InternalsVisibleTo("TaskMaster.Test")`. New `protected internal virtual LoadBasicMethod` is a minimal test seam, documented as such. |
+| **No circular dependencies** | ✅ PASS | Recorder depends only on `System`, `UtilitiesCS`, and `log4net`; no back-dependency from those onto `ApplicationGlobals`. |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Descriptive names** | ✅ PASS | `RecordPhase`, `FormatTable`, `EmitTable`, `StartupTimingRecorder`, `NullStartupTimingRecorder`, `_loadBasicElapsed`, `StopAndRestart`. |
+| **Docs/docstrings** | ✅ PASS | XML doc comments on interface members and classes describe contract, COM-free guarantee, and the deliberate non-wrapping of `SegmentStopWatch`. |
+| **Comment why, not what** | ✅ PASS | Comments explain the LoadBasic-at-construction measurement rationale, the always-zero `SegmentStopWatch.GetDurations()` total pitfall, and the negligible-overhead flag-off design. |
+
+### 2.5 After Making Changes - Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **1. Formatting** | ✅ PASS | **Command:** `csharpier check .` (CSharpier v1.3.0). **Result:** EXIT_CODE 0 (`evidence/qa-gates/final-format.2026-06-15T12-15.md`). |
+| **2. Linting** | ✅ PASS | **Command:** `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`. **Result:** EXIT_CODE 0 (`evidence/qa-gates/final-analyzer.2026-06-15T12-15.md`). |
+| **3. Type checking** | ✅ PASS | **Command:** `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`. **Result:** EXIT_CODE 0 (`evidence/qa-gates/final-typecheck.2026-06-15T12-15.md`). |
+| **4. Testing** | ✅ PASS | **Command:** `vstest.console.exe <7 assemblies> /Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation /ResultsDirectory:TestResults/final-full`. **Result:** 4194/4194 passed, EXIT_CODE 0. |
+| **Full toolchain loop** | ✅ PASS | Final pass recorded clean across all four steps in the feature evidence. |
+| **Explicit reporting** | ✅ PASS | Commands and results documented in `evidence/qa-gates/` artifacts and re-cited in this audit. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Summarize changes** | ✅ PASS | Plan and evidence artifacts summarize the change. |
+| **Design choices explained** | ✅ PASS | `evidence/other/timing-recorder-format-reuse.2026-06-15T12-15.md` records the formatter-reuse / non-wrapping decision and the log4net-vs-Console channel decision. |
+| **Update supporting documents** | ✅ PASS | `spec.md`, `user-story.md`, `issue.md` AC items updated and checked off; plan check-offs recorded. |
+| **Provide next steps** | ✅ PASS | Plan verification notes describe test scope and coverage evidence. |
+
+---
+
+## 3. Language-Specific Code Change Policy Compliance
+
+### Section 3 (C#): C# Code Change Policy Compliance
+
+#### C# Tooling & Baseline
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Formatting with CSharpier** | ✅ PASS | `csharpier check .` EXIT_CODE 0. `dotnet format` not used. |
+| **Linting / .NET analyzers** | ✅ PASS | Analyzer build EXIT_CODE 0 with `EnableNETAnalyzers`/`EnforceCodeStyleInBuild`. |
+| **Type checking / nullable** | ✅ PASS | Nullable + `TreatWarningsAsErrors` build EXIT_CODE 0. New code uses guard clauses and `new()` target-typed; no nullable warnings introduced. |
+
+#### C# Design & Type-Safety
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Strong contracts and explicit APIs** | ✅ PASS | Interface with explicit `TimeSpan`/`string`/`log4net.ILog` types; XML-documented contracts. |
+| **Null-safety by default** | ✅ PASS | `RecordPhase` and `EmitTable` throw `ArgumentNullException` on null inputs. |
+| **Composition and focused types** | ✅ PASS | Two small sealed implementations behind one interface; no inheritance beyond the interface. |
+| **Asynchrony and resource safety** | ✅ PASS | No new disposables; existing async phase awaits unchanged. `Stopwatch` requires no disposal. |
+
+#### C# Module & Structure / Naming / Dependencies
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **File focus and size** | ⚠️ PARTIAL | Production files are focused and within limit; the modified test file exceeds 500 lines (see Section 2.3 FAIL). |
+| **Internal-by-default surface** | ✅ PASS | Recorder types `internal sealed`. |
+| **Banned-API compliance** | ✅ PASS | Uses `System.Diagnostics.Stopwatch` (hardware-counter), explicitly avoiding the BannedApiAnalyzers `DateTime.Now`/`DateTime.UtcNow` rule, per spec. No banned APIs introduced. |
+| **No new dependencies** | ✅ PASS | `UtilitiesCS.PrettyPrinters`, `Stopwatch`, `log4net` already present and approved. |
+
+---
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+### Section 4 (C#): C# Unit Test Policy Compliance
+
+#### Framework and Scope
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Use MSTest** | ✅ PASS | `[TestClass]`/`[TestMethod]` from `Microsoft.VisualStudio.TestTools.UnitTesting`. No xUnit/NUnit introduced. |
+| **Mocking with Moq** | ✅ PASS | `Mock<IAppItemEngines>`, `Mock<log4net.ILog>` with `MockBehavior.Strict`/`Loose` as appropriate. |
+| **Assertions with FluentAssertions** | ✅ PASS | FluentAssertions used throughout (`.Should().Be/Contain/Throw/Equal`). |
+| **Coverage expectation** | ✅ PASS | New code 100% (>=90% floor); modified `ApplicationGlobals` no regression. |
+
+#### Test Style and Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Focused unit tests** | ✅ PASS | One behavior per test. |
+| **Mocking sparingly** | ✅ PASS | Mocks limited to the COM-bound engine collaborator and the logger sink. |
+| **Organization** | ✅ PASS | Test files mirror source location (`AppGlobals/`). |
+| **Naming and readability** | ⚠️ PARTIAL | Names/structure are clear, but the modified test file size exceeds the limit. |
+
+---
+
+## 5. Test Coverage Detail
+
+### StartupTimingRecorder / NullStartupTimingRecorder (7 tests)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| RecordPhase_WithPositiveDurations_PreservesPhaseNamesInRecordedOrder | Positive | ✅ |
+| RecordPhase_WithZeroDuration_IsCapturedAndRenderedWithoutError | Edge Case | ✅ |
+| FormatTable_ContainsHeadersPhaseNamesAndTotalEqualToSumOfInjectedSpans | Positive | ✅ |
+| RecordPhase_WithNullPhaseName_ThrowsArgumentNullException | Negative | ✅ |
+| EmitTable_LogsFormattedTableViaLoggerInfoWithStartupTimingPrefix | Positive | ✅ |
+| EmitTable_WithNullLogger_ThrowsArgumentNullException | Negative | ✅ |
+| NullStartupTimingRecorder_IsNoOp_ForFormatAndEmit | Edge Case | ✅ |
+
+**Coverage:** 100% of `StartupTimingRecorder.cs` (30/30 lines).
+
+**Not covered:** None.
+
+### ApplicationGlobals startup-timing wiring (4 tests)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| LoadAsync_WhenTimingDisabled_RecordsNothingAndEmitsNoTable | Negative (flag off) | ✅ |
+| LoadAsync_WhenTimingEnabled_RecordsAllPhasesInStartupOrderWithLoadBasicFirst | Positive | ✅ |
+| LoadAsync_WhenTimingEnabled_EmitsExactlyOneTableWithPhaseNamesAndTotal | Positive | ✅ |
+| LoadAsync_PreservesPhaseOrderingAndYieldCount_WhenTimingOnVersusOff | State Transition | ✅ |
+
+**Coverage:** `TaskMaster.ApplicationGlobals` class line-rate 77.6% (file aggregate incl. nested types 73.88%, up from 60.75% baseline). New timing lines covered; uncovered remainder is the pre-existing out-of-scope parallel path.
+
+**Not covered:** Pre-existing `LoadParallelAsync` body and parallel branch (user-story Non-Goal; uncovered in baseline; no regression).
+
+---
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total Tests | 4194 | ✅ |
+| Tests Passed | 4194 (100%) | ✅ |
+| Tests Failed | 0 | ✅ |
+| New Tests Added | 11 (7 recorder + 4 wiring) | ✅ |
+| Functions/Classes Tested (new) | 2/2 new classes (100%) | ✅ |
+| Test File Size | `ApplicationGlobalsTests.cs` 687 lines | ❌ Exceeds 500-line limit |
+| Code Coverage (new code) | 100% lines | ✅ |
+| Code Coverage (repo-wide first-party prod) | 75.12% lines (no regression; COM/VSTO exemption applies) | ⚠️ Below literal 80%, exemption-consistent, no regression |
+
+---
+
+## 7. Code Quality Checks
+
+**For C#:**
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| CSharpier Formatting | `csharpier check .` | EXIT_CODE 0 | ✅ |
+| .NET Analyzer Build | `msbuild TaskMaster.sln /t:Build /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true` | EXIT_CODE 0 | ✅ |
+| Nullable Type-check Build | `msbuild TaskMaster.sln /t:Build /p:Nullable=enable /p:TreatWarningsAsErrors=true` | EXIT_CODE 0 | ✅ |
+| MSTest Tests + Coverage | `vstest.console.exe <7 assemblies> /Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation` | 4194/4194 pass, EXIT_CODE 0 | ✅ |
+
+**Notes:**
+The repo-wide first-party production-only figure (75.12%) is below the literal 80% number but is a pre-existing condition consistent with the documented COM/VSTO/WinForms exemption; #202 improves it by +0.04. The toolchain evidence reflects the implementing agent's runs; this reviewer did not re-execute the build/test (check-only review), and parsed the existing Cobertura artifact for coverage verification.
+
+---
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+
+- **Under 500 lines (test file):** `TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` is 687 lines (baseline 440), exceeding the General Code Change Policy 500-line file-size limit. The added startup-timing wiring tests and helper methods (`AttachMemoryAppender`, `DetachMemoryAppender`, `SetEnginesMock`, expanded `TestableApplicationGlobals`) pushed the file over the limit. Remediation: split the startup-timing wiring tests (and their helpers) into a separate test file, for example `TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs`, so each file is under 500 lines. This is a FAIL-level policy finding and a remediation trigger.
+- **Canonical C# coverage artifact absent (Minor/process):** The feature-review-workflow names `artifacts/csharp/coverage.xml` as the C# coverage artifact. That path does not exist. Equivalent Cobertura coverage data exists at `TestResults/final-full.cobertura.xml` and was parsed directly; all coverage thresholds were verifiable. Recommendation: emit/copy the canonical `artifacts/csharp/coverage.xml` to satisfy the workflow's artifact contract. This does not change any coverage verdict.
+
+### Approved Exceptions
+
+- **Repo-wide 80% floor on first-party production-only denominator:** The 75.12% figure is below the literal 80% number but is consistent with the CLAUDE.md COM/VSTO/WinForms coverage exemption (the floor applies to the testable denominator after exemptions). This is a pre-existing repository condition, not introduced or worsened by #202 (+0.04 improvement). No regression. Treated as exemption-consistent, not a new violation.
+
+### Removed/Skipped Tests
+
+- **None.** All planned tests implemented; 11 new tests added.
+
+---
+
+## 9. Summary of Changes
+
+### Commits in This PR/Branch
+
+Branch `feature/debug-startup-timing-instrumentation-202` @ `1d193d90` vs base `main` @ `a21d09e1`. Commit-by-commit enumeration is available via `git log a21d09e1..1d193d90`; the net diff is summarized below.
+
+### Files Modified
+
+1. **TaskMaster/AppGlobals/IStartupTimingRecorder.cs** (NEW) — internal recorder contract (RecordPhase/FormatTable/EmitTable), COM-free.
+2. **TaskMaster/AppGlobals/StartupTimingRecorder.cs** (NEW) — production recorder (own ordered span collection, summed TOTAL, `PrettyPrinters.ToFormattedText` reuse) and `NullStartupTimingRecorder` no-op.
+3. **TaskMaster/AppGlobals/ApplicationGlobals.cs** (MODIFIED) — flag read, recorder selection, LoadBasic Stopwatch measurement, per-phase recording in `LoadSequentialAsync`, `StopAndRestart` helper, end-of-load `EmitTable`, `protected internal virtual LoadBasicMethod` test seam.
+4. **TaskMaster/Properties/Settings.settings** + **Settings.Designer.cs** (MODIFIED) — new `StartupTimingEnabled` user setting (default False).
+5. **TaskMaster/TaskMaster.csproj** + **TaskMaster.Test/TaskMaster.Test.csproj** (MODIFIED) — Compile includes for the new files.
+6. **TaskMaster.Test/AppGlobals/StartupTimingRecorderTests.cs** (NEW) — 7 recorder unit tests.
+7. **TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs** (MODIFIED) — 4 wiring tests + helpers (now 687 lines; over limit).
+8. Documentation/evidence (NEW) — scoping docs, plan, and evidence artifacts under the feature folder.
+
+---
+
+## 10. Compliance Verdict
+
+### Overall Status: ⚠️ PARTIALLY COMPLIANT
+
+The implementation is correct, well-structured, well-documented, fully toolchain-clean, and meets the new-code (100%) and no-regression coverage requirements. One FAIL-level policy violation prevents a clean PASS: the modified test file `ApplicationGlobalsTests.cs` (687 lines) exceeds the 500-line file-size limit. One Minor process gap: the canonical `artifacts/csharp/coverage.xml` is absent (equivalent verified data exists).
+
+**Fail-closed reminder:** Coverage data was located and verified; no required coverage metric is missing. The blocking item is the file-size limit, which is a policy violation, not a missing-artifact condition.
+
+---
+
+### Policy-by-Policy Summary
+
+#### General Code Change Policy (Section 2)
+- ✅ Before Making Changes: complete
+- ✅ Design Principles: simplicity, reuse, extensibility, separation all met
+- ❌ Module & File Structure: test file exceeds 500-line limit
+- ✅ Naming, Docs, Comments: strong
+- ✅ Toolchain Execution: all four steps EXIT_CODE 0
+- ✅ Summarize & Document: complete
+
+#### Language-Specific Code Change Policy (Section 3 — C#)
+- ✅ Tooling & Baseline: CSharpier + analyzers + nullable clean
+- ✅ Design & Type-Safety: explicit contracts, null guards, banned-API avoidance
+- ⚠️ Structure & Naming: test file size (see file-size FAIL)
+
+#### General Unit Test Policy (Section 1)
+- ✅ Core Principles: met (readability PARTIAL due to file size)
+- ✅ Coverage & Scenarios: new-code 100%, no regression, scenarios complete
+- ✅ Test Structure: AAA + clear diagnostics
+- ✅ External Dependencies: no external deps, no temp files
+- ✅ Policy Audit: this document
+
+#### Language-Specific Unit Test Policy (Section 4 — C#)
+- ✅ Framework & Scope: MSTest + Moq + FluentAssertions
+- ✅ Test Style & Structure: focused, mirrored
+- ⚠️ Naming & Readability: clear but file over size limit
+
+---
+
+### Metrics Summary
+
+- ✅ 4194/4194 tests passing (100%)
+- ✅ 2/2 new classes tested (100%)
+- ✅ 100% new-code line coverage
+- ✅ No coverage regression (+0.04 first-party, +0.06 raw)
+- ✅ All code-quality checks (format/analyze/nullable/test) EXIT_CODE 0
+- ❌ `ApplicationGlobalsTests.cs` 687 lines exceeds 500-line limit
+
+---
+
+### Recommendation
+
+**Needs revision** — Address the 500-line test-file violation before merge by splitting `ApplicationGlobalsTests.cs`. The Minor canonical-coverage-artifact gap should also be resolved but does not change any coverage verdict. All other policy areas are compliant.
+
+---
+
+## Appendix A: Test Inventory
+
+- TaskMaster.Test.AppGlobals.StartupTimingRecorderTests › RecordPhase_WithPositiveDurations_PreservesPhaseNamesInRecordedOrder
+- TaskMaster.Test.AppGlobals.StartupTimingRecorderTests › RecordPhase_WithZeroDuration_IsCapturedAndRenderedWithoutError
+- TaskMaster.Test.AppGlobals.StartupTimingRecorderTests › FormatTable_ContainsHeadersPhaseNamesAndTotalEqualToSumOfInjectedSpans
+- TaskMaster.Test.AppGlobals.StartupTimingRecorderTests › RecordPhase_WithNullPhaseName_ThrowsArgumentNullException
+- TaskMaster.Test.AppGlobals.StartupTimingRecorderTests › EmitTable_LogsFormattedTableViaLoggerInfoWithStartupTimingPrefix
+- TaskMaster.Test.AppGlobals.StartupTimingRecorderTests › EmitTable_WithNullLogger_ThrowsArgumentNullException
+- TaskMaster.Test.AppGlobals.StartupTimingRecorderTests › NullStartupTimingRecorder_IsNoOp_ForFormatAndEmit
+- TaskMaster.Test.AppGlobals.ApplicationGlobalsTests › LoadAsync_WhenTimingDisabled_RecordsNothingAndEmitsNoTable
+- TaskMaster.Test.AppGlobals.ApplicationGlobalsTests › LoadAsync_WhenTimingEnabled_RecordsAllPhasesInStartupOrderWithLoadBasicFirst
+- TaskMaster.Test.AppGlobals.ApplicationGlobalsTests › LoadAsync_WhenTimingEnabled_EmitsExactlyOneTableWithPhaseNamesAndTotal
+- TaskMaster.Test.AppGlobals.ApplicationGlobalsTests › LoadAsync_PreservesPhaseOrderingAndYieldCount_WhenTimingOnVersusOff
+
+---
+
+## Appendix B: Toolchain Commands Reference
+
+**For C#:**
+```powershell
+# Formatting
+dotnet tool run csharpier .
+
+# Linting / analyzers
+msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true
+
+# Type checking / nullable
+msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true
+
+# Testing + coverage
+vstest.console.exe UtilitiesCS.Test\bin\Debug\UtilitiesCS.Test.dll TaskMaster.Test\bin\Debug\TaskMaster.Test.dll QuickFiler.Test\bin\Debug\QuickFiler.Test.dll Tags.Test\bin\Debug\Tags.Test.dll TaskVisualization.Test\bin\Debug\TaskVisualization.Test.dll ToDoModel.Test\bin\Debug\ToDoModel.Test.dll VBFunctions.Test\bin\Debug\VBFunctions.Test.dll /Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation /ResultsDirectory:TestResults/final-full
+```
+
+Coverage verification (this audit, check-only):
+```bash
+# Repo-wide root line-rate
+grep -oE '<coverage[^>]*line-rate="[0-9.]*"' TestResults/final-full.cobertura.xml | head -1
+# New + modified class line-rates
+grep -oE '<class line-rate="[0-9.]*"[^>]* name="TaskMaster\.(StartupTimingRecorder|NullStartupTimingRecorder|ApplicationGlobals)"' TestResults/final-full.cobertura.xml
+```
+
+---
+
+**Audit Completed By:** feature-reviewer agent
+**Audit Date:** 2026-06-15
+**Policy Version:** Current (as of audit date)

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/policy-audit.2026-06-15T14-07.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/policy-audit.2026-06-15T14-07.md
@@ -1,0 +1,481 @@
+# Policy Compliance Audit: debug-startup-timing-instrumentation (Issue #202)
+
+**Audit Date:** 2026-06-15
+**Audit Type:** Cycle-exit re-audit (after remediation cycle that split the over-limit test file)
+**Code Under Test:** Branch `feature/debug-startup-timing-instrumentation-202` @ `253270ac6dbc94bd5b97de1d98a79938f9575040` vs base `main` @ `a21d09e18dfebb9e3450c1b3322e7715c09d91e6` (merge-base `a21d09e18dfebb9e3450c1b3322e7715c09d91e6`)
+
+Files modified (source/test/build, all C#):
+- `TaskMaster/AppGlobals/IStartupTimingRecorder.cs` (NEW, 40 lines)
+- `TaskMaster/AppGlobals/StartupTimingRecorder.cs` (NEW, 95 lines)
+- `TaskMaster/AppGlobals/ApplicationGlobals.cs` (MODIFIED, 247 lines)
+- `TaskMaster/Properties/Settings.settings` (MODIFIED)
+- `TaskMaster/Properties/Settings.Designer.cs` (MODIFIED, generated)
+- `TaskMaster/TaskMaster.csproj` (MODIFIED, +2 Compile includes)
+- `TaskMaster.Test/AppGlobals/StartupTimingRecorderTests.cs` (NEW, 184 lines)
+- `TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` (MODIFIED, 483 lines; baseline 440)
+- `TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs` (NEW, 299 lines — created by the remediation split)
+- `TaskMaster.Test/TaskMaster.Test.csproj` (MODIFIED, +2 Compile includes)
+
+Documentation/evidence (non-code): scoping docs, plan, and evidence artifacts under `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/**`, including the prior cycle's `policy-audit.2026-06-15T13-29.md`, `code-review.2026-06-15T13-29.md`, `feature-audit.2026-06-15T13-29.md`, `remediation-inputs.2026-06-15T13-29.md`, and `remediation-plan.2026-06-15T13-29.md`.
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| C# | 10 files (7 .cs, 2 .csproj, 1 .settings) | 4194 tests | PASS 4194 pass, 0 fail | 76.30% raw repo-wide line-rate | 76.37% raw repo-wide line-rate | 100% (StartupTimingRecorder + NullStartupTimingRecorder) |
+
+**Note:** C# is the only language with changed files in the branch diff. TypeScript, Python, PowerShell, Bash, and JSON have zero changed files and are therefore N/A for coverage.
+
+### Coverage Evidence Checklist
+
+- TypeScript baseline coverage artifact: `N/A - out of scope` (no TypeScript files changed)
+- TypeScript post-change coverage artifact: `N/A - out of scope` (no TypeScript files changed)
+- PowerShell baseline coverage artifact: `N/A - out of scope` (no PowerShell files changed)
+- PowerShell post-change coverage artifact: `N/A - out of scope` (no PowerShell files changed)
+- Per-language comparison summary: see Section 1.2.1 below; underlying data parsed directly from `artifacts/csharp/coverage.xml` (canonical, present this cycle) and cross-checked against `TestResults/remed-final.cobertura.xml` and `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/coverage-delta.2026-06-15T13-29.md`.
+
+**Non-negotiable verdict rule:** Numeric baseline and post-change coverage metrics are present for the single in-scope language (C#), plus new-code coverage.
+
+**Fail-closed rule:** The canonical artifact `artifacts/csharp/coverage.xml` is present this cycle (it was the prior cycle's Minor finding; resolved by the remediation copy step recorded in `evidence/qa-gates/coverage-artifact-copy.2026-06-15T13-29.md`). It was parsed directly for this audit. No required coverage artifact is missing.
+
+**Evidence rule:** All coverage figures below were read directly from `artifacts/csharp/coverage.xml` (Cobertura; root `line-rate`, and per-class line hits for the new and modified classes) and the baseline `TestResults/baseline-full.cobertura.xml`, cross-checked against the executor's `coverage-delta` and `qa-test` evidence artifacts. No figures were synthesized.
+
+---
+
+## Executive Summary
+
+This branch adds enable-on-demand startup-timing instrumentation to the TaskMaster Outlook VSTO add-in (issue #202). The change is gated behind a new `Settings.Default.StartupTimingEnabled` user setting (default `False`). When enabled, `ApplicationGlobals.LoadAsync(parallel: false)` records wall-clock spans for the seven established phase seams (LoadBasic, IntelConfig, OlObjects, ToDo, AutoFile, Engines, Events) and emits one formatted `[Startup timing]` table via the existing log4net logger. Recording and formatting logic is isolated in a new, COM-free `IStartupTimingRecorder` abstraction with a production `StartupTimingRecorder` and a `NullStartupTimingRecorder` no-op used on the flag-off path.
+
+This is the cycle-exit re-audit after a remediation cycle whose single blocking finding (the prior cycle's `ApplicationGlobalsTests.cs` at 687 lines, exceeding the 500-line limit) was addressed by splitting the four startup-timing wiring tests and their helpers into a new file. Both prior-cycle findings are now resolved:
+
+- **Prior Finding 1 (BLOCKING — test-file size):** RESOLVED. `ApplicationGlobalsTests.cs` is now 483 lines (was 687); the extracted tests live in the new `ApplicationGlobalsStartupTimingTests.cs` at 299 lines. Both are strictly under 500. Verified by `awk 'END{print NR}'` on HEAD.
+- **Prior Finding 2 (Minor/process — canonical coverage artifact absent):** RESOLVED. `artifacts/csharp/coverage.xml` now exists (21,499,084 bytes, Cobertura) and was parsed directly for this audit.
+
+All other previously-PASS areas remain PASS: new-code coverage 100%; the modified `ApplicationGlobals` class improved from 74.4% (99/133) at baseline to 77.9% (120/154) post-change (no regression); banned-API rule respected (`Stopwatch`, not `DateTime.Now`/`UtcNow`); evidence-location compliance clean; toolchain (CSharpier, analyzer build, nullable/TreatWarningsAsErrors build, MSTest+coverage over 7 assemblies) recorded EXIT_CODE 0 with 4194/4194 tests passing in the remediation pass (`evidence/qa-gates/qa-*.2026-06-15T13-29.md`).
+
+No FAIL-level findings remain. No blocking-PARTIAL findings remain. One non-blocking observation is carried forward for transparency: the raw repo-wide C# line-rate (76.37%) is below the literal 80% number, but this is a pre-existing repository condition consistent with the documented CLAUDE.md COM/VSTO/WinForms coverage exemption (the floor applies to the testable denominator after exemptions), is not introduced or worsened by #202, and is in fact slightly improved (+0.07 raw). This is recorded as an Approved Exception (Section 8), not a finding.
+
+**Policy documents evaluated:**
+- PASS `CLAUDE.md` general code-change and unit-test policies
+- PASS `.claude/rules/general-code-change.md`
+- PASS `.claude/rules/general-unit-test.md`
+
+**Language-specific policies evaluated:**
+- N/A `python-code-change` + `python-unit-test` (no Python files changed)
+- N/A `powershell-code-change` + `powershell-unit-test` (no PowerShell files changed)
+- N/A Bash (no Bash files changed)
+- N/A JSON (no governed JSON files changed)
+- PASS C# Code Change Policy + C# Unit Test Policy (CLAUDE.md C#1-C#7, CUT1-CUT3, `.claude/rules/csharp.md`)
+
+**Temporary artifacts cleanup:**
+- PASS No temporary/one-time scripts were introduced by this branch (diff is source/test/build/docs only). A throwaway coverage-parsing script used by this reviewer was created and deleted within the review session.
+- N/A No ongoing tooling scripts added.
+
+---
+
+## Rejected Scope Narrowing
+
+The caller prompt supplied the base branch, merge-base SHA, head SHA, and feature folder, and explicitly instructed: "Determine review scope yourself from the branch diff against the merge-base and execute the full SKILL contract." No instruction attempted to narrow scope to a plan/task/phase subset, to a subset of changed files, or to mark any language as out of scope. No scope-narrowing was detected; none was rejected.
+
+Note on PR-context misclassification: `artifacts/pr_context.summary.txt` reports "Core logic changes: 0 files" and classifies all changes as "Docs/templates/agents/tooling: 37 files." This is a misclassification of the C# source changes. The audit scope was taken from the actual `git diff a21d09e18dfebb9e3450c1b3322e7715c09d91e6..253270ac6dbc94bd5b97de1d98a79938f9575040`, which contains 7 changed `.cs` files plus build/settings files (10 code files total), not from the summary's overview counters.
+
+---
+
+## Evidence Location Compliance
+
+Scanned the branch diff for files written under `artifacts/baselines/`, `artifacts/qa/`, `artifacts/evidence/`, or `artifacts/coverage/`:
+
+```
+git diff --name-only a21d09e1..253270ac | grep -E "^artifacts/(baselines|qa|evidence|coverage)/"
+```
+
+Result: NONE. All evidence artifacts produced by the implementing/remediation agents are written to the canonical `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/<kind>/` layout (`baseline/`, `qa-gates/`, `issue-updates/`, `other/`). No non-canonical evidence-location violations found. Disposition: PASS.
+
+(The repository does not ship a `validate_evidence_locations.py` script; verification was performed by direct diff scan. The canonical coverage artifact `artifacts/csharp/coverage.xml` is a workflow-named coverage artifact under `artifacts/csharp/`, not an evidence artifact under any of the four non-canonical evidence prefixes, so it is not an evidence-location violation.)
+
+---
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Independence** - Tests run in any order | PASS | Recorder tests inject deterministic spans and share no state. The wiring tests in the new `ApplicationGlobalsStartupTimingTests.cs` save/restore `Settings.Default.StartupTimingEnabled` in `[TestInitialize]`/`[TestCleanup]` and are marked `[DoNotParallelize]` because they mutate the process-global settings singleton and the process-global log4net logger. The split preserved these markers and the save/restore. |
+| **Isolation** - Each test targets single behavior | PASS | Recorder tests target one behavior each (ordering, zero-duration, total sum, null-name throw, emit prefix, null-logger throw, null recorder no-op). Wiring tests target flag-off no-emit, flag-on phase order, single-table emission, and ordering/yield-count parity. |
+| **Fast Execution** - Tests complete quickly | PASS | All durations injected; no real timing waits. Full suite of 4194 tests reported green (EXIT_CODE 0, ~48 s) in `evidence/qa-gates/qa-test.2026-06-15T13-29.md`. |
+| **Determinism** - Consistent results | PASS | No clock, no sleep, no filesystem, no network. `TestableApplicationGlobals.LoadBasicMethod` sets a fixed `TimeSpan.FromMilliseconds(7)`; recorder tests inject fixed spans. |
+| **Readability & Maintainability** - Clear structure | PASS | Test names are descriptive and AAA-structured with intent comments. The 500-line readability concern from the prior cycle is resolved: `ApplicationGlobalsTests.cs` is 483 lines and `ApplicationGlobalsStartupTimingTests.cs` is 299 lines (Section 2.3). |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Baseline Coverage Documented** | PASS | **Baseline:** 76.30% raw repo-wide Cobertura line-rate; `TaskMaster.ApplicationGlobals` class 74.4% (99/133). **Command:** `vstest.console.exe <7 assemblies> /Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation`. Source: `TestResults/baseline-full.cobertura.xml` and `evidence/baseline/test-coverage-baseline.2026-06-15T12-15.md`. |
+| **No Coverage Regression** | PASS | **Post-change:** 76.37% raw repo-wide line-rate (`artifacts/csharp/coverage.xml` root `line-rate="0.7637273825777192"`, 97334/127446). **Change:** +0.07% raw repo-wide. `TaskMaster.ApplicationGlobals` class improved to 77.9% (120/154). **Status:** No regression (improved). |
+| **New Code Coverage >=90%** | PASS | **New files:** `StartupTimingRecorder.cs` (`StartupTimingRecorder` + `NullStartupTimingRecorder`). **New code coverage:** 100%. Verified directly: `TaskMaster.StartupTimingRecorder` 48/48 lines and `TaskMaster.NullStartupTimingRecorder` 10/10 lines covered in `artifacts/csharp/coverage.xml`. |
+| **Comprehensive Coverage** | PASS | `StartupTimingRecorder.RecordPhase/FormatTable/EmitTable` and `NullStartupTimingRecorder` are exercised; `ApplicationGlobals` flag read, recorder selection, LoadBasic Stopwatch, per-phase recording, `StopAndRestart`, and `EmitTable` call are all covered. Uncovered remainder of `ApplicationGlobals` is the pre-existing, out-of-scope parallel path (user-story Non-Goal). |
+| **Positive Flows** - Valid inputs | PASS | `RecordPhase_WithPositiveDurations_...`, `FormatTable_ContainsHeaders...`, `LoadAsync_WhenTimingEnabled_RecordsAllPhasesInStartupOrder...`, `..._EmitsExactlyOneTableWithPhaseNamesAndTotal`. |
+| **Negative Flows** - Invalid inputs | PASS | `RecordPhase_WithNullPhaseName_ThrowsArgumentNullException`, `EmitTable_WithNullLogger_ThrowsArgumentNullException`. |
+| **Edge Cases** - Boundary conditions | PASS | `RecordPhase_WithZeroDuration_IsCapturedAndRenderedWithoutError`; null recorder empty-table case. |
+| **Error Handling** - Error paths | PASS | Null-argument throws verified with `WithParameterName`. |
+| **Concurrency** - If applicable | PASS | Shared-global tests marked `[DoNotParallelize]` to avoid cross-class interference on the settings singleton and log4net logger; preserved across the split. |
+| **State Transitions** - If applicable | PASS | Recorder accumulates spans in call order; ordering asserted in `RecordedPhaseNames` and rendered output. |
+
+### 1.2.1 Per-Language Coverage Comparison
+
+- C#: Baseline: 76.30% lines -> Post-change: 76.37% lines. Change: +0.07% line delta. New/changed-code coverage: 100%. Disposition: PASS. Evidence: `artifacts/csharp/coverage.xml`, `TestResults/baseline-full.cobertura.xml`, `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/coverage-delta.2026-06-15T13-29.md`, `.../evidence/qa-gates/qa-test.2026-06-15T13-29.md`.
+- TypeScript: Baseline: N/A% lines -> Post-change: N/A% lines. Change: N/A% line delta. New/changed-code coverage: `N/A - out of scope`. Disposition: N/A. Evidence: `N/A - out of scope` (no TypeScript files changed in branch diff).
+- PowerShell: Baseline: N/A% lines -> Post-change: N/A% lines. Change: N/A% line delta. New/changed-code coverage: `N/A - out of scope`. Disposition: N/A. Evidence: `N/A - out of scope` (no PowerShell files changed in branch diff).
+- Python: Baseline: N/A% lines -> Post-change: N/A% lines. Change: N/A% line delta. New/changed-code coverage: `N/A - out of scope`. Disposition: N/A. Evidence: `N/A - out of scope` (no Python files changed in branch diff).
+
+Repo-wide C# note: the 76.37% raw figure is below the literal 80% number, but the denominator includes the COM/VSTO/WinForms-bound and `[ExcludeFromCodeCoverage]`-exempt classes that CLAUDE.md formally exempts from the 80% floor (the floor applies to the testable denominator after exemptions). This is a pre-existing repository condition not introduced or worsened by #202; the feature improves the raw figure by +0.07. Disposition for the repo-wide gate: no regression; consistent with documented exemption (Section 8 Approved Exceptions).
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clear Failure Messages** | PASS | FluentAssertions with `because` rationale strings throughout (e.g., "no startup-timing table may be emitted when the flag is off."). |
+| **Arrange-Act-Assert Pattern** | PASS | Each test uses explicit Arrange/Act/Assert comment sections. |
+| **Document Intent** | PASS | Descriptive `MethodUnderTest_Condition_Expectation` names plus class/test docstrings. |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Avoid External Dependencies** | PASS | No database/network/process. log4net `MemoryAppender` is attached in-process for assertion; no live Outlook/COM. |
+| **Use Mocks/Stubs** | PASS | Moq used for `IAppItemEngines` and the Outlook `Application`; `TestableApplicationGlobals` stubs COM collaborator construction via overridable seams. MSTest + Moq + FluentAssertions per CUT1/CUT2. |
+| **Environment Stability** | PASS | No temporary files created. Settings singleton mutation is saved/restored per test; tests marked `[DoNotParallelize]` to isolate global state. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Pre-submission Review** | PASS | This document is the required cycle-exit policy review. No outstanding blocking items. |
+
+---
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clarify the objective** | PASS | Objective documented in `issue.md`, `spec.md`, `user-story.md` (issue #202). |
+| **Read existing change plans** | PASS | `plan.2026-06-15T12-15.md` and `remediation-plan.2026-06-15T13-29.md` present with phased tasks. |
+| **Document the plan** | PASS | Atomic plan plus per-phase toolchain gate evidence under `evidence/qa-gates/`; remediation split documented in `evidence/qa-gates/post-split-linecounts.2026-06-15T13-29.md`. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Simplicity first** | PASS | A small interface plus two implementations; a single shared `Stopwatch` with a `StopAndRestart` helper. No deep indirection. |
+| **Reusability** | PASS | Reuses `UtilitiesCS.PrettyPrinters.ToFormattedText` (the same overload `SegmentStopWatch.GetDurations()` uses) rather than reimplementing column alignment. |
+| **Extensibility** | PASS | `IStartupTimingRecorder` interface enables alternative implementations; flag selects concrete vs no-op. |
+| **Separation of concerns** | PASS | Pure recording/formatting logic isolated from the COM-bound startup coordinator; recorder has no Outlook/COM/IO dependency. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive modules** | PASS | Interface, recorder+null-recorder, coordinator wiring, and the two cohesive test files are each focused. The remediation split produced a cohesive `ApplicationGlobalsStartupTimingTests.cs` holding the startup-timing wiring tests and their helpers. |
+| **Under 500 lines** | PASS | All changed files are under 500 lines at HEAD: `IStartupTimingRecorder.cs` 40, `StartupTimingRecorder.cs` 95, `ApplicationGlobals.cs` 247, `StartupTimingRecorderTests.cs` 184, `ApplicationGlobalsTests.cs` 483 (was 687; reduced by the split), `ApplicationGlobalsStartupTimingTests.cs` 299. The prior cycle's FAIL on `ApplicationGlobalsTests.cs` is RESOLVED. Verified by `awk 'END{print NR}'` on HEAD. |
+| **Public vs internal** | PASS | Recorder types are `internal sealed`; consumed by tests via existing `InternalsVisibleTo("TaskMaster.Test")`. `protected internal virtual LoadBasicMethod` is a minimal test seam, documented as such. |
+| **No circular dependencies** | PASS | Recorder depends only on `System`, `UtilitiesCS`, and `log4net`; no back-dependency from those onto `ApplicationGlobals`. |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Descriptive names** | PASS | `RecordPhase`, `FormatTable`, `EmitTable`, `StartupTimingRecorder`, `NullStartupTimingRecorder`, `_loadBasicElapsed`, `StopAndRestart`. |
+| **Docs/docstrings** | PASS | XML doc comments on interface members and classes describe contract, COM-free guarantee, and the deliberate non-wrapping of `SegmentStopWatch`. |
+| **Comment why, not what** | PASS | Comments explain the LoadBasic-at-construction measurement rationale, the always-zero `SegmentStopWatch.GetDurations()` total pitfall, and the negligible-overhead flag-off design. |
+
+### 2.5 After Making Changes - Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **1. Formatting** | PASS | **Command:** `csharpier format .`. **Result:** EXIT_CODE 0 (`evidence/qa-gates/qa-format.2026-06-15T13-29.md`). |
+| **2. Linting** | PASS | **Command:** `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`. **Result:** EXIT_CODE 0 (`evidence/qa-gates/qa-analyze.2026-06-15T13-29.md`). |
+| **3. Type checking** | PASS | **Command:** `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`. **Result:** EXIT_CODE 0 (`evidence/qa-gates/qa-nullable.2026-06-15T13-29.md`). |
+| **4. Testing** | PASS | **Command:** `vstest.console.exe <7 assemblies> /Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation /ResultsDirectory:TestResults/remed-final`. **Result:** 4194/4194 passed, EXIT_CODE 0 (`evidence/qa-gates/qa-test.2026-06-15T13-29.md`). |
+| **Full toolchain loop** | PASS | Remediation pass recorded clean across all four steps in `evidence/qa-gates/qa-*.2026-06-15T13-29.md` and `verification-summary.2026-06-15T13-29.md`. |
+| **Explicit reporting** | PASS | Commands and results documented in `evidence/qa-gates/` artifacts and re-cited in this audit. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Summarize changes** | PASS | Plan, remediation plan, and evidence artifacts summarize the change and the split. |
+| **Design choices explained** | PASS | `evidence/other/timing-recorder-format-reuse.2026-06-15T12-15.md` records the formatter-reuse / non-wrapping decision and the log4net channel decision; `post-split-linecounts.2026-06-15T13-29.md` records the split rationale. |
+| **Update supporting documents** | PASS | `spec.md`, `user-story.md`, `issue.md` AC items updated and checked off; plan and remediation-plan check-offs recorded. |
+| **Provide next steps** | PASS | Plan verification notes and remediation verification summary describe test scope and coverage evidence. |
+
+---
+
+## 3. Language-Specific Code Change Policy Compliance
+
+### Section 3 (C#): C# Code Change Policy Compliance
+
+#### C# Tooling & Baseline
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Formatting with CSharpier** | PASS | `csharpier format .` EXIT_CODE 0. `dotnet format` not used. |
+| **Linting / .NET analyzers** | PASS | Analyzer build EXIT_CODE 0 with `EnableNETAnalyzers`/`EnforceCodeStyleInBuild`. |
+| **Type checking / nullable** | PASS | Nullable + `TreatWarningsAsErrors` build EXIT_CODE 0. New code uses guard clauses and target-typed `new()`; no nullable warnings introduced. |
+
+#### C# Design & Type-Safety
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Strong contracts and explicit APIs** | PASS | Interface with explicit `TimeSpan`/`string`/`log4net.ILog` types; XML-documented contracts. |
+| **Null-safety by default** | PASS | `RecordPhase` and `EmitTable` throw `ArgumentNullException` on null inputs. |
+| **Composition and focused types** | PASS | Two small sealed implementations behind one interface; no inheritance beyond the interface. |
+| **Asynchrony and resource safety** | PASS | No new disposables; existing async phase awaits unchanged. `Stopwatch` requires no disposal. |
+
+#### C# Module & Structure / Naming / Dependencies
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **File focus and size** | PASS | Production and test files are focused and within the 500-line limit at HEAD (see Section 2.3); the prior-cycle test-file FAIL is resolved. |
+| **Internal-by-default surface** | PASS | Recorder types `internal sealed`. |
+| **Banned-API compliance** | PASS | Uses `System.Diagnostics.Stopwatch` (hardware-counter), explicitly avoiding the BannedApiAnalyzers `DateTime.Now`/`DateTime.UtcNow`/`Random.Shared`/`Thread.Sleep`/`Task.Delay` rules. Diff scan for banned symbols matched only an explanatory comment, not a call site. No banned APIs introduced. |
+| **No new dependencies** | PASS | `UtilitiesCS.PrettyPrinters`, `Stopwatch`, `log4net` already present and approved. |
+
+---
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+### Section 4 (C#): C# Unit Test Policy Compliance
+
+#### Framework and Scope
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Use MSTest** | PASS | `[TestClass]`/`[TestMethod]` from `Microsoft.VisualStudio.TestTools.UnitTesting`. No xUnit/NUnit introduced. |
+| **Mocking with Moq** | PASS | `Mock<IAppItemEngines>`, `Mock<OutlookApplication>`, `Mock<log4net.ILog>` with `MockBehavior.Strict`/default as appropriate. |
+| **Assertions with FluentAssertions** | PASS | FluentAssertions used throughout (`.Should().Be/Contain/Throw/Equal/BeOfType/BeEmpty`). |
+| **Coverage expectation** | PASS | New code 100% (>=90% floor); modified `ApplicationGlobals` no regression (74.4% -> 77.9%). |
+
+#### Test Style and Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Focused unit tests** | PASS | One behavior per test. |
+| **Mocking sparingly** | PASS | Mocks limited to the COM-bound engine collaborator, the Outlook application stub, and the logger sink. |
+| **Organization** | PASS | Test files mirror source location (`AppGlobals/`); the new split file is registered in `TaskMaster.Test.csproj`. |
+| **Naming and readability** | PASS | Names/structure are clear; both test files are under the size limit. |
+
+---
+
+## 5. Test Coverage Detail
+
+### StartupTimingRecorder / NullStartupTimingRecorder (7 tests)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| RecordPhase_WithPositiveDurations_PreservesPhaseNamesInRecordedOrder | Positive | PASS |
+| RecordPhase_WithZeroDuration_IsCapturedAndRenderedWithoutError | Edge Case | PASS |
+| FormatTable_ContainsHeadersPhaseNamesAndTotalEqualToSumOfInjectedSpans | Positive | PASS |
+| RecordPhase_WithNullPhaseName_ThrowsArgumentNullException | Negative | PASS |
+| EmitTable_LogsFormattedTableViaLoggerInfoWithStartupTimingPrefix | Positive | PASS |
+| EmitTable_WithNullLogger_ThrowsArgumentNullException | Negative | PASS |
+| NullStartupTimingRecorder_IsNoOp_ForFormatAndEmit | Edge Case | PASS |
+
+**Coverage:** 100% of the new recorder code (`StartupTimingRecorder` 48/48 lines; `NullStartupTimingRecorder` 10/10 lines).
+
+**Not covered:** None.
+
+### ApplicationGlobals startup-timing wiring (4 tests, now in ApplicationGlobalsStartupTimingTests.cs)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| LoadAsync_WhenTimingDisabled_RecordsNothingAndEmitsNoTable | Negative (flag off) | PASS |
+| LoadAsync_WhenTimingEnabled_RecordsAllPhasesInStartupOrderWithLoadBasicFirst | Positive | PASS |
+| LoadAsync_WhenTimingEnabled_EmitsExactlyOneTableWithPhaseNamesAndTotal | Positive | PASS |
+| LoadAsync_PreservesPhaseOrderingAndYieldCount_WhenTimingOnVersusOff | State Transition | PASS |
+
+**Coverage:** `TaskMaster.ApplicationGlobals` class line coverage 77.9% (120/154), up from 74.4% (99/133) baseline. New timing lines covered; uncovered remainder is the pre-existing out-of-scope parallel path.
+
+**Not covered:** Pre-existing `LoadParallelAsync` body and parallel branch (user-story Non-Goal; uncovered in baseline; no regression).
+
+---
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total Tests | 4194 | PASS |
+| Tests Passed | 4194 (100%) | PASS |
+| Tests Failed | 0 | PASS |
+| New Tests Added | 11 (7 recorder + 4 wiring) | PASS |
+| Functions/Classes Tested (new) | 2/2 new classes (100%) | PASS |
+| Test File Size | `ApplicationGlobalsTests.cs` 483 lines; `ApplicationGlobalsStartupTimingTests.cs` 299 lines; `StartupTimingRecorderTests.cs` 184 lines | PASS Under 500-line limit |
+| Code Coverage (new code) | 100% lines | PASS |
+| Code Coverage (raw repo-wide) | 76.37% lines (no regression; COM/VSTO exemption applies; +0.07 vs baseline) | Below literal 80%, exemption-consistent, no regression |
+
+---
+
+## 7. Code Quality Checks
+
+**For C#:**
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| CSharpier Formatting | `csharpier format .` | EXIT_CODE 0 | PASS |
+| .NET Analyzer Build | `msbuild TaskMaster.sln /t:Build /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true` | EXIT_CODE 0 | PASS |
+| Nullable Type-check Build | `msbuild TaskMaster.sln /t:Build /p:Nullable=enable /p:TreatWarningsAsErrors=true` | EXIT_CODE 0 | PASS |
+| MSTest Tests + Coverage | `vstest.console.exe <7 assemblies> /Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation` | 4194/4194 pass, EXIT_CODE 0 | PASS |
+
+**Notes:**
+The raw repo-wide figure (76.37%) is below the literal 80% number but is a pre-existing condition consistent with the documented COM/VSTO/WinForms exemption; #202 improves it by +0.07. The toolchain evidence reflects the remediation agent's runs; this reviewer did not re-execute the build/test (check-only review), and parsed the existing canonical Cobertura artifact `artifacts/csharp/coverage.xml` for coverage verification.
+
+---
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+
+**None.** Both findings from the prior cycle (`policy-audit.2026-06-15T13-29.md`) are resolved:
+- The 500-line test-file violation on `ApplicationGlobalsTests.cs` is resolved by the remediation split (now 483 + 299 lines, both < 500).
+- The absent canonical C# coverage artifact `artifacts/csharp/coverage.xml` is resolved; the file is present and was parsed directly.
+
+### Approved Exceptions
+
+- **Repo-wide 80% floor on the raw Cobertura denominator:** The 76.37% raw figure is below the literal 80% number but is consistent with the CLAUDE.md COM/VSTO/WinForms coverage exemption (the floor applies to the testable denominator after exemptions). This is a pre-existing repository condition, not introduced or worsened by #202 (+0.07 improvement). No regression. Treated as exemption-consistent, not a new violation.
+
+### Removed/Skipped Tests
+
+- **None.** All planned tests are present; 11 new tests total. The remediation split moved the four wiring tests to a new file without removing or weakening any test (`qa-test.2026-06-15T13-29.md` confirms all four pass under the new class and the total count remains 4194).
+
+---
+
+## 9. Summary of Changes
+
+### Commits in This PR/Branch
+
+Branch `feature/debug-startup-timing-instrumentation-202` @ `253270ac` vs base `main` @ `a21d09e1`. Commit-by-commit enumeration is available via `git log a21d09e1..253270ac`; the net diff is summarized below.
+
+### Files Modified
+
+1. **TaskMaster/AppGlobals/IStartupTimingRecorder.cs** (NEW) — internal recorder contract (RecordPhase/FormatTable/EmitTable), COM-free.
+2. **TaskMaster/AppGlobals/StartupTimingRecorder.cs** (NEW) — production recorder (own ordered span collection, summed TOTAL, `PrettyPrinters.ToFormattedText` reuse) and `NullStartupTimingRecorder` no-op.
+3. **TaskMaster/AppGlobals/ApplicationGlobals.cs** (MODIFIED) — flag read, recorder selection, LoadBasic Stopwatch measurement, per-phase recording in `LoadSequentialAsync`, `StopAndRestart` helper, end-of-load `EmitTable`, `protected internal virtual LoadBasicMethod` test seam.
+4. **TaskMaster/Properties/Settings.settings** + **Settings.Designer.cs** (MODIFIED) — new `StartupTimingEnabled` user setting (default False).
+5. **TaskMaster/TaskMaster.csproj** + **TaskMaster.Test/TaskMaster.Test.csproj** (MODIFIED) — Compile includes for the new files.
+6. **TaskMaster.Test/AppGlobals/StartupTimingRecorderTests.cs** (NEW) — 7 recorder unit tests.
+7. **TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs** (MODIFIED) — extended at first cycle, then reduced to 483 lines by the remediation split.
+8. **TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs** (NEW — remediation split) — 4 startup-timing wiring tests + helpers (`SetEnginesMock`, `AttachMemoryAppender`, `DetachMemoryAppender`, `TestableApplicationGlobals`), 299 lines.
+9. Documentation/evidence (NEW) — scoping docs, plan, remediation plan, and evidence artifacts under the feature folder.
+
+---
+
+## 10. Compliance Verdict
+
+### Overall Status: FULLY COMPLIANT
+
+The implementation is correct, well-structured, well-documented, fully toolchain-clean, and meets the new-code (100%) and no-regression coverage requirements. Both findings from the prior cycle are resolved: the modified test file is now under the 500-line limit (split into 483 + 299 lines), and the canonical `artifacts/csharp/coverage.xml` is present. No FAIL-level findings remain.
+
+**Fail-closed reminder:** Coverage data was located and verified from the canonical artifact; no required coverage metric or artifact is missing.
+
+---
+
+### Policy-by-Policy Summary
+
+#### General Code Change Policy (Section 2)
+- PASS Before Making Changes: complete
+- PASS Design Principles: simplicity, reuse, extensibility, separation all met
+- PASS Module & File Structure: all files under 500-line limit (prior FAIL resolved)
+- PASS Naming, Docs, Comments: strong
+- PASS Toolchain Execution: all four steps EXIT_CODE 0
+- PASS Summarize & Document: complete
+
+#### Language-Specific Code Change Policy (Section 3 — C#)
+- PASS Tooling & Baseline: CSharpier + analyzers + nullable clean
+- PASS Design & Type-Safety: explicit contracts, null guards, banned-API avoidance
+- PASS Structure & Naming: all files within size limit
+
+#### General Unit Test Policy (Section 1)
+- PASS Core Principles: met (readability resolved post-split)
+- PASS Coverage & Scenarios: new-code 100%, no regression, scenarios complete
+- PASS Test Structure: AAA + clear diagnostics
+- PASS External Dependencies: no external deps, no temp files
+- PASS Policy Audit: this document
+
+#### Language-Specific Unit Test Policy (Section 4 — C#)
+- PASS Framework & Scope: MSTest + Moq + FluentAssertions
+- PASS Test Style & Structure: focused, mirrored
+- PASS Naming & Readability: clear and within size limit
+
+---
+
+### Metrics Summary
+
+- PASS 4194/4194 tests passing (100%)
+- PASS 2/2 new classes tested (100%)
+- PASS 100% new-code line coverage
+- PASS No coverage regression (+0.07 raw repo-wide; `ApplicationGlobals` class 74.4% -> 77.9%)
+- PASS All code-quality checks (format/analyze/nullable/test) EXIT_CODE 0
+- PASS All changed files under the 500-line limit (prior FAIL resolved)
+
+---
+
+### Recommendation
+
+**Ready for merge** — Both prior-cycle findings are resolved and no new findings were identified. The branch is policy-compliant against CLAUDE.md, `.claude/rules/*`, the coverage floors with the documented COM/VSTO/WinForms exemption, banned-API rules, the 500-line file-size limit, and the tone policy. No remediation is required for this cycle.
+
+---
+
+## Appendix A: Test Inventory
+
+- TaskMaster.Test.AppGlobals.StartupTimingRecorderTests › RecordPhase_WithPositiveDurations_PreservesPhaseNamesInRecordedOrder
+- TaskMaster.Test.AppGlobals.StartupTimingRecorderTests › RecordPhase_WithZeroDuration_IsCapturedAndRenderedWithoutError
+- TaskMaster.Test.AppGlobals.StartupTimingRecorderTests › FormatTable_ContainsHeadersPhaseNamesAndTotalEqualToSumOfInjectedSpans
+- TaskMaster.Test.AppGlobals.StartupTimingRecorderTests › RecordPhase_WithNullPhaseName_ThrowsArgumentNullException
+- TaskMaster.Test.AppGlobals.StartupTimingRecorderTests › EmitTable_LogsFormattedTableViaLoggerInfoWithStartupTimingPrefix
+- TaskMaster.Test.AppGlobals.StartupTimingRecorderTests › EmitTable_WithNullLogger_ThrowsArgumentNullException
+- TaskMaster.Test.AppGlobals.StartupTimingRecorderTests › NullStartupTimingRecorder_IsNoOp_ForFormatAndEmit
+- TaskMaster.Test.AppGlobals.ApplicationGlobalsStartupTimingTests › LoadAsync_WhenTimingDisabled_RecordsNothingAndEmitsNoTable
+- TaskMaster.Test.AppGlobals.ApplicationGlobalsStartupTimingTests › LoadAsync_WhenTimingEnabled_RecordsAllPhasesInStartupOrderWithLoadBasicFirst
+- TaskMaster.Test.AppGlobals.ApplicationGlobalsStartupTimingTests › LoadAsync_WhenTimingEnabled_EmitsExactlyOneTableWithPhaseNamesAndTotal
+- TaskMaster.Test.AppGlobals.ApplicationGlobalsStartupTimingTests › LoadAsync_PreservesPhaseOrderingAndYieldCount_WhenTimingOnVersusOff
+
+---
+
+## Appendix B: Toolchain Commands Reference
+
+**For C#:**
+```powershell
+# Formatting
+dotnet tool run csharpier .
+
+# Linting / analyzers
+msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true
+
+# Type checking / nullable
+msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true
+
+# Testing + coverage
+vstest.console.exe TaskMaster.Test\bin\Debug\TaskMaster.Test.dll UtilitiesCS.Test\bin\Debug\UtilitiesCS.Test.dll QuickFiler.Test\bin\Debug\QuickFiler.Test.dll Tags.Test\bin\Debug\Tags.Test.dll TaskVisualization.Test\bin\Debug\TaskVisualization.Test.dll ToDoModel.Test\bin\Debug\ToDoModel.Test.dll VBFunctions.Test\bin\Debug\VBFunctions.Test.dll /Settings:TaskMaster.runsettings /EnableCodeCoverage /InIsolation /ResultsDirectory:TestResults/remed-final
+```
+
+Coverage verification (this audit, check-only):
+```
+# Repo-wide root line-rate and per-class line hits parsed from the canonical Cobertura artifact
+python parse artifacts/csharp/coverage.xml   # root line-rate=0.7637; StartupTimingRecorder 48/48; NullStartupTimingRecorder 10/10; ApplicationGlobals 120/154
+# Baseline comparison
+python parse TestResults/baseline-full.cobertura.xml   # root line-rate=0.7630; ApplicationGlobals 99/133
+```
+
+HEAD line-count verification (this audit, check-only):
+```bash
+awk 'END{print NR}' TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs              # 483
+awk 'END{print NR}' TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs # 299
+```
+
+---
+
+**Audit Completed By:** feature-reviewer agent
+**Audit Date:** 2026-06-15
+**Policy Version:** Current (as of audit date)

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/remediation-inputs.2026-06-15T13-29.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/remediation-inputs.2026-06-15T13-29.md
@@ -1,0 +1,47 @@
+# Remediation Inputs: debug-startup-timing-instrumentation (Issue #202)
+
+**Generated:** 2026-06-15T13-29
+**Feature Folder:** `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202`
+**Base Branch:** `main` (`a21d09e18dfebb9e3450c1b3322e7715c09d91e6`)
+**Head Branch:** `feature/debug-startup-timing-instrumentation-202` (`1d193d90dba55eec0a739ff13f5ecb5e3d218b99`)
+
+## Source Audit Artifacts
+
+- `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/policy-audit.2026-06-15T13-29.md`
+- `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/code-review.2026-06-15T13-29.md`
+- `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/feature-audit.2026-06-15T13-29.md`
+
+## Remediation-Required Findings
+
+### Finding 1 — Test file exceeds 500-line limit (BLOCKING)
+
+- **Severity:** Major / FAIL (policy violation; remediation trigger)
+- **Policy:** General Code Change Policy §4 file-size limit (CLAUDE.md and `.claude/rules/general-code-change.md`): no production or test code file may exceed 500 lines.
+- **File:** `TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs`
+- **Detail:** The file grew from 440 lines (baseline `a21d09e1`) to 687 lines (head `1d193d90`) when the four startup-timing wiring tests and their helpers (`AttachMemoryAppender`, `DetachMemoryAppender`, `SetEnginesMock`, and the timing-related additions to `TestableApplicationGlobals`) were added. 687 > 500.
+- **Required remediation:** Extract the startup-timing wiring tests and their supporting helpers into a new test file (suggested: `TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs`), add the `<Compile Include="...">` entry to `TaskMaster.Test.csproj`, and ensure both the original and new files are each under 500 lines. Preserve the `[DoNotParallelize]` markers and the `Settings.Default.StartupTimingEnabled` save/restore in the new file.
+- **Verification after fix:** `awk 'END{print NR}'` on both files must report < 500; then re-run the full C# toolchain in order (CSharpier -> analyzer build -> nullable/TreatWarningsAsErrors build -> `vstest.console.exe ... /EnableCodeCoverage`) and confirm EXIT_CODE 0 with no test loss (>= 4194 tests passing).
+- **Evidence:** `git show a21d09e1:TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs | awk 'END{print NR}'` = 440; `awk 'END{print NR}' TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` = 687.
+
+### Finding 2 — Canonical C# coverage artifact absent (NON-BLOCKING / process)
+
+- **Severity:** Minor (process; does not change any coverage verdict)
+- **Detail:** The feature-review-workflow names `artifacts/csharp/coverage.xml` as the C# coverage artifact. That path does not exist. Equivalent merged Cobertura data exists at `TestResults/final-full.cobertura.xml` and was parsed directly; all coverage thresholds (new-code 100%, no regression) were verifiable.
+- **Recommended remediation:** Emit or copy the merged Cobertura output to `artifacts/csharp/coverage.xml` so the workflow's artifact contract is satisfied on future reviews.
+- **Verification after fix:** `artifacts/csharp/coverage.xml` exists and parses to the same repo-wide and per-class figures.
+
+## Non-Blocking Confirmations (no remediation needed)
+
+- All five acceptance criteria evaluate PASS (see `feature-audit.2026-06-15T13-29.md`).
+- New-code line coverage is 100% (>= 90% floor); modified `ApplicationGlobals` improved 60.75% -> 73.88% (no regression).
+- Toolchain (format/analyze/nullable/test) recorded EXIT_CODE 0; 4194/4194 tests pass.
+- No evidence-location violations; no banned-API usage; no secrets.
+
+## Blocking Finding Count
+
+- Blocking (FAIL-level) findings: 1 (Finding 1 — test-file size).
+- Non-blocking findings: 1 (Finding 2 — canonical coverage artifact).
+
+## Handoff
+
+Route Finding 1 to atomic planning (`remediation-handoff-atomic-planner`) as a minimal, mechanical test-file split. Finding 2 may be folded into the same remediation pass or handled as a follow-up; it does not block merge on its own.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/remediation-plan.2026-06-15T13-29.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/remediation-plan.2026-06-15T13-29.md
@@ -1,0 +1,86 @@
+# Remediation Plan: debug-startup-timing-instrumentation (Issue #202)
+
+**Cycle Entry Timestamp:** 2026-06-15T13-29
+**Feature Folder:** `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202`
+**Plan Path:** `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/remediation-plan.2026-06-15T13-29.md`
+**Work Mode:** remediation (mechanical test-file split + non-blocking process artifact)
+**Source Inputs:** `remediation-inputs.2026-06-15T13-29.md`
+**Source Audits:** `policy-audit.2026-06-15T13-29.md`, `code-review.2026-06-15T13-29.md`, `feature-audit.2026-06-15T13-29.md`
+
+## Scope
+
+- **Finding 1 (BLOCKING):** `TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` is 687 lines, exceeding the 500-line file-size limit (General Code Change Policy §4). Remediate by a pure mechanical move/split of the four `[DoNotParallelize]` startup-timing wiring tests and their supporting helpers into a new file `TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs`, with the `<Compile Include="...">` entry added to `TaskMaster.Test.csproj`. Both files must each be < 500 lines. No test lost; total must remain >= 4194 passing.
+- **Finding 2 (NON-BLOCKING):** Emit/copy the merged Cobertura coverage output to `artifacts/csharp/coverage.xml` to satisfy the feature-review-workflow artifact contract. `artifacts/` is gitignored; the artifact is for local/process use only.
+
+## Do-Not List (Guardrails)
+
+- Do not weaken, delete, or alter any assertion or test intent. This is a pure move/split.
+- Do not change production code under `TaskMaster/`.
+- Do not drop or reorder `[DoNotParallelize]` attributes on the four timing tests.
+- Do not remove the `Settings.Default.StartupTimingEnabled` save/restore from any class that mutates that singleton.
+- Do not introduce temporary files in tests; do not introduce new external dependencies.
+- Do not expand scope beyond Findings 1 and 2.
+
+## Evidence Location Notice
+
+All evidence for this plan resolves to the canonical scheme `<FEATURE>/evidence/<kind>/` per `evidence-and-timestamp-conventions`. No non-canonical evidence path was supplied by the caller for this cycle; the directive's evidence instruction already names the canonical `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/<kind>/` root, so no override rejection is required. Coverage evidence is split as: baseline coverage -> `evidence/remediation-baseline/`; post-change/QA coverage -> `evidence/qa-gates/`.
+
+Note: the `artifacts/csharp/coverage.xml` path in Finding 2 is a process/workflow artifact (a coverage *report file consumed by the feature-review-workflow*), not an evidence artifact under the `<FEATURE>/evidence/` scheme. It is therefore exempt from the evidence-path clause and is written to its workflow-named location. The remediation evidence *recording* that this copy occurred is still written to the canonical `evidence/qa-gates/` location.
+
+---
+
+### Phase 0 — Policy Reads and Baseline Capture
+
+- [x] [P0-T1] Read the policy files in the mandatory order from `policy-compliance-order` (`CLAUDE.md`, `.claude/rules/general-code-change.md`, `.claude/rules/general-unit-test.md`, `.claude/rules/csharp.md`) and record a Phase 0 read-evidence artifact at `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/baseline/phase0-instructions-read.2026-06-15T13-29.md` containing `Timestamp:`, `Policy Order:`, and the explicit list of files read. Acceptance: artifact exists with all three fields populated and lists exactly the four files in order.
+- [x] [P0-T2] Capture the baseline line count of the affected test file. Run `awk 'END{print NR}' TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` and record the result in `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/remediation-baseline/baseline-linecounts.2026-06-15T13-29.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. Acceptance: artifact records the count (expected 687) and `EXIT_CODE: 0`.
+- [x] [P0-T3] Confirm the new target file does not yet exist. Run `test -f TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs; echo $?` and record the result in the same baseline-linecounts artifact (append section). Acceptance: artifact records that the target file is absent before the split.
+- [x] [P0-T4] Capture the baseline toolchain test state with coverage. Run `vstest.console.exe <TaskMaster.Test assembly path> /EnableCodeCoverage` against the current head build and record `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/remediation-baseline/baseline-test.2026-06-15T13-29.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. The `Output Summary:` MUST include the numeric passing test count (expected 4194) and the repo-wide coverage headline plus the `ApplicationGlobals` per-class coverage (baseline 73.88% post-feature; new-code 100%). Acceptance: artifact records `EXIT_CODE: 0`, >= 4194 passing, and numeric coverage values (no placeholders).
+
+---
+
+### Phase 1 — Mechanical Test-File Split
+
+- [x] [P1-T1] Create `TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs` with an explicit minimal `using` set, the `namespace TaskMaster.Test.AppGlobals`, and a new `[TestClass] public class ApplicationGlobalsStartupTimingTests`. Add only the `using` directives the new test class and its duplicated helpers actually reference: `System`, `System.Collections.Concurrent`, `System.Collections.Generic`, `System.Linq`, `System.Reflection`, `System.Threading.Tasks`, `FluentAssertions`, `log4net`, `log4net.Appender`, `log4net.Repository.Hierarchy`, `Microsoft.Office.Interop.Outlook`, `Microsoft.VisualStudio.TestTools.UnitTesting`, `Moq`, `UtilitiesCS`, and the `using OutlookApplication = Microsoft.Office.Interop.Outlook.Application;` alias. Do NOT copy `System.IO`, `System.Runtime.Serialization`, `System.Text.RegularExpressions`, `System.Threading`, or `UtilitiesCS.Threading` — those are referenced only by tests that remain in the original file. (If verification of the actual moved code shows a slightly different minimal set is needed for compilation, use the compilation-correct minimal set and note the adjustment — the principle is: only the usings the new file actually references.) Include the `_originalStartupTimingEnabled` field plus `TestInitialize`/`TestCleanup` that save and restore `TaskMaster.Properties.Settings.Default.StartupTimingEnabled` (verbatim copy of lines 27-47 of the original file). Acceptance: the new file compiles, contains no unused `using` directive, and contains the save/restore lifecycle.
+- [x] [P1-T2] Move the four `[DoNotParallelize]` startup-timing wiring test methods verbatim (no assertion or intent changes) from `ApplicationGlobalsTests.cs` (original lines 368-498) into `ApplicationGlobalsStartupTimingTests.cs`: `LoadAsync_WhenTimingDisabled_RecordsNothingAndEmitsNoTable`, `LoadAsync_WhenTimingEnabled_RecordsAllPhasesInStartupOrderWithLoadBasicFirst`, `LoadAsync_WhenTimingEnabled_EmitsExactlyOneTableWithPhaseNamesAndTotal`, `LoadAsync_PreservesPhaseOrderingAndYieldCount_WhenTimingOnVersusOff`. Preserve every `[DoNotParallelize]` attribute and the explanatory comment block above the first timing test. Acceptance: all four methods, including their `[DoNotParallelize]` markers, are present in the new file and removed from the original.
+- [x] [P1-T3] Add to `ApplicationGlobalsStartupTimingTests.cs` verbatim copies of the helpers the moved tests require: `SetEnginesMock`, `AttachMemoryAppender`, `DetachMemoryAppender`, `CreateOutlookApplicationStub`, and the nested `TestableApplicationGlobals` class (with its timing observation seam `TimingRecorder`, `LoadBasicMethod` override, phase overrides, and `YieldCount`). These are required because the new test class cannot reference the original class's private members. Acceptance: the new file compiles with no reference to members of `ApplicationGlobalsTests`.
+- [x] [P1-T4] In the original `ApplicationGlobalsTests.cs`, remove any helper that is now used ONLY by the moved timing tests and not by the remaining tests. Verify usage before removal: `AttachMemoryAppender` and `DetachMemoryAppender` are used only by the timing tests and must be removed from the original; `SetEnginesMock` is used only by the timing tests and must be removed from the original; `CreateOutlookApplicationStub`, `TestableApplicationGlobals`, `GetRepositoryRoot`, `ExtractMethodBody`, `ResetIdleAsyncQueueState`, `GetIdleAsyncQueueEntries` remain in the original because the retained tests still use them. Confirm each removal with a grep for the helper name across the original file showing zero remaining references before deleting it. Acceptance: original file contains no unused private helper and no dead `using` directive; original file still compiles.
+- [x] [P1-T5] Remove unused `using` directives from the original file after the move (for example `log4net`, `log4net.Appender`, `log4net.Repository.Hierarchy` if no longer referenced once the memory-appender helpers leave). Verify each candidate `using` has zero remaining references in the original before removal. Also verify the new file `ApplicationGlobalsStartupTimingTests.cs` contains no unused `using` (per the explicit set established in P1-T1). Acceptance: BOTH files have no unused `using`; the analyzer build (Phase 2) reports no IDE0005/unused-using diagnostic for either file.
+- [x] [P1-T6] Add `<Compile Include="AppGlobals\ApplicationGlobalsStartupTimingTests.cs" />` to `TaskMaster.Test/TaskMaster.Test.csproj` immediately after the existing `<Compile Include="AppGlobals\ApplicationGlobalsTests.cs" />` entry (currently line 261). Acceptance: the csproj contains the new Compile item exactly once and the existing item is unchanged.
+- [x] [P1-T7] Verify both files are under the 500-line limit. Run `awk 'END{print NR}' TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` and `awk 'END{print NR}' TaskMaster.Test/AppGlobals/ApplicationGlobalsStartupTimingTests.cs` and record both results in `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/post-split-linecounts.2026-06-15T13-29.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. Acceptance: both counts are strictly < 500 and recorded with `EXIT_CODE: 0`. If the NEW file is >= 500, return to P1-T2/P1-T3 and rebalance which helpers are duplicated, since the new file genuinely has duplicatable content. If the ORIGINAL file is >= 500 lines after the move, reduce it deterministically by (a) confirming the `log4net` usings and any other now-unused `using` directives have been removed (P1-T5), and (b) collapsing consecutive blank lines left by removed members to a single blank line. If the original is still >= 500 after CSharpier formatting (P2-T1), record the exact post-format line count in the qa-gates evidence artifact and escalate at completion; do not silently leave the file over the limit. This task does not pass until both files are < 500 lines.
+
+---
+
+### Phase 2 — Full C# Toolchain QA Loop
+
+Run the full C# toolchain in this exact order. If any step fails or changes files, restart the loop from P2-T1.
+
+- [x] [P2-T1] Format. Run `dotnet tool run csharpier .` (or `csharpier .`). Record `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/qa-format.2026-06-15T13-29.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. Acceptance: `EXIT_CODE: 0`. If CSharpier rewrote either file, restart the loop from P2-T1 after recording the change.
+- [x] [P2-T2] Analyze. Run `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`. Record `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/qa-analyze.2026-06-15T13-29.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. Acceptance: `EXIT_CODE: 0` with no analyzer diagnostics introduced by the split (specifically no unused-using or unused-private-member diagnostics in either AppGlobals test file).
+- [x] [P2-T3] Type-check / nullable. Run `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`. Record `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/qa-nullable.2026-06-15T13-29.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. Acceptance: `EXIT_CODE: 0` with no nullable or warning-as-error diagnostics.
+- [x] [P2-T4] Test with coverage. Run `vstest.console.exe <TaskMaster.Test assembly path> /EnableCodeCoverage`. Record `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/qa-test.2026-06-15T13-29.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. The `Output Summary:` MUST include the numeric passing count (must be >= 4194), the repo-wide coverage headline, and the `ApplicationGlobals` per-class coverage. Acceptance: `EXIT_CODE: 0`, >= 4194 passing, and coverage values equal to baseline within rounding (new-code 100% preserved; no regression on changed lines). A pure move/split must not reduce coverage.
+- [x] [P2-T5] Coverage delta verification. Compare the Phase 0 baseline coverage (P0-T4) against the Phase 2 post-change coverage (P2-T4) and record `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/coverage-delta.2026-06-15T13-29.md` with `Timestamp:`, baseline coverage, post-change coverage, new/changed-code coverage, and a PASS/FAIL determination. Acceptance: repo-wide coverage >= 80%, no regression on changed lines, new-code coverage >= 90% (recorded 100%). FAIL determination requires returning to Phase 1.
+
+---
+
+### Phase 3 — Non-Blocking Coverage Artifact (Finding 2)
+
+- [x] [P3-T1] Emit/copy the merged Cobertura coverage output (produced during P2-T4, equivalent to `TestResults/final-full.cobertura.xml`) to `artifacts/csharp/coverage.xml`. This is a workflow process artifact, not an evidence artifact; `artifacts/` is gitignored and the file is for local/feature-review-workflow use. Acceptance: `artifacts/csharp/coverage.xml` exists and parses to the same repo-wide and per-class figures recorded in P2-T4.
+- [x] [P3-T2] Record the artifact-copy action in `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/coverage-artifact-copy.2026-06-15T13-29.md` with `Timestamp:`, `Command:` (the copy command used), `EXIT_CODE:`, `Output Summary:` (source path, destination path, and a confirmation that figures match P2-T4). Acceptance: artifact exists with all fields populated and confirms figure parity.
+
+---
+
+### Phase 4 — Verification and Acceptance
+
+- [x] [P4-T1] Confirm the file-size finding is closed: re-read the post-split line counts from P1-T7 and assert both `ApplicationGlobalsTests.cs` and `ApplicationGlobalsStartupTimingTests.cs` are < 500 lines. Acceptance: both counts < 500; recorded in `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/evidence/qa-gates/verification-summary.2026-06-15T13-29.md`.
+- [x] [P4-T2] Confirm no test loss: assert the Phase 2 passing count (P2-T4) is >= 4194 and that the four `[DoNotParallelize]` timing tests appear in the run results under the new `ApplicationGlobalsStartupTimingTests` class. Acceptance: count >= 4194 and all four timing test names present; recorded in the verification-summary artifact.
+- [x] [P4-T3] Confirm assertion/intent parity: diff the moved test method bodies against the Phase 0 originals (via git diff of the move) to confirm no assertion, attribute, or comment was altered other than the class relocation. Acceptance: the only differences are file relocation, class name, and necessary helper duplication; no assertion text changed. Record the determination in the verification-summary artifact.
+- [x] [P4-T4] Confirm coverage floors hold and the AC check-offs from `feature-audit.2026-06-15T13-29.md` remain valid (all five ACs still PASS; coverage unchanged). Acceptance: verification-summary artifact records that all five ACs remain PASS, repo-wide coverage >= 80%, new-code coverage >= 90%, and no regression on changed lines.
+- [x] [P4-T5] Confirm both findings are addressed: Finding 1 (BLOCKING) closed by the split with both files < 500 lines; Finding 2 (non-blocking) closed by the `artifacts/csharp/coverage.xml` copy. Acceptance: verification-summary artifact records blocking-finding count after remediation = 0.
+
+---
+
+## Preflight Readiness
+
+DIRECTIVE: PREFLIGHT VALIDATION ONLY
+
+This plan is ready for `atomic-executor` validation-only preflight. The plan file path is fixed at `docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/remediation-plan.2026-06-15T13-29.md` and will be reused in place for any revision iterations. Expected preflight signal on a clean pass: `PREFLIGHT: ALL CLEAR`.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/spec.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/spec.md
@@ -1,0 +1,111 @@
+# debug-startup-timing-instrumentation — Spec
+
+- **Issue:** #202
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-15T14-30
+- **Status:** Ready for Planning
+- **Version:** 1.0
+
+## Overview
+
+TaskMaster's Outlook add-in startup continues to lock up the UI for an extended period. Prior work (#139, #141) added targeted log4net `[Startup timing]` entries around the store-rewire COM path, but there is no enable-on-demand, whole-of-startup view that attributes wall-clock time to each startup sub-component. Without a per-sub-component breakdown surfaced in a single readable table, diagnosing which sub-component dominates startup remains a manual log-correlation task.
+
+
+## Behavior
+
+Add diagnostic timing instrumentation to the add-in startup path that:
+
+- Is gated behind a `Settings.Default.StartupTimingEnabled` boolean user setting (default `false`). When the setting is off, startup behavior and output are unchanged.
+- When the setting is on, measures the wall-clock time spent in each startup sub-component during `ApplicationGlobals` load along the sequential startup path (`LoadAsync(parallel: false)`). The instrumented sub-components are the seven established phase seams: LoadBasic (synchronous), IntelConfig, OlObjects, ToDo, AutoFile, Engines, and Events.
+- Emits a single formatted plain-text table via the `ApplicationGlobals` log4net logger using `logger.Info(...)` with the `[Startup timing]` prefix, consistent with the prior #139/#141 timing entries. The table lists each sub-component, its elapsed time, and a TOTAL row.
+- Does not alter functional startup behavior when the setting is off, and adds only measurement and formatting overhead when on.
+
+The flag is read once in `ApplicationGlobals.LoadAsync` (following the existing `Settings.Default.EventsHooked` consumption pattern in `AppEvents.LoadAsync`), before the sequential/parallel branch. Phase recording occurs after each `await ...PhaseAsync()` in `LoadSequentialAsync`. The table is emitted at the end of `LoadAsync` so the full breakdown appears in one log statement.
+
+
+## Inputs / Outputs
+
+- **Inputs:**
+  - `Settings.Default.StartupTimingEnabled` (boolean user setting, default `false`) — the single enable/disable control. Toggled by editing the user settings file (`%LOCALAPPDATA%\TaskMaster\...\user.config`) or via a future settings UI. Requires an Outlook restart to take effect.
+  - Per-phase elapsed wall-clock spans captured around the existing `...PhaseAsync()` seams during sequential startup.
+- **Outputs:**
+  - A single multi-line `logger.Info(...)` statement on the `ApplicationGlobals` log4net logger, prefixed `[Startup timing]`, containing a bordered table with `Duration` (right-justified) and `Action` columns plus a TOTAL row. Output is routed to whatever log4net appenders are configured (file/debug), the same channel used by the existing `[Startup timing]` entries.
+- **Config keys and defaults:**
+  - `StartupTimingEnabled` = `False` (user scope) added to `TaskMaster/Properties/Settings.settings` and auto-generated into `Settings.Designer.cs`.
+- **Versioning / backward-compatibility:**
+  - No public API changes. The new setting defaults off; existing behavior is unchanged for all current users. No migration required (a missing setting resolves to its default `False`).
+
+## API / CLI Surface
+
+This feature has no CLI surface. The new internal API surface within the `TaskMaster` assembly is:
+
+- `internal interface IStartupTimingRecorder` — recording and formatting contract:
+  - `void RecordPhase(string phaseName, TimeSpan elapsed)` — records a named span.
+  - `string FormatTable()` — returns the formatted plain-text table.
+  - `void EmitTable(log4net.ILog logger)` — emits the table via the supplied logger with the `[Startup timing]` prefix.
+- `internal sealed class StartupTimingRecorder : IStartupTimingRecorder` — production implementation that maintains its own ordered `(phaseName, elapsed)` collection. It reuses the `UtilitiesCS.HelperClasses.PrettyPrinters.ToFormattedText(string[][], ...)` formatting primitive (the same overload `SegmentStopWatch.GetDurations()` uses) for column layout and computes a TOTAL row equal to the sum of recorded spans. It does not wrap `SegmentStopWatch` (whose TOTAL is derived from the watch's own `Elapsed`, which is zero for injected spans) and does not reimplement column alignment.
+- `internal sealed class NullStartupTimingRecorder : IStartupTimingRecorder` — no-op default used on the flag-off path. `RecordPhase` returns immediately; `FormatTable` returns an empty string; `EmitTable` emits nothing.
+
+These members are `internal`; `TaskMaster.Test` consumes them via the existing `InternalsVisibleTo("TaskMaster.Test")`.
+
+- **Contracts and validation rules:**
+  - `RecordPhase` accepts any non-null `phaseName`; phases are recorded in call order.
+  - `FormatTable` is pure and deterministic given the recorded spans; empty input yields a table with only the TOTAL row (or an empty/zero result for the null recorder).
+  - The recorder performs no Outlook/COM access and no filesystem or network I/O.
+
+## Data & State
+
+- **Data flow:** `LoadBasicMethod()` is measured with a `Stopwatch` and the elapsed value is stored in a private field; each sequential phase produces an elapsed `TimeSpan`. Both are passed to `IStartupTimingRecorder.RecordPhase` (LoadBasic first, then the six sequential phases when the flag is on). The recorder accumulates named spans in its own ordered collection. At the end of `LoadAsync`, `EmitTable` formats (via `PrettyPrinters.ToFormattedText`) and logs the accumulated spans with a summed TOTAL row.
+- **State changes introduced:**
+  - `ApplicationGlobals` gains one new private field, `IStartupTimingRecorder _timingRecorder`, assigned in `LoadAsync` based on the flag (concrete recorder when on, null/no-op recorder when off).
+  - One new persisted user setting, `StartupTimingEnabled`, in the application settings.
+- **Data transformations and invariants:** Spans are recorded once per phase, in startup order. The TOTAL row reflects aggregate elapsed time. No span data is persisted beyond the single log emission; the recorder holds spans only for the duration of one startup.
+- **Caching or persistence details:** None beyond the user setting persistence already provided by the .NET settings infrastructure.
+- **Migration or backfill requirements:** None. Absence of the setting resolves to the default `False`.
+
+## Constraints & Risks
+
+- The add-in runs as a .NET Framework VSTO add-in on the Outlook main STA thread; instrumentation must not introduce COM-thread affinity changes or additional async restructuring of the startup path.
+- The flag mechanism must be simple to toggle and must default to off.
+- New production code must meet the repository coverage floor (>= 90% for new modules/classes); the recorder and table formatter must be designed with a seam so they can be unit-tested without a live Outlook process.
+- Measurement overhead must be negligible when the flag is off.
+
+
+## Implementation Strategy
+
+- **Implementation scope (what changes, not sequencing):**
+  - Add the `StartupTimingEnabled` user setting to `TaskMaster/Properties/Settings.settings` (and the auto-generated `Settings.Designer.cs`), default `False`.
+  - Add a flag read in `ApplicationGlobals.LoadAsync` that selects the concrete or no-op recorder. Add the `_timingRecorder` field and a `_loadBasicElapsed` field. Instrument `LoadBasicMethod()` itself with a `Stopwatch` (the construction-time `BasicLoaded` Lazy runs before `LoadAsync`, so measuring inside `LoadAsync` would record ~0); record `("LoadBasic", _loadBasicElapsed)` as the first phase when the flag is on. Add per-phase `RecordPhase` calls after each `await ...PhaseAsync()` in `LoadSequentialAsync`. Add the table emission at the end of `LoadAsync`. Add `using TaskMaster.Properties;` to `ApplicationGlobals.cs`.
+  - Add the recorder interface and implementations as new files in `TaskMaster/AppGlobals/`.
+  - Add MSTest coverage in `TaskMaster.Test/AppGlobals/ApplicationGlobalsTests.cs` using the existing `TestableApplicationGlobals` seam.
+- **New classes/functions to add or update:**
+  - New: `TaskMaster/AppGlobals/IStartupTimingRecorder.cs`, `TaskMaster/AppGlobals/StartupTimingRecorder.cs` (own ordered collection + `PrettyPrinters.ToFormattedText` reuse + summed TOTAL), and `NullStartupTimingRecorder` (co-located or separate file).
+  - Update: `TaskMaster/AppGlobals/ApplicationGlobals.cs` (flag check, field, recording calls, emission), `TaskMaster/Properties/Settings.settings`.
+- **Dependency changes:** None. `UtilitiesCS.HelperClasses.PrettyPrinters.ToFormattedText`, `System.Diagnostics.Stopwatch`, and `log4net` are already present and approved. `TimeProvider` injection is not required because elapsed timing uses `Stopwatch` (hardware-counter based), which does not trigger the BannedApiAnalyzers `DateTime.Now`/`UtcNow` rule.
+- **Logging/telemetry additions and locations:** One `logger.Info(...)` emission at the end of `ApplicationGlobals.LoadAsync` (flag-on path only), prefixed `[Startup timing]`, on the `ApplicationGlobals` log4net logger. The alternative `Console`/`DebugTextWriter` (`OutputDebugString`) path was rejected to keep all startup-timing data on the single log4net channel already used by #139/#141.
+- **Rollout plan:** Controlled by the `StartupTimingEnabled` user setting, default off. No staged deploy needed; the feature is inert until a diagnostician enables the setting. Fallback is the existing behavior, which is the default state.
+
+## Acceptance Criteria
+
+- [x] A flag exists that enables or disables startup timing instrumentation; when disabled there is no behavioral or output change to startup.
+- [x] When enabled, each startup sub-component's elapsed wall-clock time is captured during startup.
+- [x] When enabled, a formatted plain-text table of sub-component names and elapsed times (plus a total row) is written to the output screen after startup completes.
+- [x] The timing recorder/formatter is a testable unit (no Outlook/COM dependency) with MSTest coverage meeting the repository floor for new code.
+- [x] Instrumentation uses existing logging/output infrastructure and existing approved dependencies; it does not change functional startup behavior.
+
+## Definition of Done
+
+- [ ] Acceptance criteria documented and mapped to tests or demos
+- [ ] Behavior matches acceptance criteria in all documented environments
+- [ ] Tests updated/added (unit/integration as applicable)
+- [ ] Edge cases and error handling covered by tests
+- [ ] Docs updated (README, docs/features/active/... links)
+- [ ] Telemetry/logging added or updated (if applicable)
+- [ ] Toolchain pass completed (format → lint → type-check → test)
+
+## Seeded Test Conditions (from potential)
+- [ ] Recorder captures named spans and computes elapsed time correctly (positive, zero-duration, and ordering cases).
+- [ ] Table formatter renders aligned plain-text columns deterministically for representative inputs and an empty input.
+- [ ] Flag off => no spans recorded and no table emitted; flag on => spans recorded and table emitted.
+- [ ] Wiring into the startup phase sequence preserves existing phase ordering and behavior.

--- a/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/user-story.md
+++ b/docs/features/active/2026-06-15-debug-startup-timing-instrumentation-202/user-story.md
@@ -1,0 +1,66 @@
+# `debug-startup-timing-instrumentation` — User Story
+
+- Issue: #202
+- Owner: drmoisan
+- Status: Ready for Planning
+- Last Updated: 2026-06-15T14-30
+
+## Story Statement
+
+- As the TaskMaster maintainer diagnosing the startup UI lock, I want an enable-on-demand timing breakdown of each startup sub-component surfaced as one readable table, so that I can identify which sub-component dominates startup wall-clock time without manually correlating scattered log entries.
+- As a TaskMaster end user, I want the timing instrumentation to be off by default and to have no effect on normal runs, so that diagnostic tooling never changes my startup behavior or performance.
+
+## Problem / Why
+
+TaskMaster's Outlook add-in startup continues to lock up the UI for an extended period. Prior work (#139, #141) added targeted log4net `[Startup timing]` entries around the store-rewire COM path, but there is no enable-on-demand, whole-of-startup view that attributes wall-clock time to each startup sub-component. Without a per-sub-component breakdown surfaced in a single readable table, diagnosing which sub-component dominates startup remains a manual log-correlation task.
+
+
+## Personas & Scenarios
+
+- Persona: Maintainer / diagnostician (primary)
+  - Who: The developer responsible for diagnosing TaskMaster's startup performance.
+  - What they care about: Attributing startup wall-clock time to specific sub-components quickly and reliably.
+  - Constraints: The add-in runs as a .NET Framework VSTO add-in on the Outlook main STA thread. The problematic scenario is a Release-built, installed add-in, so the diagnostic must be controllable without recompilation. Instrumentation must not introduce COM-thread affinity changes or async restructuring.
+  - Goals and frustrations: Wants a single, aligned per-sub-component table. Frustrated that prior `[Startup timing]` entries (#139/#141) only cover the store-rewire COM path and require manual log correlation to compare sub-component contributions.
+  - Context and motivations: The UI continues to lock during startup; the maintainer needs evidence of which sub-component dominates before deciding where to invest remediation effort. This feature is diagnostic instrumentation only and does not itself fix the UI lock.
+
+- Persona: End user (secondary)
+  - Who: A TaskMaster user running the add-in for normal email/task work.
+  - What they care about: Stable, unchanged startup behavior.
+  - Constraints / context: Does not run diagnostics and should not be exposed to instrumentation overhead or output.
+  - Goals and frustrations: Wants assurance that diagnostic tooling stays inert unless explicitly enabled.
+
+- Scenario: Capturing a startup timing breakdown
+  - Who is acting: The maintainer/diagnostician.
+  - What triggered the action: A reproduction of the startup UI lock that needs sub-component attribution.
+  - Steps: (1) Sets `StartupTimingEnabled` to `True` in the user settings file. (2) Restarts Outlook so the setting takes effect. (3) Allows the add-in to complete sequential startup. (4) Opens the configured log4net output and locates the single `[Startup timing]` table entry.
+  - Obstacles or decisions: The setting requires an Outlook restart to take effect; the maintainer must enable it before the run being measured. The table is emitted once, at the end of `LoadAsync`.
+  - Expected outcome: A single bordered table listing LoadBasic, IntelConfig, OlObjects, ToDo, AutoFile, Engines, and Events with right-justified durations plus a TOTAL row, on the same log channel as prior timing entries.
+
+- Scenario: Normal run with the flag off
+  - Who is acting: An end user.
+  - What triggered the action: Routine Outlook startup with the default settings.
+  - Steps: Starts Outlook; the add-in loads normally.
+  - Obstacles or decisions: None; the flag is off by default.
+  - Expected outcome: No timing spans are recorded, no timing table is emitted, and startup behavior and performance are identical to the pre-feature baseline.
+
+
+## Acceptance Criteria
+
+- [x] A flag exists that enables or disables startup timing instrumentation; when disabled there is no behavioral or output change to startup.
+- [x] When enabled, each startup sub-component's elapsed wall-clock time is captured during startup.
+- [x] When enabled, a formatted plain-text table of sub-component names and elapsed times (plus a total row) is written to the output screen after startup completes.
+- [x] The timing recorder/formatter is a testable unit (no Outlook/COM dependency) with MSTest coverage meeting the repository floor for new code.
+- [x] Instrumentation uses existing logging/output infrastructure and existing approved dependencies; it does not change functional startup behavior.
+
+
+## Non-Goals
+
+The following are explicitly excluded from this feature:
+
+- **Fixing the startup UI lock.** This feature provides diagnostic measurement only; it does not change startup performance or remediate the lock.
+- **Instrumenting the parallel startup path (`LoadAsync(parallel: true)` / `LoadParallelAsync`).** Only the sequential path (`LoadAsync(parallel: false)`), which is the path used at startup via `Application_Startup`, is in scope.
+- **COM-thread affinity or async restructuring changes.** Instrumentation only wraps existing `await ...PhaseAsync()` seams with pre/post timestamps; no marshalling or async-flow changes are introduced.
+- **Sub-phase granularity below the seven named phases.** The existing per-store/per-COM-call `[Startup timing]` instrumentation from #139/#141 is unchanged; this feature operates at the phase level above those points.
+- **A settings UI for toggling the flag.** The flag is controlled through the user settings file; a settings-UI control is potential follow-up, not part of this feature.
+- **Splitting output across channels.** Output goes to the single log4net channel only; no `Console`/`DebugTextWriter`/`OutputDebugString` emission is added.


### PR DESCRIPTION
# Debug-only startup timing instrumentation (#202)

## Summary

- Adds opt-in, flag-gated timing instrumentation to the TaskMaster add-in startup path to help diagnose the extended UI lock during load.
- Gated behind a new `Settings.Default.StartupTimingEnabled` boolean user setting (default `false`); when off, startup behavior and output are unchanged.
- When enabled, measures wall-clock time for each startup sub-component along the sequential startup path and emits a single formatted plain-text table (per-sub-component rows plus a TOTAL row).
- The table is written via the `ApplicationGlobals` log4net logger using `logger.Info(...)` with the `[Startup timing]` prefix, consistent with the prior #139/#141 timing entries.
- Diagnostic-only: introduces no COM-thread affinity changes and no async restructuring of the startup path.

## Why

TaskMaster's Outlook add-in startup remains unresponsive for an extended period during load. Prior work (#139, #141) added targeted log4net `[Startup timing]` entries around the store-rewire COM path, but there was no enable-on-demand, whole-of-startup view attributing wall-clock time to each startup sub-component. Diagnosing which sub-component dominates startup therefore required manual correlation of scattered log entries. This change provides a single readable per-sub-component breakdown, on demand, without changing default startup behavior.

## What Changed

### Core feature
- New `Settings.Default.StartupTimingEnabled` user setting (default `false`) added to `Settings.settings` and the generated `Settings.Designer.cs`, following the existing `EventsHooked` settings pattern.
- New internal `IStartupTimingRecorder` abstraction with a concrete `StartupTimingRecorder` that maintains its own ordered `(phase, TimeSpan)` collection and renders the table by reusing the existing `UtilitiesCS` `PrettyPrinters.ToFormattedText` formatting primitive (with a summed, non-zero TOTAL row). A no-op recorder is used when the flag is off.
- `ApplicationGlobals` instruments the seven sequential sub-components — LoadBasic (synchronous), IntelConfig, OlObjects, ToDo, AutoFile, Engines, and Events — around the existing phase seams. The flag is read once in `LoadAsync`; the table is emitted once after load. Scope is the sequential startup path (`LoadAsync(parallel: false)`); the parallel path is out of scope.

### Tests
- New recorder unit tests (named-span capture for positive/zero-duration/ordering cases; table format including headers and a non-zero TOTAL; null-recorder no-op).
- New `ApplicationGlobals` wiring tests (flag-off records nothing and emits nothing; flag-on records all phases in order with a single table emission; phase-ordering regression guard) using the existing `TestableApplicationGlobals` seam.
- The startup-timing wiring tests were extracted into a separate `ApplicationGlobalsStartupTimingTests.cs` to keep each test file under the 500-line repository limit.

### Docs / evidence
- Feature documents (`issue.md`, `spec.md`, `user-story.md`), the implementation plan, the remediation plan, and the cycle audit artifacts (policy-audit, code-review, feature-audit) under the active feature folder.

## Architecture / How It Fits Together

The recorder is a small, testable unit with no Outlook/COM dependency. `ApplicationGlobals.LoadAsync` reads the flag once; when enabled it constructs a `StartupTimingRecorder`, records the elapsed time of each phase seam as the existing sequential load proceeds, and emits the formatted table through the class's log4net logger after load completes. When disabled, a no-op recorder is used and there is no behavioral or output change. Table rendering reuses the existing `PrettyPrinters.ToFormattedText` primitive rather than reimplementing column alignment.

## Verification

### Completed (from context artifacts, all EXIT_CODE 0)
- Format: `csharpier` — pass.
- Analyzers: `msbuild ... /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true` — pass.
- Nullable / TreatWarningsAsErrors: `msbuild ... /p:Nullable=enable /p:TreatWarningsAsErrors=true` — pass.
- Tests + coverage: `vstest.console.exe <7 first-party test assemblies> /EnableCodeCoverage` — pass; 4194/4194 tests passing.
- Coverage: new recorder code at 100% line coverage; modified `ApplicationGlobals` improved with no regression; repo-wide first-party coverage unchanged. The repo-wide figure below the literal 80% floor is a pre-existing, exemption-consistent condition (the CLAUDE.md COM/VSTO/WinForms testable-denominator exemption) recorded as an Approved Exception, not a finding.
- Post-split file sizes: both `ApplicationGlobalsTests.cs` (483) and `ApplicationGlobalsStartupTimingTests.cs` (299) under the 500-line limit.

### Recommended (CI)
- Run the repository CI required checks against the branch head and confirm green before merge.

## Backward Compatibility / Migration Notes

- No breaking changes. The new setting defaults to `false`, so default startup behavior and output are unchanged.
- No public API removals or path renames. No new external dependencies (reuses existing log4net and `UtilitiesCS` formatting).

## Risks and Mitigations

- Risk: instrumentation perturbs startup behavior. Mitigation: off by default; single boolean read and a no-op recorder when disabled; no COM-thread or async-structure changes.
- Risk: table output is misread or lands on an unexpected channel. Mitigation: emitted on the same log4net channel as the prior #139/#141 `[Startup timing]` entries.
- Rollback: revert this branch; with the flag default `false`, runtime impact is limited even before revert.

## Review Guide

1. `ApplicationGlobals` wiring (flag read, phase recording, single table emission).
2. `IStartupTimingRecorder` / `StartupTimingRecorder` (collection + `ToFormattedText` reuse + summed TOTAL) and the no-op recorder.
3. `Settings.settings` / `Settings.Designer.cs` flag addition.
4. Tests, including the mechanical split into `ApplicationGlobalsStartupTimingTests.cs`.

## Follow-ups

- This change is diagnostic instrumentation; it does not itself fix the UI lock. Once the dominating sub-component is identified from the table, a targeted fix can be scoped as separate work.
- Optional: extend instrumentation to the parallel startup path if needed for future diagnosis.

## GitHub Auto-close

- Closes #202
