### PR TITLE
fix(folder-tree): keep dispatcher yields on the captured UI dispatcher

### DIFF
--- a/TaskMaster/TaskMaster.csproj
+++ b/TaskMaster/TaskMaster.csproj
@@ -37,7 +37,7 @@
     <PublishUrl>C:\Users\DanMoisan\OneDrive - The Real Good Food Company\TM\</PublishUrl>
     <InstallUrl />
     <TargetCulture>en</TargetCulture>
-    <ApplicationVersion>1.0.0.23</ApplicationVersion>
+    <ApplicationVersion>1.0.0.25</ApplicationVersion>
     <AutoIncrementApplicationRevision>true</AutoIncrementApplicationRevision>
     <UpdateEnabled>true</UpdateEnabled>
     <UpdateInterval>7</UpdateInterval>

--- a/UtilitiesCS/OutlookObjects/Folder/WpfDispatcherYield.cs
+++ b/UtilitiesCS/OutlookObjects/Folder/WpfDispatcherYield.cs
@@ -7,7 +7,7 @@ using System.Windows.Threading;
 namespace UtilitiesCS.OutlookObjects.Folder
 {
     /// <summary>
-    /// Yields folder tree work through the current WPF dispatcher.
+    /// Yields folder tree work through the captured UI dispatcher.
     /// </summary>
     [ExcludeFromCodeCoverage]
     public sealed class WpfDispatcherYield : IDispatcherYield
@@ -15,7 +15,11 @@ namespace UtilitiesCS.OutlookObjects.Folder
         public async Task YieldAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await Dispatcher.Yield(DispatcherPriority.Background);
+            await UtilitiesCS.UiThread.Dispatcher.InvokeAsync(
+                () => { },
+                DispatcherPriority.Background,
+                cancellationToken
+            );
             cancellationToken.ThrowIfCancellationRequested();
         }
     }

