### PR TITLE
ci(nullable-gate): use /t:Rebuild so the nullable gate is actually enforced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,13 @@ jobs:
       - name: Build with nullable warnings treated as errors
         shell: pwsh
         run: |
-          & msbuild $env:SOLUTION_PATH /t:Build /m /p:Configuration=Debug `
+          # Use /t:Rebuild (not /t:Build) so this step always performs a genuine full
+          # recompile under /p:Nullable=enable. The preceding "Build with analyzers"
+          # step already compiled everything under the projects' own Nullable settings;
+          # MSBuild's incremental up-to-date check does not invalidate on a changed
+          # -p:Nullable command-line property alone, so a plain /t:Build here would
+          # silently skip recompilation and never actually enforce this gate.
+          & msbuild $env:SOLUTION_PATH /t:Rebuild /m /p:Configuration=Debug `
               "/p:Platform=Any CPU" `
               /p:Nullable=enable /p:TreatWarningsAsErrors=true
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
## Summary

Fixes a masking bug in the CI "Build with nullable warnings treated as errors" step: it ran `/t:Build` right after the preceding "Build with analyzers" step had already compiled everything, so MSBuild's incremental up-to-date check silently skipped recompilation and the nullable gate never actually ran a real check. Switches that step to `/t:Rebuild` so it performs a genuine full recompile under `/p:Nullable=enable` every run.

## Why

Discovered while rebuilding PR #347 (log4net 3.3.1->3.3.2): that bump changes a referenced assembly path for every first-party project, which forced a genuine recompile and exposed ~2131 pre-existing nullable errors in `UtilitiesCS` that this gate should have been catching all along but wasn't. Confirmed via a local `/t:Rebuild` on `main` itself (pre-log4net-bump) that the same ~2131 errors already exist there, unrelated to any pending PR change.

## Consequence (important)

Once merged, this makes the nullable-build CI step genuinely enforce for the first time. Every current/future PR based on `main` will fail this check until the exposed pre-existing debt is remediated separately. This PR does not attempt that remediation -- it only makes the gate report the true state instead of silently passing.

## Verification

- Locally confirmed: `/t:Rebuild` with `/p:Nullable=enable /p:TreatWarningsAsErrors=true` on `main` produces the same 2131 errors as on the log4net branch, all in `UtilitiesCS` (and `SVGControl`, depending on the exact rebuild path), none introduced by this change.
- CI run on this PR itself will demonstrate the fix (expected: nullable step now fails, since main's existing debt is unaddressed -- this is intentional and expected until the debt is separately remediated).
