### PR TITLE
chore(memory): record #512 toolchain-gate outcomes for the orchestrator

### DIFF
--- a/.claude/agent-memory/orchestrator/MEMORY.md
+++ b/.claude/agent-memory/orchestrator/MEMORY.md
@@ -1,4 +1,5 @@
-- [CLAUDE.md nullable command != the CI gate](project_claudemd_nullable_command_diverges_from_ci.md) — ci.yml omits `/p:Nullable=enable`; CS86xx from the forced flag is a FALSE blocker
+- [CLAUDE.md nullable command != CI gate — RESOLVED by #540](project_claudemd_nullable_command_diverges_from_ci.md) — docs now match ci.yml; a reappearance of `/p:Nullable=enable` or `/t:Build` is a regression. Carries the 195-error UtilitiesCS lower bound for #492
+- [PoshQC test drops coverage.xml at repo root](poshqc-test-drops-coverage-xml-at-repo-root.md) — untracked, not gitignored/csharpierignored; inflates the CSharpier file count and leaks into `git add -A`
 - [Agent-worktree discovery + evidence hygiene](project_agent_worktree_discovery_and_evidence_hygiene.md) — `\.claude\` test-glob filter must use the RELATIVE path; never commit raw Cobertura
 - [Completion-gate receipt shapes](completion-gate-receipt-shapes.md) — exact fields require_complete wants: delegation_receipts as a LIST, skill_receipts required:true
 - [JaCoCo not Cobertura for coverage evidence](jacoco-not-cobertura-for-evidence.md) — maintainer deletes committed Cobertura; convert to package-level JaCoCo before pushing
@@ -68,7 +69,7 @@
 - [C# coverage has two denominators](csharp-coverage-denominator-two-figures.md) — filtered first-party ~85.9% clears the gate, unfiltered ~70.4% doesn't; measure before trusting
 - [Preflight catches vacuous gates](preflight-catches-vacuous-gates.md) — MCP `ok:true` is not enough; executor preflight found 6 gates that passed while verifying nothing
 - [Bash tool mangles MSBuild switches](bash-tool-mangles-msbuild-switches.md) — `/m` becomes `M:/` (MSB1008); run C# tools via `pwsh -NoProfile` with absolute paths
-- [Analyzer gate is vacuous without /t:Rebuild](msbuild-analyzer-gate-vacuous-without-rebuild.md) — `/t:Build` after any earlier build skips CoreCompile and compiles NOTHING at EXIT 0
+- [Analyzer gate is vacuous without /t:Rebuild](msbuild-analyzer-gate-vacuous-without-rebuild.md) — `/t:Build` after any earlier build skips CoreCompile and compiles NOTHING at EXIT 0; assert a ZERO `Skipping target "CoreCompile"` count, NOT a csc.exe count (csc is 0 even on real compiles)
 - [Aggregate vstest crash: isolate per assembly](vstest-aggregate-crash-isolate-per-assembly.md) — "Test host process crashed" is environmental; re-run per assembly with /InIsolation
 - [Direct-csproj build facts (AnyCPU; CS2002)](csharp-direct-csproj-build-facts.md) — a single project needs `AnyCPU` (no space) while the .sln needs `"Any CPU"`; TWAE doesn't promote CS2002
 - [Model-routing hook reads the canonical path only](model-routing-hook-reads-canonical-path-only.md) — it hardcodes artifacts/orchestration/orchestrator-state.json; a child-scoped file alone is blocked

--- a/.claude/agent-memory/orchestrator/poshqc-test-drops-coverage-xml-at-repo-root.md
+++ b/.claude/agent-memory/orchestrator/poshqc-test-drops-coverage-xml-at-repo-root.md
@@ -1,0 +1,23 @@
+---
+name: poshqc-test-drops-coverage-xml-at-repo-root
+description: run_poshqc_test and direct Pester coverage runs write an untracked coverage.xml to the repo root that is neither gitignored nor in .csharpierignore, so it inflates the CSharpier file count and can leak into a diff
+metadata:
+  type: project
+---
+
+`mcp__drm-copilot__run_poshqc_test`, and a direct `Invoke-Pester` run with
+`$c.CodeCoverage.Enabled = $true`, both write a `coverage.xml` to the **repository root**. As of
+2026-08-11 that path is in neither `.gitignore` nor `.csharpierignore`.
+
+**Why it matters:** CSharpier 1.2.6 processes `*.xml`, so the stray file raises the CSharpier
+`Checked N files` count by one between two otherwise-identical runs, which looks like formatter
+drift when you are comparing a baseline count against a final-QC count. It is also untracked, so a
+`git add -A` at commit time will sweep it into the diff.
+
+**How to apply:** in any route that runs a PowerShell test gate before a C# format gate, delete the
+root `coverage.xml` between the two and record the deletion in the format-step evidence artifact.
+Re-check for it immediately before `git add`. Observed on issue #512 / PR #540; the executor removed
+it before each CSharpier gate and attributed the count difference in the evidence.
+
+Distinct from [[jacoco-not-cobertura-for-evidence]] (which is about what coverage format to commit)
+and from [[feature-review-coverage-85-floor-trap]] (about `artifacts/csharp/coverage.xml`).

--- a/.claude/agent-memory/orchestrator/project_claudemd_nullable_command_diverges_from_ci.md
+++ b/.claude/agent-memory/orchestrator/project_claudemd_nullable_command_diverges_from_ci.md
@@ -1,15 +1,29 @@
 ---
 name: claudemd-nullable-command-diverges-from-ci
-description: CLAUDE.md's nullable toolchain command adds /p:Nullable=enable but ci.yml does not; forced-flag CS86xx in a file with no #nullable pragma is a false blocker, not a merge gate
+description: RESOLVED 2026-08-11 by PR #540 - CLAUDE.md's C# toolchain commands now match ci.yml; the historical divergence (forced /p:Nullable=enable, vacuous /t:Build) and its false-blocker failure mode are recorded here
 metadata:
   type: project
 ---
 
-`CLAUDE.md` documents the nullable stage as
+**STATUS: RESOLVED on 2026-08-11 by issue #512 / PR #540** (child of epic
+`build-ci-coverage-gate-fidelity`). `CLAUDE.md`, `.claude/rules/csharp.md` and
+`.claude/skills/csharp-qa-gate/SKILL.md` now document `/t:Rebuild /m ... /p:TreatWarningsAsErrors=true`
+with no `/p:Nullable=enable`, character-for-character `ci.yml`'s command, with in-line prohibitions
+against re-adding either defect. The format command is now `dotnet tool run csharpier format .`
+(v0 bare-path syntax fixed, #509). Read the sections below as the historical record of what the
+divergence was and what it cost, not as a live description of the repo.
+
+**If you find `/p:Nullable=enable` or `/t:Build` back in a documented C# toolchain command, that is
+a regression of #512/#522, not policy.** The corrected sites carry explicit "do not restore this"
+prose for exactly that reason.
+
+---
+
+Historically `CLAUDE.md` documented the nullable stage as
 `msbuild TaskMaster.sln /t:Build ... /p:Nullable=enable /p:TreatWarningsAsErrors=true`.
 
 The gate that actually governs merge, in `.github/workflows/ci.yml` ("Build with nullable warnings
-treated as errors"), is:
+treated as errors"), is (and always was):
 
 ```
 msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:TreatWarningsAsErrors=true
@@ -31,6 +45,13 @@ and `TaskMaster.csproj` has no `<Nullable>` element. Running CI's exact command 
 applied returned EXIT 0, zero errors, zero CS8603. The blocker was an artifact of the documented-but-
 unenforced flag. The sibling `SB` property already returns `null` from a non-nullable declared
 return type, so the pattern was pre-existing anyway.
+
+**Measured figure for the follow-on burn-down (2026-08-10, #492).** Under an explicit
+`/p:Nullable=enable` probe the corrected `/t:Rebuild` gate reports **195 errors, all in
+`UtilitiesCS.csproj`** (CS8766 x130, CS8618 x23, CS8625 x12, CS8600 x9, CS8601 x8, CS8604 x7,
+CS8602 x3, CS8603 x2, CS8714 x1). That is a **lower bound**: the build aborted after 22 of 73
+`CoreCompile` executions, so `UtilitiesCS`'s dependents never compiled. Size that epic by measuring
+the solution-wide total first, not by trusting 195.
 
 **How to apply:** when a delegated agent reports a nullable failure, do not relay it. Check whether
 the diagnostic is in a file carrying `#nullable enable`; if not, reproduce `ci.yml`'s command


### PR DESCRIPTION
# chore(memory): record #512 toolchain-gate outcomes for the orchestrator

## Summary

Agent-memory follow-up to PR #540 (issue #512). Three deltas, no production or governance code.

- **Marks a memory RESOLVED.** `project_claudemd_nullable_command_diverges_from_ci.md` described a live divergence between `CLAUDE.md`'s C# toolchain commands and `ci.yml`. PR #540 eliminated that divergence, so the memory's operative advice ("reproduce `ci.yml`'s command before accepting a nullable blocker") no longer describes the repository. The memory now leads with its resolved status and states that a future reappearance of `/p:Nullable=enable` or `/t:Build` in a documented command is a regression of #512/#522, not policy.
- **Records the #492 burn-down figure.** 195 nullable errors, all attributed to `UtilitiesCS.csproj`, with the per-diagnostic breakdown and the explicit lower-bound qualification: the build aborted after 22 of 73 `CoreCompile` executions, so `UtilitiesCS`'s dependents never compiled. Whoever sizes that epic should measure the solution-wide total rather than trusting 195.
- **Adds a new memory** for the untracked `coverage.xml` that `run_poshqc_test` and direct Pester coverage runs drop at the repository root.
- **Corrects an existing memory.** The analyzer-vacuity entry previously prescribed a `csc.exe` invocation count greater than zero as the non-vacuity acceptance. That count is zero at `verbosity=normal` even for genuine compiles, so the prescribed acceptance was unsatisfiable. The correct assertion is a **zero** count of the literal `Skipping target "CoreCompile"` in an MSBuild `/fl` log.

## Why

Two of these are corrections to memories that would have actively misled a future run: one describes a defect that no longer exists, and one prescribes a check that can never pass. The third is a repeat-encounter hazard that costs a confusing formatter-count discrepancy every time a PowerShell test gate runs before a C# format gate.

## What Changed

| File | Change |
|---|---|
| `.claude/agent-memory/orchestrator/project_claudemd_nullable_command_diverges_from_ci.md` | Resolved-status header; #492 measurement section added; historical record retained |
| `.claude/agent-memory/orchestrator/poshqc-test-drops-coverage-xml-at-repo-root.md` | New |
| `.claude/agent-memory/orchestrator/MEMORY.md` | Two index lines updated, one added |

## Verification

- Index is 14.3 KB, below the 17.1 KB compaction target and well below the 24.4 KB read limit.
- Every `](*.md)` link target in the index resolves to a file that exists; verified by set difference against the directory listing.
- No conflict markers remain in the index.

Not applicable: no code changed, so no toolchain gate applies.

## Backward Compatibility / Migration Notes

None. Agent-memory files are read-only inputs to future agent runs.

## Risks and Mitigations

| Risk | Mitigation |
|---|---|
| Index conflicts with a concurrently-landing sibling | The index was compacted by a sibling while this branch was in progress. This commit takes the **sibling's compaction as the base** and applies only the three deltas, so the diff is three lines rather than a competing rewrite. A further conflict resolves by union. |
| The "RESOLVED" marking becomes wrong if #540 is reverted | The memory names the issue and PR that resolved it, so the claim is falsifiable against git history rather than asserted bare. |

## Review Guide

Read `project_claudemd_nullable_command_diverges_from_ci.md` first — it is the only substantive rewrite, and only its header and one new section changed. The remaining two files are one new file and a three-line index delta.

## Follow-ups

None.

## GitHub Auto-close

None. This is a follow-up to #540, which carries the closing references.
