### PR TITLE
test: stabilize Visual Studio-specific unit tests

### DIFF
--- a/ToDoModel.Test/Data Model/ID/IDListGetNextToDoIDTests.cs
+++ b/ToDoModel.Test/Data Model/ID/IDListGetNextToDoIDTests.cs
@@ -10,34 +10,19 @@ namespace ToDoModel.Test
     /// Unit tests for <see cref="IDList.GetNextToDoID(string)"/>. The list is constructed only via
     /// the Outlook-free constructors (<see cref="IDList()"/>, <see cref="IDList(IList{string})"/>,
     /// <see cref="IDList(IEnumerable{string})"/>), so no live Outlook is required. Only the pure
-    /// base-36 arithmetic path is exercised. The method may write
-    /// <c>Settings.Default.MaxLengthOfID</c> when the produced ID is longer than the cached
-    /// maximum; that value is snapshotted in <see cref="TestInitialize"/> and restored in
-    /// <see cref="TestCleanup"/> so machine state is not mutated and tests stay independent. No
-    /// <c>Filepath</c> is set, so the internal <c>Serialize()</c> branch is not taken.
+    /// base-36 arithmetic path is exercised. Tests that call the successful path initialize the
+    /// list's cached maximum ID length before generating an ID so the method does not persist
+    /// <c>Settings.Default.MaxLengthOfID</c>. No <c>Filepath</c> is set, so the internal
+    /// <c>Serialize()</c> branch is not taken.
     /// </summary>
     [TestClass]
     public class IDListGetNextToDoIDTests
     {
-        private int _originalMaxLengthOfID;
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            _originalMaxLengthOfID = ToDoModel.Properties.Settings.Default.MaxLengthOfID;
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            ToDoModel.Properties.Settings.Default.MaxLengthOfID = _originalMaxLengthOfID;
-        }
-
         [TestMethod]
         public void GetNextToDoID_NoCollision_ReturnsNextBase36ValueAndAddsIt()
         {
             // Arrange: seed "0001" => base10 1; next id is 2 => base36 padded "02".
-            var list = new IDList(new List<string> { "ZZZZ" });
+            var list = CreateListWithCachedMaxLength("ZZZZ");
 
             // Act
             var result = list.GetNextToDoID("0001");
@@ -51,7 +36,7 @@ namespace ToDoModel.Test
         public void GetNextToDoID_IdAlreadyPresent_AdvancesPastTheCollision()
         {
             // Arrange: seed "0001" => next candidate "02" collides; loop advances to "03".
-            var list = new IDList(new List<string> { "02" });
+            var list = CreateListWithCachedMaxLength("02");
 
             // Act
             var result = list.GetNextToDoID("0001");
@@ -65,7 +50,7 @@ namespace ToDoModel.Test
         public void GetNextToDoID_MultipleConsecutiveCollisions_AdvancesToFirstFreeValue()
         {
             // Arrange: candidates "02","03","04" all present; first free is "05".
-            var list = new IDList(new List<string> { "02", "03", "04" });
+            var list = CreateListWithCachedMaxLength("02", "03", "04");
 
             // Act
             var result = list.GetNextToDoID("0001");
@@ -80,7 +65,7 @@ namespace ToDoModel.Test
             // Arrange: seed "ZZ" => base10 (35*36 + 35) = 1295; next is 1296 => base36 "100"
             // (three digits, padded to even length is still "100" because 3 % 2 == 1 prepends "0"
             // => "0100"). Assert the produced value and its length to cover the rollover branch.
-            var list = new IDList(new List<string>());
+            var list = CreateListWithCachedMaxLength("0000");
 
             // Act
             var result = list.GetNextToDoID("ZZ");
@@ -122,6 +107,14 @@ namespace ToDoModel.Test
                 .Throw<ArgumentException>(
                     "GetNextToDoID guards against an empty seed via ThrowIfNullOrEmpty"
                 );
+        }
+
+        private static IDList CreateListWithCachedMaxLength(params string[] ids)
+        {
+            var list = new IDList(new List<string>(ids));
+            _ = list.MaxLengthOfID;
+
+            return list;
         }
     }
 }

--- a/UtilitiesCS.Test/Threading/TimeOutTaskCoverageTests.cs
+++ b/UtilitiesCS.Test/Threading/TimeOutTaskCoverageTests.cs
@@ -88,7 +88,7 @@ namespace UtilitiesCS.Test
             // Act
             int result = await function.RunWithTimeout(
                 CancellationToken.None,
-                milliseconds: 100,
+                milliseconds: Timeout.Infinite,
                 maxAttempts: 0,
                 strict: true
             );
@@ -154,7 +154,7 @@ namespace UtilitiesCS.Test
                     1,
                     2,
                     CancellationToken.None,
-                    milliseconds: 100,
+                    milliseconds: Timeout.Infinite,
                     maxAttempts: 0,
                     strict: true
                 );


### PR DESCRIPTION
- Use infinite timeout for RunWithTimeout result and strict exception coverage paths

- Avoid persisting ToDoModel user settings during ID collision tests