### PR TITLE
(docs(epic-planner)): capture planner state and tooling constraints

### DIFF
--- a/.claude/agent-memory/epic-orchestrator/MEMORY.md
+++ b/.claude/agent-memory/epic-orchestrator/MEMORY.md
@@ -2,3 +2,5 @@
 
 - [Inline child lifecycle prohibited](feedback_inline_child_lifecycle_prohibited.md) — must delegate every child via Agent(orchestrator) and final PR via Agent(pr-author); on genuine spawn failure record delegation_failures[] verbatim and stop blocked, never run inline
 - [orchestrator/pr-author runtime availability is a moving target](project_orchestrator_subagent_not_registered.md) — 'orchestrator' absent 06:08Z but PRESENT/launchable 11:33Z on 2026-07-10; 'pr-author' still absent (use pr-author SKILL inline). Always verify the spawn per run
+- [Hung wave child = no clean autonomous recovery](feedback_hung_child_recovery_blocked_by_removal_gate.md) — orphaned/stalled prior-session child can't be re-attached, removal gate blocks worktree reset, feature branch collides on re-delegate; halt and report, never falsify merge_status or kill sibling processes
+- [Live child at pr-author is NOT necessarily hung](feedback_live_child_at_pr_author_not_hung.md) — re-derive REMOTE branch/PR truth before declaring a stall; push rejection = a child just landed work; child may merge minutes later (324/PR#333 case)

--- a/.claude/agent-memory/epic-orchestrator/feedback_hung_child_recovery_blocked_by_removal_gate.md
+++ b/.claude/agent-memory/epic-orchestrator/feedback_hung_child_recovery_blocked_by_removal_gate.md
@@ -1,0 +1,63 @@
+---
+name: hung-child-recovery-blocked-by-removal-gate
+description: On resume, a stalled/orphaned wave child has no clean autonomous recovery — the worktree-removal gate blocks reset and orphaned background agents can't be re-attached; halt and report
+metadata:
+  type: feedback
+---
+
+When resuming an epic and a wave child is found orphaned/hung (prior-session background
+Agent(orchestrator) that stalled — e.g. reached Phase 0 baseline then no file writes for
+hours, no commits, no PR), there is no clean autonomous recovery path. Halt and report to
+the user with precise durable state; do not improvise destructive cleanup.
+
+**Why:** Three constraints compose into a dead end:
+1. Orphaned background children launched in a *prior* session are not children of the
+   current conversation, so they cannot be re-attached, waited on, or messaged.
+2. `enforce-epic-worktree-removal-gate.ps1` denies `git worktree remove` unless the
+   matching `features[]` record has `merge_status` in {merged, worktree_removed}. A stalled
+   child is still `worktree_created`, so nuke-and-recreate is blocked by design.
+3. The canonical feature branch (e.g. `feature/<slug>-<issue>`) is still checked out in the
+   stale worktree, so a fresh `isolation:"worktree"` re-delegation collides on branch
+   setup; and the branch can't be deleted while checked out in a worktree I can't remove.
+The gate's fail-closed design is a deliberate signal that destroying an unmerged child's
+worktree is not sanctioned.
+
+**How to apply:** On resume, re-derive durable truth first (git worktree list --porcelain,
+git branch, gh pr view, plus child mtime/idle check and child orchestrator-state.json
+next_step). If a wave child is stalled with no commits/PR, record the finding in the epic
+checkpoint (session-local, gitignored) and stop blocked. Recovery requires human
+intervention: release the stale worktrees/branches (outside my gated tools) or revive the
+orphaned runs. Never run child lifecycle inline (see [[inline-child-lifecycle-prohibited]]),
+never falsify `merge_status` to bypass the gate, and do not kill sibling `claude.exe`
+processes — a shared machine routinely has several live. See also
+[[orchestrator-subagent-not-registered]] for verifying spawn/liveness per run.
+
+**Confirmed recovery path (folder-tree-percentage-ui epic, 2026-07-16):** The blocked-stop
+worked as intended. Between sessions the maintainer released the two stalled wave-0
+worktrees and deleted their feature branches. On the next resume, durable re-derivation
+showed the worktrees pruned, the child branches gone locally+remotely, integration tip
+unchanged, and no child PR. The correct action was NOT to stay blocked: reset the affected
+features to `not_started` (clear the dead worktree_path/worktree_created_at) to match durable
+truth, then cleanly re-delegate the wave via `Agent(orchestrator, isolation:"worktree")`.
+Lesson: the blocked state is a checkpoint, not a terminal state — always re-derive on the
+next run and clear the block when the external release has happened.
+
+**Second confirmed stall, same epic, wave 1 (2026-07-16T12:10Z):** Feature 325 (PR #335) —
+the last unmerged wave-1 child — stalled a different way. Its child (pid 14780) finished
+implementation + feature-review, opened PR #335, then on fan-in ran
+`git merge --no-commit origin/<integration>` and hit ONE conflict
+(`UU UtilitiesCS/UtilitiesCS.csproj` — 325 and 327 both add files to the same .csproj; classic
+fan-in conflict when a sibling merges first). It wrote `remediation-inputs`/`remediation-plan`,
+set its own `next_step=remediation.cycle_1.execute`, then went silent ~6h with MERGE_HEAD still
+present and the one UU path unresolved. Blocked-stopped per this memory; same recommended
+maintainer action (release pid 14780 + worktree).
+
+**Key discriminator (refines [[live-child-at-pr-author-not-hung]]):** a stall at an *execute*
+step (`remediation.cycle_N.execute`, atomic-executor actively editing files) is NOT the same as
+idle-at-`pr-author` (a CI wait that legitimately writes nothing for many minutes). At an execute
+step, zero worktree writes for hours + a mid-flight `MERGE_HEAD` + unresolved `UU` paths is a
+genuine stall, not slowness. Confirm via: child's own `orchestrator-state.json` next_step,
+`git rev-parse -q --verify MERGE_HEAD` in the child worktree, `git status --porcelain | grep '^UU'`,
+and last-write mtime vs now. Do NOT spawn a second orchestrator into a worktree still held by a
+live (even if inert) prior-session pid while a merge is mid-flight — concurrent writes to that
+index are unrecoverable. Halt, report, recommend release.

--- a/.claude/agent-memory/epic-orchestrator/feedback_live_child_at_pr_author_not_hung.md
+++ b/.claude/agent-memory/epic-orchestrator/feedback_live_child_at_pr_author_not_hung.md
@@ -1,0 +1,31 @@
+---
+name: live-child-at-pr-author-not-hung
+description: A live child idle at next_step=pr-author is NOT necessarily hung; re-derive remote branch/PR truth (esp. on a push rejection) before declaring a stall — the child may complete minutes later
+metadata:
+  type: feedback
+---
+
+A wave child whose own orchestrator-state.json shows `next_step: pr-author` with an alive
+process and stale file mtimes is NOT reliably a stall. On the folder-tree-percentage-ui epic
+(2026-07-16), I observed feature 324's child (pid 14780) idle at pr-author with no worktree
+file writes for ~50+ minutes while its co-launched sibling 326 had fully merged. I nearly
+recorded a blocking-stall finding (per [[hung-child-recovery-blocked-by-removal-gate]]). Before
+halting, a routine `git push` of the epic-status doc was REJECTED (remote advanced) — re-deriving
+durable truth revealed the 324 child had, in the intervening minutes, pushed its branch and
+opened + merged PR #333 into the integration branch. It was slow, not hung.
+
+**Why:** The pr-author step (collect_pr_context, author body + provenance receipt, gh pr create,
+wait for CI, gh pr merge) can take many minutes and writes little/nothing to the worktree during
+the CI wait, so file-mtime idleness and a frozen `last_updated` are weak stall signals. Local
+worktree state is a lagging cache; the authoritative signal is the remote branch/PR state.
+
+**How to apply:** Before declaring any wave child stalled/hung, re-derive REMOTE durable truth:
+`git ls-remote origin refs/heads/<child-branch>`, `gh pr list --state all --search "<slug> in:title"`,
+and the integration branch remote tip. A push rejection on the integration branch is itself a
+signal that a child just landed work — always fetch + re-derive on rejection, never assume.
+Only after the child branch is absent from origin AND no PR exists AND the integration tip is
+unchanged over a sustained window should the dead-end recovery in
+[[hung-child-recovery-blocked-by-removal-gate]] be considered. Never kill the process, never
+falsify merge_status, never force-remove a locked worktree. When a merged child's process is
+still alive and holding its worktree lock, defer `git worktree remove` (record
+worktree_removed_at: null with a note) — it does not block the next wave.

--- a/.claude/agent-memory/epic-planner/MEMORY.md
+++ b/.claude/agent-memory/epic-planner/MEMORY.md
@@ -1,0 +1,4 @@
+# Epic-Planner Memory Index
+
+- [epic-planner-state required fields](feedback_epic_planner_state_required_fields.md) — checkpoint validator also requires top-level max_parallel_features (int 1-8) and per-feature research_path
+- [epic-plan tooling not vendored](reference_epic_plan_tooling_not_vendored.md) — epic_wave_computation.py + epic-manifest validator absent in this repo; verify DAG/waves manually, no `plan`-type validation of epic.md

--- a/.claude/agent-memory/epic-planner/feedback_epic_planner_state_required_fields.md
+++ b/.claude/agent-memory/epic-planner/feedback_epic_planner_state_required_fields.md
@@ -1,0 +1,24 @@
+---
+name: epic-planner-state-required-fields
+description: epic-planner-state checkpoint validator requires top-level max_parallel_features and per-feature research_path, beyond the fields listed in the agent doc
+metadata:
+  type: feedback
+---
+
+The `epic-planner-state` schema enforced by `mcp__drm-copilot__validate_orchestration_artifacts`
+(artifact_type `epic-planner-state`) requires fields not called out in
+`.claude/agents/epic-planner.md` "Checkpoint Persistence":
+
+- top-level `max_parallel_features` — integer 1 through 8 (set it to the number of concurrent
+  preparation delegations launched).
+- per-feature `research_path` — every entry in `features[]` must carry it (the research artifact
+  path under `<feature-folder>/research/`).
+
+**Why:** A resumed run inherited a prior checkpoint that lacked both fields; the validator failed
+until they were added. The agent doc's field list is necessary but not sufficient for the schema.
+
+**How to apply:** Include `max_parallel_features` and per-feature `research_path` in the first
+checkpoint write, then validate with the MCP tool before treating the checkpoint as durable.
+Read each child's `research_artifact` from its own `orchestrator-state.json`; a child still in
+S4 planning may not have recorded it yet, so read the file present under its `research/` dir.
+Related: [[epic-plan-tooling-not-vendored]].

--- a/.claude/agent-memory/epic-planner/reference_epic_plan_tooling_not_vendored.md
+++ b/.claude/agent-memory/epic-planner/reference_epic_plan_tooling_not_vendored.md
@@ -1,0 +1,21 @@
+---
+name: epic-plan-tooling-not-vendored
+description: The epic-plan/epic-orchestrate skills reference epic_wave_computation.py and an epic-manifest validator that are NOT present in this repo; verify DAG manually
+metadata:
+  type: reference
+---
+
+The `epic-plan` and `epic-orchestrate` skills cite
+`scripts/dev_tools/epic_wave_computation.py` as the tested wave-assignment reference and imply an
+epic-manifest schema validator. In the TaskMaster repo (worktrees under
+`C:/Users/DanMoisan/repos/TaskMaster-wt/`) neither is vendored: `find scripts -name "*epic*"`
+returns nothing, and the MCP validator's `artifact_type` enum has no epic-manifest type (only
+`epic-planner-state`, `epic-orchestrator-state`, `epic-kickoff`, `plan`, etc.).
+
+**How to apply:** For the epic manifest (`docs/features/epics/<slug>/epic.md`), verify the DAG
+manually — every `depends_on` entry resolves to a feature in the set, and no node sits in its own
+dependency chain (cycle-free) — and compute waves by longest-path layering by hand
+(`wave=0` when no deps, else `1 + max(wave(dep))`). Do NOT try to run the named script or pass the
+manifest to the `plan` validator (that type is for atomic plans and will misparse). Validate the
+planner checkpoint and kickoff artifact with their real MCP artifact types.
+Related: [[epic-planner-state-required-fields]].


### PR DESCRIPTION
- Record the additional `epic-planner-state` fields required by checkpoint validation, including top-level `max_parallel_features` and per-feature `research_path`
- Document that epic wave tooling and epic-manifest validation are not vendored in this repo and must be replaced with manual DAG and wave verification
- Add both findings to the epic-planner memory index for future resumptions