### PR TITLE
docs(epic): finalize store-lockup-resilience epic status (#260)

### DIFF
--- a/docs/features/epics/store-lockup-resilience/epic-status.md
+++ b/docs/features/epics/store-lockup-resilience/epic-status.md
@@ -10,8 +10,8 @@
   docs already landed on `main` via PR #268; no deviation recorded).
 - **Model budget:** `fable_policy: disabled`
 - **Current wave:** 2 (complete)
-- **Phase:** all 5 features merged into integration; `origin/main` merged into integration; driving the integration→main PR
-- **Last updated:** 2026-07-08T13:36:26Z
+- **Phase:** COMPLETE — all 5 features merged; integration→main PR #281 merged into `main` (`2396b392`); issues #260–#265 closed
+- **Last updated:** 2026-07-08T13:53:40Z
 
 ## Feature Status
 
@@ -31,8 +31,12 @@
 
 ## Integration → main
 
-- **epic_merge_pr:** opening. Integration is current with `origin/main` (`92f65bea`, merged as `4995d4fd`),
-  which includes the flaky `PhysicalFileInfoAdapter` fix (PR #279) so the final CI gate is green-eligible.
+- **epic_merge_pr:** [#281](https://github.com/drmoisan/TaskMaster/pull/281) — **MERGED into `main`** at
+  `2396b3920881a7c558760de1ed086090d875d322` (2026-07-08T13:53:40Z). CI (`ci.yml` run 28947668822):
+  actionlint pass, Format/build/analyze/test pass, mergeStateStatus CLEAN.
+- **Issues closed by the merge:** #260 (epic), #261, #262, #263, #264, #265.
+- Integration was brought current with `origin/main` (`92f65bea`, merged as `4995d4fd`), which includes the
+  flaky `PhysicalFileInfoAdapter` fix (PR #279); the final CI gate was green.
 - **F4 recovery note:** the first F4 agent was interrupted mid-run; its committed work (`e0b58302`) was
   preserved, pushed, and a resume orchestrator carried it to merge (PR #280).
 - **CI gate note:** `ci.yml` triggers only on `pull_request`/`push` to `main`/`development`, so


### PR DESCRIPTION
# docs(epic): finalize store-lockup-resilience epic status

## Summary

- Lands the final `epic-status.md` completion update for epic #260 store-lockup-resilience onto `main`.
- Documentation only — no production code, tests, or build configuration change.

## Why

The epic's five features and the integration→`main` merge (PR #281, `2396b392`) are already on `main`, and issues #260–#265 are closed. The epic-orchestrator's status projection was finalized on the integration branch after that merge, so this follow-up PR brings the completed-state `epic-status.md` onto `main` for the record.

## What Changed

- `docs/features/epics/store-lockup-resilience/epic-status.md`: marks the epic COMPLETE, records the integration→`main` merge (PR #281, `2396b392`) and the closed issues, and updates the Integration→main section to the merged state (8 insertions, 4 deletions).

## Verification

Completed:
- Change is confined to a single Markdown status document; no code paths affected.

Recommended:
- CI (`ci.yml`) runs on this PR because it targets `main`; expected green (docs-only diff).

## Backward Compatibility / Migration Notes

- None. Documentation-only change.

## Risks and Mitigations

- No runtime risk; the only file changed is a status document.

## Review Guide

- Single-file diff; review the `epic-status.md` completion wording.

## Follow-ups

- None.

## GitHub Auto-close

- None
