### PR TITLE
docs(quickfiler): track two latent defects found during #424

### DIFF
--- a/docs/features/potential/promoted/2026-08-07-emailmovemonitor-rejected-item-hook-retention.md
+++ b/docs/features/potential/promoted/2026-08-07-emailmovemonitor-rejected-item-hook-retention.md
@@ -1,0 +1,80 @@
+# emailmovemonitor-rejected-item-hook-retention (Issue #426)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/emailmovemonitor-rejected-item-hook-retention/ (Issue #426)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #426
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/426
+- Last Updated: 2026-08-07
+## Summary
+
+Mail items that the QuickFiler high-confidence dequeue gate scores and rejects are removed from the master queue but are never unhooked from `EmailMoveMonitor`. Each retained entry holds a live `MailItem` COM reference and participates in a `Folder.BeforeItemMove` subscription until session cleanup, so COM-reference retention grows in proportion to the number of rejected candidates.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Runtime: C# / .NET Framework 4.8.1 VSTO add-in (no Python involvement)
+- Command/flags used: QuickFiler launched from the TaskMaster ribbon with `QfSettings.HighConfidenceModeEnabled = true`
+- Data source or fixture: Live Outlook mailbox with a realistic message volume and a low fraction of items above `HighConfidenceThreshold`
+
+## Steps to Reproduce
+
+1. Enable High Confidence mode and launch QuickFiler against a folder where most messages score below the threshold.
+2. Let the dequeue gate scan and reject a large number of candidates while assembling the first batch.
+3. Inspect `EmailMoveMonitor._hookedItems` (or observe process COM-reference growth) while the QuickFiler session remains open.
+
+## Expected Behavior
+
+An item removed from the master queue is unhooked from the move monitor regardless of whether the gate accepted or rejected it, so `_hookedItems` tracks only items still under management.
+
+## Actual Behavior
+
+Only accepted items are unhooked. `_hookedItems` accumulates one `EmailMoveAction` per rejected candidate for the life of the session, each holding a live `MailItem` COM reference. If such a mail is moved while QuickFiler is open, the retained hook action fires `_masterQueue.Remove(x)` for an item no longer in the queue — a no-op removal, but evidence that the stale hook is still live.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Snippet: not captured. The defect was found by static analysis during the issue #424 investigation, not from a runtime report.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+Medium: no data loss or incorrect filing. The cost is session-scoped unmanaged-resource retention and a set of live event subscriptions that outlive their purpose. Everything is released at `Cleanup()`. Severity rises with the volume of rejected candidates, so the issue #424 fix — which makes high-confidence scanning practical and therefore more heavily used — increases exposure rather than reducing it.
+
+## Suspected Cause / Notes
+
+Verified by reading the code at `fb32b923` (all citations checked against that commit):
+
+- Accepted items go out through `UnhookDequeuedNodes` (`QuickFiler/Controllers/QfcDatamodel.QueueProcessing.cs:107-128`), which calls `TryUnhookOrReplace` (`:18`) and reaches `_moveMonitor.UnhookItem(node)` (`:33`).
+- The high-confidence gate, however, takes candidates through the bare delegate `() => _masterQueue.TryTakeFirst()` (`QuickFiler/Controllers/QfcDatamodel.QueueProcessing.cs:82`). Rejected candidates are simply not added to `accepted` in `QfcStreamingDequeueConfidenceGate.DequeueAsync`; they never pass through `UnhookDequeuedNodes`.
+- `EmailMoveMonitor.HookItem` (`QuickFiler/Helper Classes/EmailMoveMonitor.cs:46-58`) adds an `EmailMoveAction(mail, folder, moveAction)` to `_hookedItems` (`:44`) and subscribes `folder.BeforeItemMove` (`:57`). Nothing removes the entry except `UnhookItem` or `UnhookAll` (`:185`), and `UnhookAll` runs only from `QfcDatamodel` cleanup (`QuickFiler/Controllers/QfcDatamodel.cs:80`).
+
+Dropping rejected items from the session is the intended mode contract, pinned by `DequeueAsync_BelowThresholdItemsAreDiscarded` (`QuickFiler.Test/Controllers/QfcStreamingDequeueConfidenceGateTests.cs:226-237`). This issue is not a request to change that contract — only to release the monitor hook when the item is dropped.
+
+Full analysis: `docs/features/active/2026-08-06-quickfiler-high-confidence-queue-init-stall-424/research/2026-08-06T22-00-quickfiler-high-confidence-queue-init-stall-research.md` § 5.2. Recorded as an explicit non-goal of issue #424 and listed in the PR #425 follow-ups.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Unit coverage areas: `QfcDatamodel.QueueProcessing` dequeue paths, `QfcStreamingDequeueConfidenceGate` rejection path, `EmailMoveMonitor` hook lifecycle
+- [ ] Integration scenario to retest: high-confidence launch against a low-yield folder, asserting `_hookedItems` does not grow with rejected candidates
+- [ ] Manual verification notes: confirm no regression in the existing move-monitor behavior for accepted items
+
+Candidate directions (not a decision):
+
+- Route the gate's take through a delegate that unhooks on rejection, rather than the bare `TryTakeFirst`.
+- Give the gate an explicit rejection callback that the datamodel wires to `_moveMonitor.UnhookItem`.
+- Unhook at the point the item is taken and re-hook only for accepted items.
+
+Testability note: `EmailMoveMonitor.HookItem` marshals COM work (`mail.Parent`, `folder.EntryID`, event wiring) onto the captured STA thread. Any fix must preserve the thread-affinity contract established by issues #214 and #420. Tests must use the existing injectable seams with Moq — no live Outlook COM, no temporary files, per repository unit-test policy.
+
+## Next Step
+
+- [x] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-post-show-duplicate-scoring.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-post-show-duplicate-scoring.md
@@ -1,0 +1,77 @@
+# quickfiler-post-show-duplicate-scoring (Issue #427)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/quickfiler-post-show-duplicate-scoring/ (Issue #427)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #427
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/427
+- Last Updated: 2026-08-07
+## Summary
+
+In QuickFiler high-confidence mode, every accepted mail item is scored twice. The dequeue gate computes the item's top folder and discards it, then the item controller re-runs the identical `MailItemHelper` plus `FolderPredictor` sequence after the form is shown, to populate the folder combo. A carrier type that exists specifically to pass the predetermined folder forward is left unused on the live path.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Runtime: C# / .NET Framework 4.8.1 VSTO add-in (no Python involvement)
+- Command/flags used: QuickFiler launched from the TaskMaster ribbon with `QfSettings.HighConfidenceModeEnabled = true`
+- Data source or fixture: Live Outlook mailbox
+
+## Steps to Reproduce
+
+1. Enable High Confidence mode and launch QuickFiler.
+2. Enable debug logging and inspect the `Probability debug` entries for a single accepted item.
+3. Observe one entry from `QfcDatamodel.ScoreRemainingQueueMailItemAsync` during the pre-UI scan and a second, independent classification from `QfcItemController.LoadFolderHandlerAsync (FromField)` after the form is shown.
+
+## Expected Behavior
+
+An item accepted by the confidence gate carries its already-computed top-folder suggestion forward, so the item controller populates the folder combo from that result instead of recomputing it.
+
+## Actual Behavior
+
+The score is computed, the folder is discarded, and the full scoring sequence runs a second time per accepted item after `Show()`.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Snippet: two `Probability debug` lines per accepted item — one tagged `[QfcDatamodel.ScoreRemainingQueueMailItemAsync (master-queue admission)]`, one tagged `[QfcItemController.LoadFolderHandlerAsync (FromField)]`.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [ ] Medium
+- [x] Low
+
+Low: this is wasted work, not incorrect behavior. It occurs after `Show()`, so it does not contribute to the startup stall fixed under issue #424. The user-visible effect is slower folder-combo population and redundant Outlook COM traffic proportional to the number of items on screen.
+
+## Suspected Cause / Notes
+
+Verified by reading the code at `fb32b923` (all citations checked against that commit):
+
+- `QfcDatamodel.ScoreRemainingQueueMailItemAsync` (`QuickFiler/Controllers/QfcDatamodel.cs:346-360`) calls `FolderScoringService.ScoreAsync`, which returns `(Score, TopFolder)`, and returns only `score.Score`. The computed `TopFolder` is dropped.
+- After the form is shown, `QfcItemController.LoadFolderHandlerAsync` (`QuickFiler/Controllers/QfcItemController.FolderHandling.cs:57-90`) constructs a `FolderPredictor` with `InitOptions.FromField` and awaits `InitAsync` — the same sequence `FolderScoringService.ScoreAsync` already ran.
+- `QfcFormController` already has the machinery to avoid this: a `LoadItemsAsync(IList<QfcPreScoredItem>)` overload (`QuickFiler/Controllers/QfcFormController.Actions.cs:114-120`) alongside the plain `LoadItemsAsync(IList<MailItem>)` (`:62`). `QfcPreScoredItem` pairs a surviving mail item with its predetermined folder path for exactly this purpose. The live high-confidence path calls the plain overload, so the carrier overload is dormant.
+
+Full analysis: `docs/features/active/2026-08-06-quickfiler-high-confidence-queue-init-stall-424/research/2026-08-06T22-00-quickfiler-high-confidence-queue-init-stall-research.md` § 4. Recorded as an explicit non-goal of issue #424 and listed in the PR #425 follow-ups.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Unit coverage areas: `QfcStreamingDequeueConfidenceGate` result shape, `QfcDatamodel` queue-processing return path, `QfcFormController.LoadItemsAsync` overload selection, `QfcItemController` folder-handler population
+- [ ] Integration scenario to retest: high-confidence launch, confirming one scoring pass per accepted item and an unchanged folder-combo selection
+- [ ] Manual verification notes: compare `Probability debug` log output before and after; confirm the preselected folder matches the previous behavior
+
+Candidate directions (not a decision):
+
+- Carry `TopFolder` through the gate's result so accepted items reach `LoadItemsAsync(IList<QfcPreScoredItem>)`, activating the existing dormant overload.
+- Keep the plain overload as the normal-mode path so non-high-confidence behavior is untouched.
+
+Scope note: the existing `QfcHomeControllerIssue218Tests` and `QfcFormControllerTests` pin the current overload-selection discipline and would need deliberate updating. Treat those pins as part of the specification, not as obstacles to route around. Tests must use MSTest with Moq and FluentAssertions, no live Outlook COM and no temporary files, per repository unit-test policy.
+
+## Next Step
+
+- [x] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch


