### PR TITLE
chore(394,395): record promoted potential entries for PR #391 follow-ups

### DIFF
--- a/docs/features/potential/promoted/2026-07-20-system-reactive-7-packages-config-migration.md
+++ b/docs/features/potential/promoted/2026-07-20-system-reactive-7-packages-config-migration.md
@@ -1,0 +1,42 @@
+# system-reactive-7-packages-config-migration (Issue #395)
+
+- Date captured: 2026-07-20
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/system-reactive-7-packages-config-migration/ (Issue #395)
+
+- Issue: #395
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/395
+- Last Updated: 2026-07-21
+## Problem / Why
+
+The package update merged in PR #391 moved `System.Reactive` to 7.0.0 in five projects (`QuickFiler`, `TaskMaster`, `ToDoModel`, `UtilitiesCS`, `UtilitiesCS.Test`). System.Reactive 7.0 no longer supports `packages.config`-based projects: its `System.Reactive.PackagesConfigCheck.targets` emits an MSBuild warning on every build of each affected project ("The project contains a packages.config file, which is not supported by System.Reactive v7.0 or later. Please migrate to PackageReference."). The repository is running an explicitly unsupported configuration, and the warning repeats five times per build.
+
+## Proposed Behavior
+
+Resolve the unsupported System.Reactive 7.0 + packages.config combination in one of two ways (decision required):
+
+1. Migrate the five affected projects from `packages.config` to `PackageReference`. Note this conflicts with the current analyzer wiring convention, which deliberately keeps legacy non-SDK VSTO projects on `packages.config` with file-based `<Analyzer Include>` items (see `.claude/rules/csharp.md`, Analyzer Stack mechanism). A migration must preserve analyzer wiring, binding redirects, and VSTO build behavior.
+2. Alternatively, pin `System.Reactive` back to the last 6.x release in the affected projects, or set the documented `RxUseUnsupportedPackagesConfig=true` escape hatch with an in-repo rationale, accepting the unsupported status explicitly.
+
+## Acceptance Criteria (early draft)
+
+- [ ] Builds of all five affected projects produce no `System.Reactive.PackagesConfigCheck` warning.
+- [ ] The chosen approach is documented (decision record or rule update), including analyzer-wiring implications for legacy projects.
+- [ ] Full C# toolchain (CSharpier, analyzer build, TreatWarningsAsErrors rebuild, MSTest suite) passes with no regressions.
+
+## Constraints & Risks
+
+- The affected projects are legacy non-SDK .NET Framework 4.8.1 / VSTO projects; PackageReference migration in such projects is non-trivial and can change restore layout (`packages\` folder disappears), breaking `<HintPath>` and `<Analyzer Include>` items and at least one test fixture that resolves files under `packages\`.
+- The long-term direction is to leave VSTO entirely, which may argue for the low-effort pin/escape-hatch option rather than investing in migration.
+- Suppressing the warning via `RxUseUnsupportedPackagesConfig=true` leaves the repo on an unsupported package configuration.
+
+## Test Conditions to Consider
+
+- [ ] Full solution build with `/p:TreatWarningsAsErrors=true` remains green.
+- [ ] MSTest suite passes for all eight solution test assemblies.
+- [ ] Rx-dependent runtime paths in QuickFiler/ToDoModel behave unchanged (binding redirects still resolve System.Reactive 7.0.0.0).
+
+## Next Step
+
+- [x] Promote to GitHub issue (feature request template)
+- [ ] Create `docs/features/active/system-reactive-7-packages-config-migration/` folder from the template

--- a/docs/features/potential/promoted/2026-07-20-utilitiescs-test-cs2002-duplicate-compile-entry.md
+++ b/docs/features/potential/promoted/2026-07-20-utilitiescs-test-cs2002-duplicate-compile-entry.md
@@ -1,0 +1,63 @@
+# utilitiescs-test-cs2002-duplicate-compile-entry (Issue #394)
+
+- Date captured: 2026-07-20
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/utilitiescs-test-cs2002-duplicate-compile-entry/ (Issue #394)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #394
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/394
+- Last Updated: 2026-07-21
+## Summary
+
+`UtilitiesCS.Test.csproj` contains two identical `<Compile Include="OutlookObjects\Folder\PercentageFormatterTests.cs" />` items (lines 288 and 338), producing compiler warning CS2002 ("Source file ... specified multiple times") on every build of the test project.
+
+## Environment
+
+- OS/version: Windows (any); also reproduces on the `windows-latest` CI runner
+- Toolchain: MSBuild, TaskMaster.sln, Configuration=Debug, Platform=Any CPU
+- Command/flags used: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU"`
+- Data source or fixture: none
+
+## Steps to Reproduce
+
+1. Build the solution: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU"`.
+2. Observe the compiler output for `UtilitiesCS.Test.csproj`.
+
+## Expected Behavior
+
+The build completes without CS2002; each source file appears exactly once in the project's `<Compile>` item group.
+
+## Actual Behavior
+
+`CSC : warning CS2002: Source file 'C:\...\UtilitiesCS.Test\OutlookObjects\Folder\PercentageFormatterTests.cs' specified multiple times [UtilitiesCS.Test.csproj]`
+
+## Logs / Screenshots
+
+- [x] Attached minimal logs or screenshot
+- Snippet: observed in local toolchain runs on 2026-07-20 during PR #391 verification (analyzer build and TreatWarningsAsErrors rebuild).
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [ ] Medium
+- [x] Low
+
+Build warning noise only; the duplicate entry does not currently fail any gate because CS2002 is not promoted to an error in the affected configuration. It risks masking real warnings and could break the build if warning promotion rules change.
+
+## Suspected Cause / Notes
+
+Likely a merge artifact: two `<ItemGroup>` sections in `UtilitiesCS.Test.csproj` each include the same file (lines 288 and 338 as of commit 443a1a52).
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Remove one of the duplicate `<Compile>` items from `UtilitiesCS.Test.csproj`.
+- [ ] Rebuild and confirm CS2002 no longer appears.
+- [ ] Confirm `PercentageFormatterTests` still runs (test count unchanged) via vstest.
+
+## Next Step
+
+- [x] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch


### PR DESCRIPTION
## Summary

- Records the promoted potential-entry artifacts for two follow-up findings identified during PR #391 verification.
- Adds `docs/features/potential/promoted/2026-07-20-utilitiescs-test-cs2002-duplicate-compile-entry.md`, the promotion record behind issue #394 (CS2002 duplicate `<Compile>` entry in `UtilitiesCS.Test.csproj`).
- Adds `docs/features/potential/promoted/2026-07-20-system-reactive-7-packages-config-migration.md`, the promotion record behind issue #395 (System.Reactive 7.0 `packages.config` incompatibility warning).
- Documentation-only change; no production code, tests, or build configuration are modified.

## Why

The feature-promotion lifecycle requires each potential entry promoted to a GitHub issue to have its promotion record committed under `docs/features/potential/promoted/`. Both entries were promoted via the drm-copilot promotion tooling on 2026-07-20; this PR lands the resulting artifacts so the repository audit trail matches the open issues. Direct pushes to `main` are blocked by repository rules, so the artifacts are delivered through this pull request.

## What Changed

- Docs/templates: two new promotion-record Markdown files under `docs/features/potential/promoted/` (+105 lines total, no deletions).

## Architecture / How It Fits Together

Not applicable; no runtime components are affected. The files are inputs to the feature-promotion lifecycle (potential entry → issue → active feature folder) and will be referenced when issues #394 and #395 are picked up.

## Verification

- Completed: PR context collected against `origin/main` (merge base `793508e7`); changed-files overview confirms a docs-only diff of the two listed files.
- Recommended: none beyond CI; the change contains no executable content.

## Backward Compatibility / Migration Notes

None. Additive documentation only.

## Risks and Mitigations

- Risk: negligible; docs-only. Rollback is a single revert of this commit.

## Review Guide

1. `docs/features/potential/promoted/2026-07-20-utilitiescs-test-cs2002-duplicate-compile-entry.md` — bug promotion record for issue #394.
2. `docs/features/potential/promoted/2026-07-20-system-reactive-7-packages-config-migration.md` — refactor promotion record for issue #395.

## Follow-ups

- Issue #394: remove the duplicate `<Compile>` item in `UtilitiesCS.Test.csproj`.
- Issue #395: decide between PackageReference migration, a 6.x pin, or the documented escape hatch for System.Reactive 7.0.

## GitHub Auto-close

- None
