### PR TITLE
chore(memory): record two orchestrator lessons from the #457 child run

### DIFF
--- a/.claude/agent-memory/orchestrator/MEMORY.md
+++ b/.claude/agent-memory/orchestrator/MEMORY.md
@@ -75,3 +75,5 @@
 - [No helper scripts under evidence/](feedback_no_helper_scripts_under_evidence.md) — feature-review's language match is extension-only and path-blind; one retained `.ps1` forces a coverage FAIL
 - [One executor per worktree](one-executor-per-worktree.md) — a stale checkpoint is NOT a dead delegation; never launch a second executor into a live worktree
 - [Removing a halt requires branch propagation](removing-a-halt-requires-branch-propagation.md) — converting a HALT into a recorded blocker strands downstream tasks; propagate to ALL consumers
+- [Bash tool rejects complex commands in isolated worktrees](bash-tool-rejects-complex-commands-in-isolated-worktree.md) — heredoc+redirect+git compounds are refused as unverifiable; gather with plain chained commands, then author via Write
+- [#457 coverage moved UP, and the kickoff figure was wrong](project_457_coverage_moved_up_not_down.md) — the denominator fix raised the rate 85.3514%→85.5355%; kickoff's 85.0317% matched no measurement, so #494 must re-measure

--- a/.claude/agent-memory/orchestrator/bash-tool-rejects-complex-commands-in-isolated-worktree.md
+++ b/.claude/agent-memory/orchestrator/bash-tool-rejects-complex-commands-in-isolated-worktree.md
@@ -1,0 +1,28 @@
+---
+name: bash-tool-rejects-complex-commands-in-isolated-worktree
+description: In a .claude/worktrees/agent-<id> worktree the Bash tool refuses compound commands it cannot statically prove stay in-worktree (heredoc + redirect + git); build such files with Write or separate plain commands
+metadata:
+  type: project
+---
+
+Inside an isolated `.claude/worktrees/agent-<id>` worktree, the Bash tool statically inspects each command and
+**refuses to run** anything it cannot prove stays within the worktree, with:
+
+> "this command is too complex to verify that it stays inside the worktree; break it into plain, separate commands.
+> Refusing to run it — a worktree-isolated agent's git operations must target its own worktree."
+
+Verified 2026-08-11 (issue #457, epic `build-ci-coverage-gate-fidelity`). The rejected form was a single command
+that assigned shell variables, ran several `git diff`/`git log` calls inside a `{ ... }` group, piped through `awk`,
+and redirected the group's stdout into `artifacts/pr_context.summary.txt`. Every path in it was relative and
+in-worktree; the refusal is about static verifiability, not an actual escape.
+
+**Why it matters:** the natural way to synthesize `artifacts/pr_context.summary.txt` from the real diff — the step
+you must do by hand because `collect_pr_context` leaves a stale file (see
+[[collect-pr-context-lands-in-main-checkout]]) — is exactly this shape, so the PR gate is where you hit it.
+
+**How to apply:** do not fight it with quoting. Split into two steps: (1) one plain read-only command that gathers
+the data (`git rev-parse HEAD`, `git diff --shortstat <base>..HEAD`, `git diff --numstat <base>..HEAD -- <paths>`,
+`git log --format=... <base>..HEAD` chained with `&&` and no redirect — that form IS accepted), then (2) the `Write`
+tool to author the file from the returned output. Same for any generated evidence or context artifact. The
+scratchpad `.ps1` + `pwsh -NoProfile -File` route from [[bash-tool-mangles-msbuild-switches]] also works and is
+preferable when the content needs computation rather than transcription.

--- a/.claude/agent-memory/orchestrator/project_457_coverage_moved_up_not_down.md
+++ b/.claude/agent-memory/orchestrator/project_457_coverage_moved_up_not_down.md
@@ -1,0 +1,31 @@
+---
+name: project_457_coverage_moved_up_not_down
+description: Issue #457's denominator fix RAISED the repo line rate (85.3514% -> 85.5355%), and the epic kickoff's stated 85.0317% baseline did not match measurement — verify the figure before #494 reasons from it
+metadata:
+  type: project
+---
+
+Issue #457 (epic `build-ci-coverage-gate-fidelity`, wave 1, merged as PR #542, merge commit `ee082ba1`) removed
+lambdas hoisted out of `[ExcludeFromCodeCoverage]` members from the Cobertura denominator. Two facts that are easy
+to get backwards:
+
+**1. The fix moved the repository rate UP, not down.** `lines-valid` 62873 -> 62401 and `lines-covered`
+53663 -> 53375, so `line-rate` went **0.853514 -> 0.855355**. The intuition that removing lines from a denominator
+must help is not automatic — the removed lambda lines included *covered* ones (`<>c__DisplayClass42_0` contributes
+two covered lines from the exempt member `DisposeProductionSurface`), so both numerator and denominator shrank. The
+direction was measured, not derived; a rate computed as `covered / (valid - N)` would have been wrong.
+
+**2. The epic kickoff's baseline figure did not match measurement.** The kickoff stated the corrected repo-wide rate
+sat at **85.0317%** against the 85% floor, a 0.03-point margin framed as the reason to be careful. The child's own
+`[P0-T11]` baseline capture on the same integration tip measured **85.3514%**. The child recorded the divergence as
+an observation and did not reconcile it, which was correct for its scope.
+
+**Why:** sibling feature #494 (`coverage-threshold-policy-reconciliation`, wave 2) is blocked on #457 specifically so
+it can decide thresholds against a corrected figure. If #494 reasons from the kickoff's 85.0317% it starts from a
+number no measurement reproduced.
+
+**How to apply:** when #494 (or any threshold work) runs, re-measure rather than inheriting a quoted figure, and
+reconcile the 85.0317% / 85.3514% divergence explicitly. Note also the two live measurement caveats: the PowerShell
+branch floor is unmeasurable because Pester 5.6.1 emits no branch counter, and `artifacts/pester/powershell-coverage.xml`
+reports zero covered lines repo-wide (open issue #536). See [[csharp-coverage-denominator-two-figures]] and
+[[feature-review-coverage-85-floor-trap]].


### PR DESCRIPTION
## Summary

Follow-up to #542 (merged). Records two orchestrator lessons from the #457 child run as agent memory. No production code, tests, feature documents, or evidence artifacts are touched — the entire feature landed in #542.

## Lessons recorded

**The Bash tool refuses compound commands it cannot statically prove stay inside an isolated agent worktree.** The refusal message is about static verifiability, not an actual escape; every path in the rejected command was relative and in-worktree. It matters because the shape it rejects — shell variables, a `{ ... }` group of `git diff`/`git log` calls, a pipe, and a redirect into a file — is exactly how you would synthesize `artifacts/pr_context.summary.txt` by hand, which is a step the PR gate requires whenever `collect_pr_context` leaves a stale file. The remedy is to gather with one plain chained read-only command and author the file with the `Write` tool.

**#457's denominator fix raised the repository line rate rather than lowering it.** `lines-valid` fell 62873 → 62401 and `lines-covered` fell 53663 → 53375, giving a line rate of 0.853514 → 0.855355. The removed lambda lines included covered ones, so both numerator and denominator shrank; the direction was measured, not derived. The memory also flags that the epic kickoff quoted an 85.0317% baseline where measurement on the same integration tip gave 85.3514%. Sibling #494 is blocked on this feature specifically so it can set thresholds against a corrected figure, so it should re-measure rather than inherit either number.

## Base branch

Targets `epic/build-ci-coverage-gate-fidelity-integration`, not `main`. `.github/workflows/ci.yml` triggers `pull_request` only on `main` and `development`, so no workflow runs against this PR by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