### PR DESCRIPTION
## Summary

- Records two latent defects found during the issue #424 investigation as tracked bug entries, so they survive the merge of that feature folder.
- Documentation only. Two files added under `docs/features/potential/promoted/`. No production or test code is touched.
- Backing issues: **#426** (`EmailMoveMonitor` hook retention for gate-rejected items, `full-bug`) and **#427** (post-`Show()` double-scoring, `minor-audit`).

## Why

Both defects were identified by static analysis while diagnosing the QuickFiler High Confidence startup stall (#424) and were deliberately left unfixed there — the fix was scoped to bounding the pre-UI wait, and widening it would have violated the repository's minimal-fix rule for defects.

They were recorded in three places: the research artifact, the spec's Non-Goals, and the PR #425 follow-ups. All three live inside the #424 feature folder. Once that merges, the defects exist only as prose in a completed feature's paperwork, with nothing to surface them again. This PR promotes them through the standard lifecycle so they are tracked independently.

## What Changed

- `docs/features/potential/promoted/2026-08-07-emailmovemonitor-rejected-item-hook-retention.md`
- `docs/features/potential/promoted/2026-08-07-quickfiler-post-show-duplicate-scoring.md`

Both were created with `new_potential_bug_entry`, filled in with the verified diagnosis, and promoted with `potential_to_issue`, which produced the issue and moved the entry into `promoted/`.

### #426 — `EmailMoveMonitor` hook retention (Medium, `full-bug`)

Accepted items are unhooked from the move monitor on dequeue via `UnhookDequeuedNodes` → `TryUnhookOrReplace` → `_moveMonitor.UnhookItem`. The high-confidence gate, however, takes candidates through the bare `() => _masterQueue.TryTakeFirst()` delegate, so rejected candidates never pass through that path. Each retained `EmailMoveAction` holds a live `MailItem` COM reference and participates in a `Folder.BeforeItemMove` subscription until session `Cleanup()` calls `UnhookAll`.

Dropping rejected items from the session is the intended mode contract and is test-pinned; the issue asks only that the monitor hook be released when the item is dropped. Scoped `full-bug` because it needs its own regression coverage and any fix must preserve the STA thread-affinity contract from #214/#420, since `HookItem` marshals COM work onto the captured thread.

### #427 — post-`Show()` double-scoring (Low, `minor-audit`)

`ScoreRemainingQueueMailItemAsync` calls a scoring service that returns `(Score, TopFolder)` and returns only the score, discarding the folder. After the form is shown, `QfcItemController.LoadFolderHandlerAsync` re-runs the identical `MailItemHelper` + `FolderPredictor(FromField)` sequence to populate the folder combo. `QfcFormController` already carries a dormant `LoadItemsAsync(IList<QfcPreScoredItem>)` overload built for exactly this hand-off.

Wasted work only, and it happens after `Show()`, so it did not contribute to the #424 stall. Scoped `minor-audit` because the change is localized to activating an overload that already exists.

## Verification

### Completed

Every `file:line` citation in both entries was checked against `fb32b923`, the merge-base of this branch:

- `QfcDatamodel.QueueProcessing.cs` — `TryUnhookOrReplace` at `:18`, `UnhookItem` at `:33`, the gate's bare `TryTakeFirst` delegate at `:82`, `UnhookDequeuedNodes` at `:107-128`
- `EmailMoveMonitor.cs` — `_hookedItems` at `:44`, `HookItem` at `:46-58`, `BeforeItemMove` subscribe at `:57`, `UnhookAll` at `:185`
- `QfcDatamodel.cs` — `ScoreRemainingQueueMailItemAsync` at `:346-360`, `UnhookAll` call at `:80`
- `QfcItemController.FolderHandling.cs` — `LoadFolderHandlerAsync` at `:57-90`
- `QfcFormController.Actions.cs` — plain overload at `:62`, `QfcPreScoredItem` overload at `:114-120`

No toolchain run applies: the diff contains no `.cs`, `.csproj`, `.props`, or `.targets` files, so the CSharpier / analyzer / nullable / MSTest loop has nothing in scope. CI still runs on the PR.

### Recommended

Confirm both issues render correctly on GitHub and carry the intended labels and milestone.

## Backward Compatibility / Migration Notes

None. Documentation only; no API, behavior, settings, schema, or dependency change.

## Risks and Mitigations

- **Risk:** the recorded diagnosis drifts from the code before either issue is worked. **Mitigation:** every citation is pinned to `fb32b923` and the commit message says so, so a future reader knows exactly what to re-verify against.
- **Risk:** #427's fix would touch test files that currently pin the existing overload-selection discipline. **Mitigation:** the entry names those suites and states explicitly that they are part of the specification, not obstacles to route around.
- **Rollback:** revert a single documentation commit. The GitHub issues would need closing separately.

## Review Guide

Short diff — read the two entries directly. The substance is in the **Suspected Cause / Notes** section of each; the rest is the standard bug template.

Both are deliberately scoped as *report and track*, not *fix*. Neither entry proposes a decision; the "Candidate directions" lists are explicitly marked as not decisions, to be settled when the issue is picked up.

## Follow-ups

- Work #426 and #427 on their own branches through the normal lifecycle.
- Consider whether #426 should be prioritized ahead of wider High Confidence adoption: the #424 fix makes the mode practical for routine use, which increases the volume of rejected candidates and therefore the retention this defect causes.

## GitHub Auto-close

- None.

This PR records issues #426 and #427; it does not resolve them, so no `Closes` keyword is appropriate. Separately, the PR-context collector reported `GitHub CLI unavailable` and could not verify a closing-issue list, which independently rules out emitting one.