--- a/UtilitiesCS/OutlookObjects/Folder/WpfDispatcherYield.cs
+++ b/UtilitiesCS/OutlookObjects/Folder/WpfDispatcherYield.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,7 +16,24 @@ namespace UtilitiesCS.OutlookObjects.Folder
         public async Task YieldAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await UtilitiesCS.UiThread.Dispatcher.InvokeAsync(
+
+            // Prefer the dispatcher already affinitized to this thread so a traversal that the
+            // service marshalled onto a captured dispatcher keeps yielding through that same
+            // dispatcher. Only a worker thread with no dispatcher of its own falls back to the
+            // process-global UI dispatcher, which is the case Dispatcher.Yield() could not serve.
+            // UiThread.Dispatcher is set-once state populated by UiThread.Init() and is null
+            // outside a live host, so that null state is surfaced as InvalidOperationException to
+            // preserve the strict contract callers relied on.
+            Dispatcher dispatcher =
+                Dispatcher.FromThread(Thread.CurrentThread) ?? UtilitiesCS.UiThread.Dispatcher;
+            if (dispatcher is null)
+            {
+                throw new InvalidOperationException(
+                    "The UI dispatcher has not been captured. Call UiThread.Init() before yielding folder tree work."
+                );
+            }
+
+            await dispatcher.InvokeAsync(
                 () => { },
                 DispatcherPriority.Background,
                 cancellationToken


### PR DESCRIPTION
## Summary

- Folder-tree traversal yields now resolve a dispatcher explicitly instead of relying on `Dispatcher.Yield()`, which requires the calling thread to own a dispatcher and throws when it does not.
- The dispatcher already affinitized to the running thread is preferred, so a traversal the service marshalled onto a captured dispatcher keeps yielding through that same dispatcher.
- `UtilitiesCS.UiThread.Dispatcher` is used only as a fallback, for the dispatcher-free worker-thread case that `Dispatcher.Yield()` could not serve.
- When no dispatcher is available at all, the method throws `InvalidOperationException` with an actionable message rather than surfacing a `NullReferenceException`.
- The ClickOnce `ApplicationVersion` in `TaskMaster/TaskMaster.csproj` advances from `1.0.0.23` to `1.0.0.25`.

## Why

`WpfDispatcherYield.YieldAsync` previously awaited `Dispatcher.Yield(DispatcherPriority.Background)`. `Dispatcher.Yield()` operates on the dispatcher of the *current* thread, so on a worker thread with no dispatcher of its own it cannot yield and fails. Resolving the dispatcher explicitly makes the yield target unambiguous and allows the worker-thread case to be marshalled to the UI dispatcher instead of failing.

The dispatcher must still be resolved thread-first rather than from the process-global `UiThread.Dispatcher`. `OutlookFolderTreeService` accepts an injected dispatcher (`DispatcherUiDispatcher`) and marshals traversal onto it; reading the global unconditionally would bypass that seam and break the Outlook STA thread-affinity guarantee established on this code path.

## What Changed

**Core behavior — `UtilitiesCS/OutlookObjects/Folder/WpfDispatcherYield.cs`**

- Replaced `await Dispatcher.Yield(DispatcherPriority.Background)` with an explicit background-priority `InvokeAsync` post against a resolved dispatcher.
- Dispatcher resolution order: `Dispatcher.FromThread(Thread.CurrentThread)`, then `UtilitiesCS.UiThread.Dispatcher`.
- Added an explicit `InvalidOperationException` for the no-dispatcher-available state.
- Updated the class summary comment to describe the captured-dispatcher behavior.
- Both existing cancellation checks (before and after the yield) are retained unchanged.

**Build configuration — `TaskMaster/TaskMaster.csproj`**

- `ApplicationVersion` `1.0.0.23` to `1.0.0.25`. The file's trailing newline was dropped by the publishing toolchain; no other project content changed.

No test files were added or modified in this PR.

## Architecture / How It Fits Together

`FolderTreeSnapshotBuilder.YieldIfNeededAsync` consults `IDeadlineClock` and, when the traversal has held the thread long enough, calls `IDispatcherYield.YieldAsync`. `WpfDispatcherYield` is the production implementation of that interface; `OutlookFolderTreeService` composes the builder and marshals traversal work onto its injected `IUiDispatcher`.

The resolution order preserves that composition. When the service has already placed traversal on a captured dispatcher thread, `Dispatcher.FromThread` returns that dispatcher and the background-priority `InvokeAsync` behaves as the previous `Dispatcher.Yield()` did — it releases the thread for higher-priority work and resumes the traversal on the same thread. Only when the traversal runs on a thread with no dispatcher does control transfer to the process-global UI dispatcher.

## Verification

**Completed** (run locally against head `47ca8047`; MSBuild 18, VSTest 18.8.0):

- Format — `dotnet tool run csharpier check UtilitiesCS/OutlookObjects/Folder/WpfDispatcherYield.cs`: exit 0.
- Analyzers — `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`: exit 0, 0 errors.
- Tests — `vstest.console.exe UtilitiesCS.Test\bin\Debug\UtilitiesCS.Test.dll`: 4665 total, 4665 passed, 0 failed.
- Tests — `vstest.console.exe` across `QuickFiler.Test`, `SVGControl.Test`, `Tags.Test`, `TaskMaster.Test`, `TaskTree.Test`, `TaskVisualization.Test`, `ToDoModel.Test`, `VBFunctions.Test`: 1577 total, 1577 passed, 0 failed.

Two existing tests specifically constrain this code path and both pass at head:

- `WpfDispatcherYieldTests.YieldAsync_WithoutDispatcher_RemainsStrict` — asserts `InvalidOperationException` when no dispatcher exists.
- `OutlookFolderTreeServiceConcurrencyTests.GetSnapshotAsync_WorkerOriginatedColdBuild_UsesCapturedStaDispatcher` — asserts all reader access occurs on the captured STA dispatcher thread.

**Nullable / type-check status.** `UtilitiesCS.csproj` does not set the `Nullable` property, so the mandated `/p:Nullable=enable /p:TreatWarningsAsErrors=true` command enables nullable analysis across files that carry no annotations. A forced `/t:Rebuild` of `UtilitiesCS.csproj` under that property set exits non-zero on pre-existing violations in unrelated files (`ClassifierGroup.cs`, `PropertyStore.cs`, `ConfigViewer.cs`, `ConfigGroupBox.cs`, `ManagerAsyncLazy.cs`, `OutlookItemTry.cs`, `SubjectMapEntry.cs`, and others). No diagnostic in that output is attributable to `WpfDispatcherYield.cs`, which carries file-scoped `#nullable enable` and compiles clean. This is a pre-existing repository condition, not a regression introduced here.

**Recommended:**

- Exercise the folder-filter UI against a live Outlook profile and confirm the folder tree populates without a dispatcher exception, since the fallback branch is only reachable in a hosted process.
- Confirm CI is green on the branch head before merge.

## Backward Compatibility / Migration Notes

- No public API signature changed. `IDispatcherYield` and `WpfDispatcherYield.YieldAsync` keep their existing shapes.
- The failure mode for the no-dispatcher case changes from whatever `Dispatcher.Yield()` produced to a typed `InvalidOperationException` with a diagnostic message. Callers that caught `InvalidOperationException` are unaffected.
- The ClickOnce `ApplicationVersion` bump affects published-install versioning only.

## Risks and Mitigations

- **Fallback path is not unit-tested.** `UiThread.Dispatcher` is set-once process-global state populated by `UiThread.Init()`, which constructs a hidden WinForms form; it is null in the test host, so the fallback branch cannot be exercised without a live host. Mitigation: the two existing tests pin the thread-first branch and the no-dispatcher branch, bounding the untested surface to the fallback assignment itself. `WpfDispatcherYield` is marked `[ExcludeFromCodeCoverage]`.
- **Behavior on the fallback path moves continuations to the UI thread.** Awaiting a `DispatcherOperation` resumes on the dispatcher thread, so traversal that fell back continues on the UI thread rather than the worker. This is the intended marshalling behavior, but it shifts where subsequent traversal work executes. Mitigation: the fallback is reached only when the current thread has no dispatcher, which is exactly the case that previously failed.
- **Rollback.** Both commits are additive and confined to one production file plus a version string; reverting the branch restores prior behavior with no data or schema migration.

## Review Guide

Suggested order:

1. `UtilitiesCS/OutlookObjects/Folder/WpfDispatcherYield.cs` — the entire behavioral change, 19 added lines.
2. `TaskMaster/TaskMaster.csproj` — version string only; the second hunk is a dropped trailing newline with no content change.

The branch contains two commits. `edcb571a` introduced the explicit dispatcher post but read `UiThread.Dispatcher` unconditionally; `47ca8047` corrects the resolution order to be thread-first. Reviewing the squashed diff is sufficient.

## Follow-ups

- `UtilitiesCS.csproj` does not opt into nullable reference types, so the repository's mandated type-check command cannot pass against this project without pre-existing cleanup. Annotating the project is deferred work outside this change.
- The PR-context collector reports `Core logic changes: 0 files` against two changed files and reports the GitHub CLI unavailable when `gh 2.87.3` is installed and resolves. Both are known recurring tooling defects, not conditions of this branch.

## GitHub Auto-close

- None. No issue reference appears in the collected PR context.
