### PR TITLE
upgrade all nuget packages that can be updated

### DIFF
--- a/QuickFiler.Test/QuickFiler.Test.csproj
+++ b/QuickFiler.Test/QuickFiler.Test.csproj
@@ -471,11 +471,11 @@
   <Import Project="..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets')" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
-    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
+    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
     <Analyzer Include="..\packages\AsyncFixer.2.1.0\analyzers\dotnet\cs\AsyncFixer.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />

--- a/QuickFiler.Test/QuickFiler.Test.csproj
+++ b/QuickFiler.Test/QuickFiler.Test.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" />
+  <Import Project="..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" />
   <Import Project="..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props')" />
   <Import Project="..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props" Condition="Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.props" Condition="Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.props')" />
@@ -186,8 +186,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Azure.Core, Version=1.60.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Azure.Core.1.60.0\lib\net472\Azure.Core.dll</HintPath>
+    <Reference Include="Azure.Core, Version=1.61.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Core.1.61.0\lib\net472\Azure.Core.dll</HintPath>
     </Reference>
     <Reference Include="Azure.Monitor.OpenTelemetry.Exporter, Version=1.8.3.0, Culture=neutral, PublicKeyToken=92742159e12e44c8">
       <HintPath>..\packages\Azure.Monitor.OpenTelemetry.Exporter.1.8.3\lib\netstandard2.0\Azure.Monitor.OpenTelemetry.Exporter.dll</HintPath>
@@ -208,61 +208,60 @@
     <Reference Include="Microsoft.ApplicationInsights, Version=3.1.2.115, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.3.1.2\lib\net462\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.10\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.TimeProvider, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.TimeProvider.10.0.10\lib\net462\Microsoft.Bcl.TimeProvider.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.TimeProvider, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.TimeProvider.10.0.11\lib\net462\Microsoft.Bcl.TimeProvider.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.10\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.11\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.10\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.11\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.10\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.11\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.10\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.11\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.10\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.11\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.TimeProvider.Testing, Version=10.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.TimeProvider.Testing.10.8.0\lib\net462\Microsoft.Extensions.TimeProvider.Testing.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.TimeProvider.Testing, Version=10.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.TimeProvider.Testing.10.9.0\lib\net462\Microsoft.Extensions.TimeProvider.Testing.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Identity.Client, Version=4.87.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae">
       <HintPath>..\packages\Microsoft.Identity.Client.4.87.0\lib\net472\Microsoft.Identity.Client.dll</HintPath>
@@ -278,6 +277,18 @@
     </Reference>
     <Reference Include="Microsoft.Office.Interop.Outlook, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
       <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.TestPlatform.AdapterUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.18.9.0\lib\net462\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.TestPlatform.PlatformAbstractions, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.WebView2.Core, Version=1.0.4129.50, Culture=neutral, PublicKeyToken=2a8ab48044d2601e, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.WebView2.1.0.4129.50\lib\net462\Microsoft.Web.WebView2.Core.dll</HintPath>
@@ -302,18 +313,6 @@
     </Reference>
     <Reference Include="Microsoft.Testing.Platform, Version=2.3.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Testing.Platform.2.3.3\lib\netstandard2.0\Microsoft.Testing.Platform.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.TestPlatform.AdapterUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.18.8.1\lib\net462\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.TestPlatform.PlatformAbstractions, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.20.72.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.20.72\lib\net462\Moq.dll</HintPath>
@@ -350,44 +349,48 @@
     <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.ClientModel, Version=1.14.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ClientModel.1.14.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
+    <Reference Include="System.ClientModel, Version=1.15.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ClientModel.1.15.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.10.0.10\lib\net462\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.10.0.11\lib\net462\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.10\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.11\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Drawing.Design" />
-    <Reference Include="System.Formats.Asn1, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Formats.Asn1.10.0.10\lib\net462\System.Formats.Asn1.dll</HintPath>
+    <Reference Include="System.Formats.Asn1, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Formats.Asn1.10.0.11\lib\net462\System.Formats.Asn1.dll</HintPath>
     </Reference>
     <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IO" />
     <Reference Include="System.IO.FileSystem.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.FileSystem.AccessControl.5.0.0\lib\net461\System.IO.FileSystem.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Pipelines, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Pipelines.10.0.10\lib\net462\System.IO.Pipelines.dll</HintPath>
+    <Reference Include="System.IO.Pipelines, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.10.0.11\lib\net462\System.IO.Pipelines.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="System.Memory.Data, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.Data.10.0.10\lib\net462\System.Memory.Data.dll</HintPath>
+    <Reference Include="System.Memory.Data, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.Data.10.0.11\lib\net462\System.Memory.Data.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.ServerSentEvents, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.ServerSentEvents.10.0.11\lib\net462\System.Net.ServerSentEvents.dll</HintPath>
+    </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.6.1\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.10.0.10\lib\net462\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.10.0.11\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -398,17 +401,17 @@
     <Reference Include="System.Security.AccessControl, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.AccessControl.6.0.1\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.10\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.11\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.10.0.10\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.10.0.11\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.10.0.10\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.10.0.11\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.3\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
@@ -441,6 +444,7 @@
   <ItemGroup>
     <Analyzer Include="..\packages\MSTest.Analyzers.4.3.3\analyzers\dotnet\cs\MSTest.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\MSTest.Analyzers.4.3.3\analyzers\dotnet\cs\MSTest.Analyzers.dll" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.32.0.713\analyzers\SonarAnalyzer.CSharp.dll" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -458,7 +462,7 @@
     <Error Condition="!Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets'))" />
-    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props'))" />
   </Target>
   <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.2.3.3\build\netstandard2.0\Microsoft.Testing.Platform.targets" Condition="Exists('..\packages\Microsoft.Testing.Platform.2.3.3\build\netstandard2.0\Microsoft.Testing.Platform.targets')" />
@@ -468,7 +472,6 @@
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
     <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.31.0.145097\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />

--- a/QuickFiler.Test/app.config
+++ b/QuickFiler.Test/app.config
@@ -3,23 +3,43 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Tasks.Extensions"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Buffers"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Runtime.CompilerServices.Unsafe"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Channels"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -31,11 +51,19 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Collections.Immutable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.AsyncInterfaces"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -51,31 +79,59 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <assemblyIdentity
+          name="Newtonsoft.Json"
+          publicKeyToken="30ad4fe6b2a6aeed"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Graph.Core"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Diagnostics.DiagnosticSource"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Json"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encodings.Web"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -83,215 +139,427 @@
         <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory.Data"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Vectors"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encoding.CodePages"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="System.ClientModel"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.Http.WinHttpHandler"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="System.IdentityModel.Tokens.Jwt"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.JsonWebTokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Logging"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Tokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Validators"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Text"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Form"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Multipart"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.TimeProvider"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Tensors"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reflection.Metadata"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Json"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Authentication.Azure"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.ApplicationInsights"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Http.HttpClientLibrary"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
+        <assemblyIdentity
+          name="Std.UriTemplate"
+          publicKeyToken="c118b0afb4598f9a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.HashCode"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Numerics"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Options"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Diagnostics.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Hosting.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Binder"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Formats.Asn1"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reactive"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Primitives"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Linq.AsyncEnumerable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.Abstractions"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.FileSystem"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client.Extensions.Msal"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.Cryptography.ProtectedData"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.AccessControl"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="Azure.Monitor.OpenTelemetry.Exporter"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Cryptography"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Web.WebView2.Core" publicKeyToken="2a8ab48044d2601e" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Web.WebView2.Core"
+          publicKeyToken="2a8ab48044d2601e"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.0.4078.44" newVersion="1.0.4078.44" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.ServerSentEvents"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>

--- a/QuickFiler.Test/app.config
+++ b/QuickFiler.Test/app.config
@@ -3,44 +3,24 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Tasks.Extensions"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Buffers"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Runtime.CompilerServices.Unsafe"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Channels"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -51,20 +31,12 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Collections.Immutable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.AsyncInterfaces"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="ExCSS" publicKeyToken="bdbe16be9b936b9a" culture="neutral" />
@@ -79,480 +51,248 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Newtonsoft.Json"
-          publicKeyToken="30ad4fe6b2a6aeed"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Graph.Core"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Diagnostics.DiagnosticSource"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Json"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encodings.Web"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.60.0.0" newVersion="1.60.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory.Data"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Vectors"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encoding.CodePages"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.ClientModel"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Net.Http.WinHttpHandler"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.IdentityModel.Tokens.Jwt"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.JsonWebTokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Logging"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Tokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Validators"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Text"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Form"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Multipart"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.TimeProvider"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Tensors"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reflection.Metadata"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Json"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Authentication.Azure"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.ApplicationInsights"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Http.HttpClientLibrary"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Std.UriTemplate"
-          publicKeyToken="c118b0afb4598f9a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.HashCode"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Numerics"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Options"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Diagnostics.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Configuration"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Hosting.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Binder"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Formats.Asn1"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reactive"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Primitives"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Linq.AsyncEnumerable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="OpenTelemetry.PersistentStorage.Abstractions"
-          publicKeyToken="7bd6737fe5b67e3c"
-          culture="neutral"
-        />
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="OpenTelemetry.PersistentStorage.FileSystem"
-          publicKeyToken="7bd6737fe5b67e3c"
-          culture="neutral"
-        />
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client.Extensions.Msal"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.Cryptography.ProtectedData"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.AccessControl"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Azure.Monitor.OpenTelemetry.Exporter"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Cryptography"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Web.WebView2.Core"
-          publicKeyToken="2a8ab48044d2601e"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Web.WebView2.Core" publicKeyToken="2a8ab48044d2601e" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.0.4078.44" newVersion="1.0.4078.44" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/QuickFiler.Test/packages.config
+++ b/QuickFiler.Test/packages.config
@@ -7,49 +7,146 @@
   <package id="Deedle" version="3.0.0" targetFramework="net481" />
   <package id="FluentAssertions" version="8.10.0" targetFramework="net481" />
   <package id="FSharp.Core" version="11.0.100" targetFramework="net481" />
-  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Meziantou.Analyzer"
+    version="3.0.156"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Bcl.TimeProvider" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
+    version="5.6.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Configuration.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.Binder"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Diagnostics.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.FileProviders.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Hosting.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Logging.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Logging.Configuration"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Options.ConfigurationExtensions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.TimeProvider.Testing" version="10.9.0" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.TimeProvider.Testing"
+    version="10.9.0"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
+  <package
+    id="Microsoft.Identity.Client.Extensions.Msal"
+    version="4.87.0"
+    targetFramework="net481"
+  />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
+  <package
+    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
+    version="2.3.3"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Testing.Extensions.VSTestBridge"
+    version="2.3.3"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.9.0" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
   <package id="Moq" version="4.20.72" targetFramework="net481" />
-  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="MSTest.Analyzers"
+    version="4.3.3"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
+  <package
+    id="OpenTelemetry.Api.ProviderBuilderExtensions"
+    version="1.17.0"
+    targetFramework="net481"
+  />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
-  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
-  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="OpenTelemetry.PersistentStorage.Abstractions"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="OpenTelemetry.PersistentStorage.FileSystem"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="Roslynator.Analyzers"
+    version="4.16.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="SonarAnalyzer.CSharp"
+    version="10.32.0.713"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
   <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
   <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
@@ -64,7 +161,11 @@
   <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
+  <package
+    id="System.Security.Cryptography.ProtectedData"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
   <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
   <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />

--- a/QuickFiler.Test/packages.config
+++ b/QuickFiler.Test/packages.config
@@ -1,173 +1,73 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
-  <package id="Azure.Core" version="1.60.0" targetFramework="net481" />
+  <package id="Azure.Core" version="1.61.0" targetFramework="net481" />
   <package id="Azure.Monitor.OpenTelemetry.Exporter" version="1.8.3" targetFramework="net481" />
   <package id="Castle.Core" version="5.2.1" targetFramework="net481" />
   <package id="Deedle" version="3.0.0" targetFramework="net481" />
   <package id="FluentAssertions" version="8.10.0" targetFramework="net481" />
   <package id="FSharp.Core" version="11.0.100" targetFramework="net481" />
-  <package
-    id="Meziantou.Analyzer"
-    version="3.0.138"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.10" targetFramework="net481" />
-  <package id="Microsoft.Bcl.TimeProvider" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
-    version="5.6.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package id="Microsoft.Extensions.Configuration" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Configuration.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.Binder"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Diagnostics.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.FileProviders.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Hosting.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Logging" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Logging.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Logging.Configuration"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Options" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Options.ConfigurationExtensions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Primitives" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.TimeProvider.Testing"
-    version="10.8.0"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Bcl.TimeProvider" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.TimeProvider.Testing" version="10.9.0" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package
-    id="Microsoft.Identity.Client.Extensions.Msal"
-    version="4.87.0"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package
-    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
-    version="2.3.3"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Testing.Extensions.VSTestBridge"
-    version="2.3.3"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
+  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.8.1" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="18.8.1" targetFramework="net481" />
+  <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.9.0" targetFramework="net481" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
   <package id="Moq" version="4.20.72" targetFramework="net481" />
-  <package
-    id="MSTest.Analyzers"
-    version="4.3.3"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.Api.ProviderBuilderExtensions"
-    version="1.17.0"
-    targetFramework="net481"
-  />
+  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.PersistentStorage.Abstractions"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="OpenTelemetry.PersistentStorage.FileSystem"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="Roslynator.Analyzers"
-    version="4.15.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="SonarAnalyzer.CSharp"
-    version="10.31.0.145097"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
+  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
+  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
-  <package id="System.ClientModel" version="1.14.0" targetFramework="net481" />
-  <package id="System.Collections.Immutable" version="10.0.10" targetFramework="net481" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.10" targetFramework="net481" />
-  <package id="System.Formats.Asn1" version="10.0.10" targetFramework="net481" />
+  <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
+  <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.11" targetFramework="net481" />
+  <package id="System.Formats.Asn1" version="10.0.11" targetFramework="net481" />
   <package id="System.IO.FileSystem.AccessControl" version="5.0.0" targetFramework="net481" />
-  <package id="System.IO.Pipelines" version="10.0.10" targetFramework="net481" />
+  <package id="System.IO.Pipelines" version="10.0.11" targetFramework="net481" />
   <package id="System.Memory" version="4.6.3" targetFramework="net481" />
-  <package id="System.Memory.Data" version="10.0.10" targetFramework="net481" />
+  <package id="System.Memory.Data" version="10.0.11" targetFramework="net481" />
+  <package id="System.Net.ServerSentEvents" version="10.0.11" targetFramework="net481" />
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net481" />
-  <package id="System.Reflection.Metadata" version="10.0.10" targetFramework="net481" />
+  <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package
-    id="System.Security.Cryptography.ProtectedData"
-    version="10.0.10"
-    targetFramework="net481"
-  />
+  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
-  <package id="System.Text.Encodings.Web" version="10.0.10" targetFramework="net481" />
-  <package id="System.Text.Json" version="10.0.10" targetFramework="net481" />
+  <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
+  <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net481" />
   <package id="System.ValueTuple" version="4.6.2" targetFramework="net481" />
 </packages>

--- a/QuickFiler/QuickFiler.csproj
+++ b/QuickFiler/QuickFiler.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" />
+  <Import Project="..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -57,16 +57,14 @@
     <Reference Include="log4net.Ext.Json, Version=3.0.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.Ext.Json.3.0.3\lib\net462\log4net.Ext.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.10\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.Memory, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\Microsoft.Bcl.Memory.10.0.10\lib\net462\Microsoft.Bcl.Memory.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Bcl.Memory, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Memory.10.0.11\lib\net462\Microsoft.Bcl.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.TimeProvider, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.TimeProvider.10.0.10\lib\net462\Microsoft.Bcl.TimeProvider.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.TimeProvider, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.TimeProvider.10.0.11\lib\net462\Microsoft.Bcl.TimeProvider.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Analysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.Analysis.0.23.0\lib\netstandard2.0\Microsoft.Data.Analysis.dll</HintPath>
@@ -113,8 +111,8 @@
     <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.10.0.10\lib\net462\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.10.0.11\lib\net462\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
@@ -130,8 +128,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Design" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.10\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.11\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Diagnostics.Tracing, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Diagnostics.Tracing.4.3.0\lib\net462\System.Diagnostics.Tracing.dll</HintPath>
@@ -574,15 +572,14 @@
     <Error Condition="!Exists('..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets'))" />
     <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets'))" />
     <Error Condition="!Exists('..\packages\System.Reactive.7.0.0\build\System.Reactive.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Reactive.7.0.0\build\System.Reactive.targets'))" />
-    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.4129.50\build\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.4129.50\build\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props'))" />
   </Target>
   <Import Project="..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets" Condition="Exists('..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" />
   <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
     <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.31.0.145097\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
@@ -591,6 +588,7 @@
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\BannedSymbols.txt" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.32.0.713\analyzers\SonarAnalyzer.CSharp.dll" />
   </ItemGroup>
   <Import Project="..\packages\System.Reactive.7.0.0\build\System.Reactive.targets" Condition="Exists('..\packages\System.Reactive.7.0.0\build\System.Reactive.targets')" />
   <Import Project="..\packages\Microsoft.Web.WebView2.1.0.4129.50\build\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.4129.50\build\Microsoft.Web.WebView2.targets')" />

--- a/QuickFiler/QuickFiler.csproj
+++ b/QuickFiler/QuickFiler.csproj
@@ -579,11 +579,11 @@
   <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
-    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
+    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
     <Analyzer Include="..\packages\AsyncFixer.2.1.0\analyzers\dotnet\cs\AsyncFixer.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />

--- a/QuickFiler/app.config
+++ b/QuickFiler/app.config
@@ -3,27 +3,51 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Runtime.CompilerServices.Unsafe"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Buffers"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Tasks.Extensions"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Vectors"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Channels"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -35,11 +59,19 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Collections.Immutable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.AsyncInterfaces"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -55,31 +87,59 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <assemblyIdentity
+          name="Newtonsoft.Json"
+          publicKeyToken="30ad4fe6b2a6aeed"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Graph.Core"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Diagnostics.DiagnosticSource"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Json"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encodings.Web"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -87,147 +147,291 @@
         <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory.Data"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encoding.CodePages"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="System.ClientModel"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.Http.WinHttpHandler"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="System.IdentityModel.Tokens.Jwt"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Tokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Validators"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Text"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Form"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Multipart"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.TimeProvider"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Tensors"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Json"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Authentication.Azure"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Http.HttpClientLibrary"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
+        <assemblyIdentity
+          name="Std.UriTemplate"
+          publicKeyToken="c118b0afb4598f9a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.HashCode"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Numerics"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Formats.Asn1"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Hosting.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Diagnostics.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Primitives"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reactive"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Linq.AsyncEnumerable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client.Extensions.Msal"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.Cryptography.ProtectedData"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.AccessControl"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Cryptography"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -235,7 +439,11 @@
         <bindingRedirect oldVersion="0.0.0.0-3.4.0.0" newVersion="3.4.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.ServerSentEvents"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>

--- a/QuickFiler/app.config
+++ b/QuickFiler/app.config
@@ -3,52 +3,28 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Runtime.CompilerServices.Unsafe"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Buffers"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Tasks.Extensions"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Vectors"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Channels"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -59,20 +35,12 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Collections.Immutable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.AsyncInterfaces"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="ExCSS" publicKeyToken="bdbe16be9b936b9a" culture="neutral" />
@@ -87,356 +55,188 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Newtonsoft.Json"
-          publicKeyToken="30ad4fe6b2a6aeed"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Graph.Core"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Diagnostics.DiagnosticSource"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Json"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encodings.Web"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.60.0.0" newVersion="1.60.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory.Data"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encoding.CodePages"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.ClientModel"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Net.Http.WinHttpHandler"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.IdentityModel.Tokens.Jwt"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Tokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Validators"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Text"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Form"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Multipart"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.TimeProvider"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Tensors"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Json"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Authentication.Azure"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Http.HttpClientLibrary"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="Std.UriTemplate"
-          publicKeyToken="c118b0afb4598f9a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.HashCode"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Numerics"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Formats.Asn1"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Hosting.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Diagnostics.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Primitives"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reactive"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Linq.AsyncEnumerable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client.Extensions.Msal"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.Cryptography.ProtectedData"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.AccessControl"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Cryptography"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Svg" publicKeyToken="12a0bac221edeae2" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.4.0.0" newVersion="3.4.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/QuickFiler/packages.config
+++ b/QuickFiler/packages.config
@@ -8,11 +8,21 @@
   <package id="FSharp.Core" version="11.0.100" targetFramework="net481" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
   <package id="log4net.Ext.Json" version="3.0.3" targetFramework="net481" />
-  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Meziantou.Analyzer"
+    version="3.0.156"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Bcl.Memory" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Bcl.TimeProvider" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
+    version="5.6.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.Data.Analysis" version="0.23.0" targetFramework="net481" />
   <package id="Microsoft.ML.DataView" version="5.0.0" targetFramework="net481" />
   <package id="Microsoft.NETCore.Platforms" version="7.0.4" targetFramework="net481" />
@@ -20,8 +30,18 @@
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net481" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net481" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net481" />
-  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
-  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Roslynator.Analyzers"
+    version="4.16.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="SonarAnalyzer.CSharp"
+    version="10.32.0.713"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Svg" version="3.4.8" targetFramework="net481" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net481" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
@@ -63,12 +83,20 @@
   <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="net481" />
   <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net481" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net481" />
-  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net481" />
+  <package
+    id="System.Runtime.InteropServices.RuntimeInformation"
+    version="4.3.0"
+    targetFramework="net481"
+  />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net481" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net481" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net481" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net481" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net481" />
+  <package
+    id="System.Security.Cryptography.X509Certificates"
+    version="4.3.2"
+    targetFramework="net481"
+  />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net481" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net481" />
   <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="net481" />

--- a/QuickFiler/packages.config
+++ b/QuickFiler/packages.config
@@ -8,21 +8,11 @@
   <package id="FSharp.Core" version="11.0.100" targetFramework="net481" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
   <package id="log4net.Ext.Json" version="3.0.3" targetFramework="net481" />
-  <package
-    id="Meziantou.Analyzer"
-    version="3.0.138"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.10" targetFramework="net481" />
-  <package id="Microsoft.Bcl.Memory" version="10.0.10" targetFramework="net481" />
-  <package id="Microsoft.Bcl.TimeProvider" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
-    version="5.6.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Bcl.Memory" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Bcl.TimeProvider" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
   <package id="Microsoft.Data.Analysis" version="0.23.0" targetFramework="net481" />
   <package id="Microsoft.ML.DataView" version="5.0.0" targetFramework="net481" />
   <package id="Microsoft.NETCore.Platforms" version="7.0.4" targetFramework="net481" />
@@ -30,28 +20,18 @@
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net481" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net481" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net481" />
-  <package
-    id="Roslynator.Analyzers"
-    version="4.15.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="SonarAnalyzer.CSharp"
-    version="10.31.0.145097"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
   <package id="Svg" version="3.4.8" targetFramework="net481" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net481" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
   <package id="System.Collections" version="4.3.0" targetFramework="net481" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net481" />
-  <package id="System.Collections.Immutable" version="10.0.10" targetFramework="net481" />
+  <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
   <package id="System.Console" version="4.3.1" targetFramework="net481" />
   <package id="System.Data.Common" version="4.3.0" targetFramework="net481" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net481" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.10" targetFramework="net481" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.11" targetFramework="net481" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net481" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net481" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net481" />
@@ -83,20 +63,12 @@
   <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="net481" />
   <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net481" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net481" />
-  <package
-    id="System.Runtime.InteropServices.RuntimeInformation"
-    version="4.3.0"
-    targetFramework="net481"
-  />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net481" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net481" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net481" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net481" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net481" />
-  <package
-    id="System.Security.Cryptography.X509Certificates"
-    version="4.3.2"
-    targetFramework="net481"
-  />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net481" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net481" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net481" />
   <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="net481" />

--- a/SVGControl.Test/SVGControl.Test.csproj
+++ b/SVGControl.Test/SVGControl.Test.csproj
@@ -115,9 +115,8 @@
     <None Include="Resources\OpenFolder.png" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Azure.Core, Version=1.60.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8">
-      <HintPath>..\packages\Azure.Core.1.60.0\lib\net472\Azure.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Azure.Core, Version=1.61.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Core.1.61.0\lib\net472\Azure.Core.dll</HintPath>
     </Reference>
     <Reference Include="Azure.Monitor.OpenTelemetry.Exporter, Version=1.8.3.0, Culture=neutral, PublicKeyToken=92742159e12e44c8">
       <HintPath>..\packages\Azure.Monitor.OpenTelemetry.Exporter.1.8.3\lib\netstandard2.0\Azure.Monitor.OpenTelemetry.Exporter.dll</HintPath>
@@ -139,69 +138,54 @@
       <HintPath>..\packages\Microsoft.ApplicationInsights.3.1.2\lib\net462\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.10\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.10\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.11\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.10\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.11\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.10\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.11\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.10\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.11\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.10\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.11\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Identity.Client, Version=4.87.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae">
       <HintPath>..\packages\Microsoft.Identity.Client.4.87.0\lib\net472\Microsoft.Identity.Client.dll</HintPath>
@@ -235,17 +219,14 @@
       <HintPath>..\packages\Microsoft.Testing.Platform.2.3.3\lib\netstandard2.0\Microsoft.Testing.Platform.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.TestPlatform.PlatformAbstractions, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.TestPlatform.PlatformAbstractions, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.20.72.0, Culture=neutral, PublicKeyToken=69f491c39445e920">
       <HintPath>..\packages\Moq.4.20.72\lib\net462\Moq.dll</HintPath>
@@ -292,74 +273,73 @@
       <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.ClientModel, Version=1.14.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8">
-      <HintPath>..\packages\System.ClientModel.1.14.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.ClientModel, Version=1.15.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ClientModel.1.15.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\System.Collections.Immutable.10.0.10\lib\net462\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.10.0.11\lib\net462\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.10\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.11\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Drawing.Design" />
-    <Reference Include="System.Formats.Asn1, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\System.Formats.Asn1.10.0.10\lib\net462\System.Formats.Asn1.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Formats.Asn1, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Formats.Asn1.10.0.11\lib\net462\System.Formats.Asn1.dll</HintPath>
     </Reference>
+    <Reference Include="System.IO" />
     <Reference Include="System.IO.FileSystem.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\System.IO.FileSystem.AccessControl.5.0.0\lib\net461\System.IO.FileSystem.AccessControl.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Pipelines, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\System.IO.Pipelines.10.0.10\lib\net462\System.IO.Pipelines.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.IO.Pipelines, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.10.0.11\lib\net462\System.IO.Pipelines.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
       <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Memory.Data, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\System.Memory.Data.10.0.10\lib\net462\System.Memory.Data.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Memory.Data, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.Data.10.0.11\lib\net462\System.Memory.Data.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.ServerSentEvents, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.ServerSentEvents.10.0.11\lib\net462\System.Net.ServerSentEvents.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\System.Numerics.Vectors.4.6.1\lib\net462\System.Numerics.Vectors.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\System.Reflection.Metadata.10.0.10\lib\net462\System.Reflection.Metadata.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Reflection.Metadata, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.10.0.11\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security" />
     <Reference Include="System.Security.AccessControl, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\System.Security.AccessControl.6.0.1\lib\net461\System.Security.AccessControl.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.10\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.11\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\System.Text.Encodings.Web.10.0.10\lib\net462\System.Text.Encodings.Web.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.10.0.11\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\System.Text.Json.10.0.10\lib\net462\System.Text.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Text.Json, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.10.0.11\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.3\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/SVGControl.Test/app.config
+++ b/SVGControl.Test/app.config
@@ -3,11 +3,19 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Tasks.Extensions"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -19,7 +27,11 @@
         <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Runtime.CompilerServices.Unsafe"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -27,7 +39,11 @@
         <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="FluentAssertions" publicKeyToken="33f2691a05b67b6a" culture="neutral" />
+        <assemblyIdentity
+          name="FluentAssertions"
+          publicKeyToken="33f2691a05b67b6a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.10.0.0" newVersion="8.10.0.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -35,23 +51,43 @@
         <bindingRedirect oldVersion="0.0.0.0-4.20.72.0" newVersion="4.20.72.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="MSTest.TestFramework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="MSTest.TestFramework"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.3.3.0" newVersion="4.3.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="MSTest.TestFramework.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="MSTest.TestFramework.Extensions"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.3.3.0" newVersion="4.3.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="System.ClientModel"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Binder"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -59,119 +95,235 @@
         <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Json"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.AsyncInterfaces"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory.Data"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Diagnostics.DiagnosticSource"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Options"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Hosting.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.Abstractions"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.FileSystem"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Buffers"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="Azure.Monitor.OpenTelemetry.Exporter"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Formats.Asn1"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encodings.Web"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.Cryptography.ProtectedData"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.AccessControl"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.ApplicationInsights"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Diagnostics.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reflection.Metadata"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.ServerSentEvents"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Primitives"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client.Extensions.Msal"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
     </assemblyBinding>

--- a/SVGControl.Test/app.config
+++ b/SVGControl.Test/app.config
@@ -3,19 +3,11 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Tasks.Extensions"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -27,11 +19,7 @@
         <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Runtime.CompilerServices.Unsafe"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -39,11 +27,7 @@
         <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="FluentAssertions"
-          publicKeyToken="33f2691a05b67b6a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="FluentAssertions" publicKeyToken="33f2691a05b67b6a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.10.0.0" newVersion="8.10.0.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -51,20 +35,144 @@
         <bindingRedirect oldVersion="0.0.0.0-4.20.72.0" newVersion="4.20.72.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="MSTest.TestFramework"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="MSTest.TestFramework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.3.3.0" newVersion="4.3.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="MSTest.TestFramework.Extensions"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="MSTest.TestFramework.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.3.3.0" newVersion="4.3.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/SVGControl.Test/packages.config
+++ b/SVGControl.Test/packages.config
@@ -8,39 +8,112 @@
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Configuration.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.Binder"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Diagnostics.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.FileProviders.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Hosting.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Logging.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Logging.Configuration"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Options.ConfigurationExtensions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
+  <package
+    id="Microsoft.Identity.Client.Extensions.Msal"
+    version="4.87.0"
+    targetFramework="net481"
+  />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
+  <package
+    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
+    version="2.3.3"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Testing.Extensions.VSTestBridge"
+    version="2.3.3"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
   <package id="Moq" version="4.20.72" targetFramework="net481" />
-  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="MSTest.Analyzers"
+    version="4.3.3"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
+  <package
+    id="OpenTelemetry.Api.ProviderBuilderExtensions"
+    version="1.17.0"
+    targetFramework="net481"
+  />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
+  <package
+    id="OpenTelemetry.PersistentStorage.Abstractions"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="OpenTelemetry.PersistentStorage.FileSystem"
+    version="1.1.1"
+    targetFramework="net481"
+  />
   <package id="Svg" version="3.4.8" targetFramework="net481" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
   <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
@@ -56,7 +129,11 @@
   <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
+  <package
+    id="System.Security.Cryptography.ProtectedData"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
   <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
   <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />

--- a/SVGControl.Test/packages.config
+++ b/SVGControl.Test/packages.config
@@ -1,141 +1,65 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Azure.Core" version="1.60.0" targetFramework="net481" />
+  <package id="Azure.Core" version="1.61.0" targetFramework="net481" />
   <package id="Azure.Monitor.OpenTelemetry.Exporter" version="1.8.3" targetFramework="net481" />
   <package id="Castle.Core" version="5.2.1" targetFramework="net481" />
   <package id="ExCSS" version="4.3.2" targetFramework="net481" />
   <package id="FluentAssertions" version="8.10.0" targetFramework="net481" />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.10" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Configuration.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.Binder"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Diagnostics.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.FileProviders.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Hosting.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Logging" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Logging.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Logging.Configuration"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Options" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Options.ConfigurationExtensions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Primitives" version="10.0.10" targetFramework="net481" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package
-    id="Microsoft.Identity.Client.Extensions.Msal"
-    version="4.87.0"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package
-    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
-    version="2.3.3"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Testing.Extensions.VSTestBridge"
-    version="2.3.3"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
+  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="18.8.1" targetFramework="net481" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
   <package id="Moq" version="4.20.72" targetFramework="net481" />
-  <package
-    id="MSTest.Analyzers"
-    version="4.3.3"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.Api.ProviderBuilderExtensions"
-    version="1.17.0"
-    targetFramework="net481"
-  />
+  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.PersistentStorage.Abstractions"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="OpenTelemetry.PersistentStorage.FileSystem"
-    version="1.1.1"
-    targetFramework="net481"
-  />
+  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
+  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
   <package id="Svg" version="3.4.8" targetFramework="net481" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
-  <package id="System.ClientModel" version="1.14.0" targetFramework="net481" />
-  <package id="System.Collections.Immutable" version="10.0.10" targetFramework="net481" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.10" targetFramework="net481" />
-  <package id="System.Formats.Asn1" version="10.0.10" targetFramework="net481" />
+  <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
+  <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.11" targetFramework="net481" />
+  <package id="System.Formats.Asn1" version="10.0.11" targetFramework="net481" />
   <package id="System.IO.FileSystem.AccessControl" version="5.0.0" targetFramework="net481" />
-  <package id="System.IO.Pipelines" version="10.0.10" targetFramework="net481" />
+  <package id="System.IO.Pipelines" version="10.0.11" targetFramework="net481" />
   <package id="System.Memory" version="4.6.3" targetFramework="net481" />
-  <package id="System.Memory.Data" version="10.0.10" targetFramework="net481" />
+  <package id="System.Memory.Data" version="10.0.11" targetFramework="net481" />
+  <package id="System.Net.ServerSentEvents" version="10.0.11" targetFramework="net481" />
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net481" />
-  <package id="System.Reflection.Metadata" version="10.0.10" targetFramework="net481" />
+  <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package
-    id="System.Security.Cryptography.ProtectedData"
-    version="10.0.10"
-    targetFramework="net481"
-  />
+  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
-  <package id="System.Text.Encodings.Web" version="10.0.10" targetFramework="net481" />
-  <package id="System.Text.Json" version="10.0.10" targetFramework="net481" />
+  <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
+  <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net481" />
   <package id="System.ValueTuple" version="4.6.2" targetFramework="net481" />
 </packages>

--- a/Tags.Test/Tags.Test.csproj
+++ b/Tags.Test/Tags.Test.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" />
+  <Import Project="..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" />
   <Import Project="..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props')" />
   <Import Project="..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props" Condition="Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.props" Condition="Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.props')" />
@@ -45,8 +45,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Azure.Core, Version=1.60.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Azure.Core.1.60.0\lib\net472\Azure.Core.dll</HintPath>
+    <Reference Include="Azure.Core, Version=1.61.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Core.1.61.0\lib\net472\Azure.Core.dll</HintPath>
     </Reference>
     <Reference Include="Azure.Monitor.OpenTelemetry.Exporter, Version=1.8.3.0, Culture=neutral, PublicKeyToken=92742159e12e44c8">
       <HintPath>..\packages\Azure.Monitor.OpenTelemetry.Exporter.1.8.3\lib\netstandard2.0\Azure.Monitor.OpenTelemetry.Exporter.dll</HintPath>
@@ -61,55 +61,54 @@
     <Reference Include="Microsoft.ApplicationInsights, Version=3.1.2.115, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.3.1.2\lib\net462\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.10\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.10\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.11\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.10\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.11\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.10\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.11\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.10\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.11\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.10\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.11\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Identity.Client, Version=4.87.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae">
       <HintPath>..\packages\Microsoft.Identity.Client.4.87.0\lib\net472\Microsoft.Identity.Client.dll</HintPath>
@@ -142,16 +141,16 @@
       <HintPath>..\packages\Microsoft.Testing.Platform.2.3.3\lib\netstandard2.0\Microsoft.Testing.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.AdapterUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.18.8.1\lib\net462\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.18.9.0\lib\net462\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.PlatformAbstractions, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.20.72.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.20.72\lib\net462\Moq.dll</HintPath>
@@ -184,44 +183,48 @@
     <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.ClientModel, Version=1.14.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ClientModel.1.14.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
+    <Reference Include="System.ClientModel, Version=1.15.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ClientModel.1.15.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.10.0.10\lib\net462\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.10.0.11\lib\net462\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.10\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.11\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Formats.Asn1, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Formats.Asn1.10.0.10\lib\net462\System.Formats.Asn1.dll</HintPath>
+    <Reference Include="System.Formats.Asn1, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Formats.Asn1.10.0.11\lib\net462\System.Formats.Asn1.dll</HintPath>
     </Reference>
     <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IO" />
     <Reference Include="System.IO.FileSystem.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.FileSystem.AccessControl.5.0.0\lib\net461\System.IO.FileSystem.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Pipelines, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Pipelines.10.0.10\lib\net462\System.IO.Pipelines.dll</HintPath>
+    <Reference Include="System.IO.Pipelines, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.10.0.11\lib\net462\System.IO.Pipelines.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="System.Memory.Data, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.Data.10.0.10\lib\net462\System.Memory.Data.dll</HintPath>
+    <Reference Include="System.Memory.Data, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.Data.10.0.11\lib\net462\System.Memory.Data.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.ServerSentEvents, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.ServerSentEvents.10.0.11\lib\net462\System.Net.ServerSentEvents.dll</HintPath>
+    </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.6.1\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.10.0.10\lib\net462\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.10.0.11\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -232,17 +235,17 @@
     <Reference Include="System.Security.AccessControl, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.AccessControl.6.0.1\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.10\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.11\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.10.0.10\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.10.0.11\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.10.0.10\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.10.0.11\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.3\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
@@ -282,6 +285,7 @@
   <ItemGroup>
     <Analyzer Include="..\packages\MSTest.Analyzers.4.3.3\analyzers\dotnet\cs\MSTest.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\MSTest.Analyzers.4.3.3\analyzers\dotnet\cs\MSTest.Analyzers.dll" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.32.0.713\analyzers\SonarAnalyzer.CSharp.dll" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -298,7 +302,7 @@
     <Error Condition="!Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets'))" />
-    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props'))" />
   </Target>
   <Import Project="..\packages\Microsoft.Testing.Platform.2.3.3\build\netstandard2.0\Microsoft.Testing.Platform.targets" Condition="Exists('..\packages\Microsoft.Testing.Platform.2.3.3\build\netstandard2.0\Microsoft.Testing.Platform.targets')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.targets" Condition="Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.targets')" />
@@ -308,7 +312,6 @@
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
     <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.31.0.145097\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />

--- a/Tags.Test/Tags.Test.csproj
+++ b/Tags.Test/Tags.Test.csproj
@@ -311,11 +311,11 @@
   <Import Project="..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets')" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
-    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
+    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
     <Analyzer Include="..\packages\AsyncFixer.2.1.0\analyzers\dotnet\cs\AsyncFixer.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />

--- a/Tags.Test/app.config
+++ b/Tags.Test/app.config
@@ -3,208 +3,108 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Tasks.Extensions"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Runtime.CompilerServices.Unsafe"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reflection.Metadata"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Diagnostics.DiagnosticSource"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Collections.Immutable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Buffers"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.ApplicationInsights"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Vectors"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.AsyncInterfaces"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Json"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Options"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Diagnostics.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Configuration"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Hosting.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Binder"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encodings.Web"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory.Data"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encoding.CodePages"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -215,300 +115,160 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Json"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Text"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Form"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Multipart"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Authentication.Azure"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.IdentityModel.Tokens.Jwt"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.JsonWebTokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Logging"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Tokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Http.HttpClientLibrary"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Net.Http.WinHttpHandler"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Validators"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Formats.Asn1"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.TimeProvider"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Tensors"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Channels"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="ExCSS" publicKeyToken="bdbe16be9b936b9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.3.2.0" newVersion="4.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reactive"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Graph.Core"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Primitives"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.ClientModel"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.60.0.0" newVersion="1.60.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="OpenTelemetry.PersistentStorage.Abstractions"
-          publicKeyToken="7bd6737fe5b67e3c"
-          culture="neutral"
-        />
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="OpenTelemetry.PersistentStorage.FileSystem"
-          publicKeyToken="7bd6737fe5b67e3c"
-          culture="neutral"
-        />
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Linq.AsyncEnumerable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client.Extensions.Msal"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.Cryptography.ProtectedData"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.AccessControl"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Azure.Monitor.OpenTelemetry.Exporter"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Std.UriTemplate"
-          publicKeyToken="c118b0afb4598f9a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Cryptography"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Tags.Test/app.config
+++ b/Tags.Test/app.config
@@ -3,99 +3,195 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Tasks.Extensions"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Runtime.CompilerServices.Unsafe"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reflection.Metadata"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Diagnostics.DiagnosticSource"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Collections.Immutable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Buffers"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.ApplicationInsights"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Vectors"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.AsyncInterfaces"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Json"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Options"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Diagnostics.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Hosting.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Binder"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encodings.Web"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory.Data"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -103,7 +199,11 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encoding.CodePages"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -115,83 +215,163 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Json"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Text"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Form"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Multipart"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Authentication.Azure"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="System.IdentityModel.Tokens.Jwt"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.JsonWebTokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Logging"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Tokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Http.HttpClientLibrary"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.Http.WinHttpHandler"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Validators"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Formats.Asn1"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.TimeProvider"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Tensors"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Channels"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -199,27 +379,51 @@
         <bindingRedirect oldVersion="0.0.0.0-4.3.2.0" newVersion="4.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reactive"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Graph.Core"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Primitives"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="System.ClientModel"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -227,47 +431,91 @@
         <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.Abstractions"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.FileSystem"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Linq.AsyncEnumerable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client.Extensions.Msal"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.Cryptography.ProtectedData"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.AccessControl"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="Azure.Monitor.OpenTelemetry.Exporter"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
+        <assemblyIdentity
+          name="Std.UriTemplate"
+          publicKeyToken="c118b0afb4598f9a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Cryptography"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.ServerSentEvents"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>

--- a/Tags.Test/packages.config
+++ b/Tags.Test/packages.config
@@ -5,47 +5,140 @@
   <package id="Azure.Monitor.OpenTelemetry.Exporter" version="1.8.3" targetFramework="net481" />
   <package id="Castle.Core" version="5.2.1" targetFramework="net481" />
   <package id="FluentAssertions" version="8.10.0" targetFramework="net481" />
-  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Meziantou.Analyzer"
+    version="3.0.156"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
+    version="5.6.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Configuration.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.Binder"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Diagnostics.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.FileProviders.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Hosting.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Logging.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Logging.Configuration"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Options.ConfigurationExtensions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
+  <package
+    id="Microsoft.Identity.Client.Extensions.Msal"
+    version="4.87.0"
+    targetFramework="net481"
+  />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
+  <package
+    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
+    version="2.3.3"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Testing.Extensions.VSTestBridge"
+    version="2.3.3"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.9.0" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
   <package id="Moq" version="4.20.72" targetFramework="net481" />
-  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="MSTest.Analyzers"
+    version="4.3.3"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
+  <package
+    id="OpenTelemetry.Api.ProviderBuilderExtensions"
+    version="1.17.0"
+    targetFramework="net481"
+  />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
-  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
-  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="OpenTelemetry.PersistentStorage.Abstractions"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="OpenTelemetry.PersistentStorage.FileSystem"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="Roslynator.Analyzers"
+    version="4.16.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="SonarAnalyzer.CSharp"
+    version="10.32.0.713"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
   <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
   <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
@@ -60,7 +153,11 @@
   <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
+  <package
+    id="System.Security.Cryptography.ProtectedData"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
   <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
   <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />

--- a/Tags.Test/packages.config
+++ b/Tags.Test/packages.config
@@ -1,165 +1,69 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
-  <package id="Azure.Core" version="1.60.0" targetFramework="net481" />
+  <package id="Azure.Core" version="1.61.0" targetFramework="net481" />
   <package id="Azure.Monitor.OpenTelemetry.Exporter" version="1.8.3" targetFramework="net481" />
   <package id="Castle.Core" version="5.2.1" targetFramework="net481" />
   <package id="FluentAssertions" version="8.10.0" targetFramework="net481" />
-  <package
-    id="Meziantou.Analyzer"
-    version="3.0.138"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
-    version="5.6.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package id="Microsoft.Extensions.Configuration" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Configuration.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.Binder"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Diagnostics.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.FileProviders.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Hosting.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Logging" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Logging.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Logging.Configuration"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Options" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Options.ConfigurationExtensions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Primitives" version="10.0.10" targetFramework="net481" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package
-    id="Microsoft.Identity.Client.Extensions.Msal"
-    version="4.87.0"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package
-    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
-    version="2.3.3"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Testing.Extensions.VSTestBridge"
-    version="2.3.3"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
+  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.8.1" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="18.8.1" targetFramework="net481" />
+  <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.9.0" targetFramework="net481" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
   <package id="Moq" version="4.20.72" targetFramework="net481" />
-  <package
-    id="MSTest.Analyzers"
-    version="4.3.3"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.Api.ProviderBuilderExtensions"
-    version="1.17.0"
-    targetFramework="net481"
-  />
+  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.PersistentStorage.Abstractions"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="OpenTelemetry.PersistentStorage.FileSystem"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="Roslynator.Analyzers"
-    version="4.15.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="SonarAnalyzer.CSharp"
-    version="10.31.0.145097"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
+  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
+  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
-  <package id="System.ClientModel" version="1.14.0" targetFramework="net481" />
-  <package id="System.Collections.Immutable" version="10.0.10" targetFramework="net481" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.10" targetFramework="net481" />
-  <package id="System.Formats.Asn1" version="10.0.10" targetFramework="net481" />
+  <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
+  <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.11" targetFramework="net481" />
+  <package id="System.Formats.Asn1" version="10.0.11" targetFramework="net481" />
   <package id="System.IO.FileSystem.AccessControl" version="5.0.0" targetFramework="net481" />
-  <package id="System.IO.Pipelines" version="10.0.10" targetFramework="net481" />
+  <package id="System.IO.Pipelines" version="10.0.11" targetFramework="net481" />
   <package id="System.Memory" version="4.6.3" targetFramework="net481" />
-  <package id="System.Memory.Data" version="10.0.10" targetFramework="net481" />
+  <package id="System.Memory.Data" version="10.0.11" targetFramework="net481" />
+  <package id="System.Net.ServerSentEvents" version="10.0.11" targetFramework="net481" />
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net481" />
-  <package id="System.Reflection.Metadata" version="10.0.10" targetFramework="net481" />
+  <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package
-    id="System.Security.Cryptography.ProtectedData"
-    version="10.0.10"
-    targetFramework="net481"
-  />
+  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
-  <package id="System.Text.Encodings.Web" version="10.0.10" targetFramework="net481" />
-  <package id="System.Text.Json" version="10.0.10" targetFramework="net481" />
+  <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
+  <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net481" />
   <package id="System.ValueTuple" version="4.6.2" targetFramework="net481" />
 </packages>

--- a/Tags/Tags.csproj
+++ b/Tags/Tags.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" />
+  <Import Project="..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -95,7 +95,6 @@
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
     <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.31.0.145097\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
@@ -104,11 +103,12 @@
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\BannedSymbols.txt" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.32.0.713\analyzers\SonarAnalyzer.CSharp.dll" />
   </ItemGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props'))" />
   </Target>
 </Project>

--- a/Tags/Tags.csproj
+++ b/Tags/Tags.csproj
@@ -94,11 +94,11 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
-    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
+    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
     <Analyzer Include="..\packages\AsyncFixer.2.1.0\analyzers\dotnet\cs\AsyncFixer.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />

--- a/Tags/app.config
+++ b/Tags/app.config
@@ -3,35 +3,19 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Buffers"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Tasks.Extensions"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Runtime.CompilerServices.Unsafe"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -43,28 +27,16 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Collections.Immutable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Channels"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.AsyncInterfaces"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="ExCSS" publicKeyToken="bdbe16be9b936b9a" culture="neutral" />
@@ -79,360 +51,188 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Newtonsoft.Json"
-          publicKeyToken="30ad4fe6b2a6aeed"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Graph.Core"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Diagnostics.DiagnosticSource"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Json"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encodings.Web"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.60.0.0" newVersion="1.60.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory.Data"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Vectors"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encoding.CodePages"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.ClientModel"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Net.Http.WinHttpHandler"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.IdentityModel.Tokens.Jwt"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Tokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Validators"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Text"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Form"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Multipart"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.TimeProvider"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Tensors"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Json"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Authentication.Azure"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Std.UriTemplate"
-          publicKeyToken="c118b0afb4598f9a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Http.HttpClientLibrary"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.HashCode"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Numerics"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reactive"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Formats.Asn1"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Hosting.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Diagnostics.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Primitives"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Linq.AsyncEnumerable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client.Extensions.Msal"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.Cryptography.ProtectedData"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.AccessControl"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Cryptography"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Tags/app.config
+++ b/Tags/app.config
@@ -3,19 +3,35 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Buffers"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Tasks.Extensions"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Runtime.CompilerServices.Unsafe"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -27,15 +43,27 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Collections.Immutable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Channels"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.AsyncInterfaces"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -51,31 +79,59 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <assemblyIdentity
+          name="Newtonsoft.Json"
+          publicKeyToken="30ad4fe6b2a6aeed"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Graph.Core"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Diagnostics.DiagnosticSource"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Json"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encodings.Web"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -83,155 +139,307 @@
         <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory.Data"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Vectors"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encoding.CodePages"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="System.ClientModel"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.Http.WinHttpHandler"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="System.IdentityModel.Tokens.Jwt"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Tokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Validators"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Text"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Form"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Multipart"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.TimeProvider"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Tensors"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Json"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Authentication.Azure"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
+        <assemblyIdentity
+          name="Std.UriTemplate"
+          publicKeyToken="c118b0afb4598f9a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Http.HttpClientLibrary"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.HashCode"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Numerics"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reactive"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Formats.Asn1"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Hosting.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Diagnostics.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Primitives"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Linq.AsyncEnumerable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client.Extensions.Msal"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.Cryptography.ProtectedData"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.AccessControl"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Cryptography"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.ServerSentEvents"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>

--- a/Tags/packages.config
+++ b/Tags/packages.config
@@ -3,8 +3,28 @@
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
   <package id="log4net.Ext.Json" version="3.0.3" targetFramework="net481" />
-  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
-  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
-  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
-  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Meziantou.Analyzer"
+    version="3.0.156"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
+    version="5.6.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="Roslynator.Analyzers"
+    version="4.16.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="SonarAnalyzer.CSharp"
+    version="10.32.0.713"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
 </packages>

--- a/Tags/packages.config
+++ b/Tags/packages.config
@@ -3,28 +3,8 @@
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
   <package id="log4net.Ext.Json" version="3.0.3" targetFramework="net481" />
-  <package
-    id="Meziantou.Analyzer"
-    version="3.0.138"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
-    version="5.6.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="Roslynator.Analyzers"
-    version="4.15.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="SonarAnalyzer.CSharp"
-    version="10.31.0.145097"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
 </packages>

--- a/TaskMaster.Test/TaskMaster.Test.csproj
+++ b/TaskMaster.Test/TaskMaster.Test.csproj
@@ -374,11 +374,11 @@
   <Import Project="..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets')" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
-    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
+    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
     <Analyzer Include="..\packages\AsyncFixer.2.1.0\analyzers\dotnet\cs\AsyncFixer.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />

--- a/TaskMaster.Test/TaskMaster.Test.csproj
+++ b/TaskMaster.Test/TaskMaster.Test.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" />
+  <Import Project="..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" />
   <Import Project="..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props')" />
   <Import Project="..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props" Condition="Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.props" Condition="Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.props')" />
@@ -46,8 +46,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Azure.Core, Version=1.60.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Azure.Core.1.60.0\lib\net472\Azure.Core.dll</HintPath>
+    <Reference Include="Azure.Core, Version=1.61.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Core.1.61.0\lib\net472\Azure.Core.dll</HintPath>
     </Reference>
     <Reference Include="Azure.Monitor.OpenTelemetry.Exporter, Version=1.8.3.0, Culture=neutral, PublicKeyToken=92742159e12e44c8">
       <HintPath>..\packages\Azure.Monitor.OpenTelemetry.Exporter.1.8.3\lib\netstandard2.0\Azure.Monitor.OpenTelemetry.Exporter.dll</HintPath>
@@ -68,57 +68,56 @@
     <Reference Include="Microsoft.ApplicationInsights, Version=3.1.2.115, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.3.1.2\lib\net462\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.10\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.10\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.11\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.10\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.11\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.10\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.11\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.10\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.11\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.10\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.11\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Identity.Client, Version=4.87.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae">
       <HintPath>..\packages\Microsoft.Identity.Client.4.87.0\lib\net472\Microsoft.Identity.Client.dll</HintPath>
@@ -151,16 +150,16 @@
       <HintPath>..\packages\Microsoft.Testing.Platform.2.3.3\lib\netstandard2.0\Microsoft.Testing.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.AdapterUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.18.8.1\lib\net462\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.18.9.0\lib\net462\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.PlatformAbstractions, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.20.72.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.20.72\lib\net462\Moq.dll</HintPath>
@@ -196,44 +195,48 @@
     <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.ClientModel, Version=1.14.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ClientModel.1.14.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
+    <Reference Include="System.ClientModel, Version=1.15.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ClientModel.1.15.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.10.0.10\lib\net462\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.10.0.11\lib\net462\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.10\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.11\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Formats.Asn1, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Formats.Asn1.10.0.10\lib\net462\System.Formats.Asn1.dll</HintPath>
+    <Reference Include="System.Formats.Asn1, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Formats.Asn1.10.0.11\lib\net462\System.Formats.Asn1.dll</HintPath>
     </Reference>
     <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IO" />
     <Reference Include="System.IO.FileSystem.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.FileSystem.AccessControl.5.0.0\lib\net461\System.IO.FileSystem.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Pipelines, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Pipelines.10.0.10\lib\net462\System.IO.Pipelines.dll</HintPath>
+    <Reference Include="System.IO.Pipelines, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.10.0.11\lib\net462\System.IO.Pipelines.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="System.Memory.Data, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.Data.10.0.10\lib\net462\System.Memory.Data.dll</HintPath>
+    <Reference Include="System.Memory.Data, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.Data.10.0.11\lib\net462\System.Memory.Data.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.ServerSentEvents, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.ServerSentEvents.10.0.11\lib\net462\System.Net.ServerSentEvents.dll</HintPath>
+    </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.6.1\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.10.0.10\lib\net462\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.10.0.11\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -244,17 +247,17 @@
     <Reference Include="System.Security.AccessControl, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.AccessControl.6.0.1\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.10\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.11\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.10.0.10\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.10.0.11\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.10.0.10\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.10.0.11\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.3\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
@@ -293,9 +296,9 @@
     <Compile Include="AppGlobals\AppEventsTests.Helpers.cs" />
     <Compile Include="AppGlobals\AppFileSystemFolderPathsMatchBestSpecialFolderTests.cs" />
     <Compile Include="AppGlobals\AppOlObjectsCoverageTests.cs" />
-      <Compile Include="AppGlobals\AppOlObjectsFolderTreeServiceTests.cs" />
-      <Compile Include="AppGlobals\AppOlObjectsFolderTreeServiceLifecycleTests.cs" />
-      <Compile Include="AppGlobals\AppOlObjectsFolderTreeServiceLifecycleTests.Coverage.cs" />
+    <Compile Include="AppGlobals\AppOlObjectsFolderTreeServiceTests.cs" />
+    <Compile Include="AppGlobals\AppOlObjectsFolderTreeServiceLifecycleTests.cs" />
+    <Compile Include="AppGlobals\AppOlObjectsFolderTreeServiceLifecycleTests.Coverage.cs" />
     <Compile Include="AppGlobals\AppOlObjectsTests.cs" />
     <Compile Include="AppGlobals\JunkFolderPathNavigatorTests.cs" />
     <Compile Include="AppGlobals\AppQuickFilerSettingsTests.cs" />
@@ -345,6 +348,7 @@
   <ItemGroup>
     <Analyzer Include="..\packages\MSTest.Analyzers.4.3.3\analyzers\dotnet\cs\MSTest.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\MSTest.Analyzers.4.3.3\analyzers\dotnet\cs\MSTest.Analyzers.dll" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.32.0.713\analyzers\SonarAnalyzer.CSharp.dll" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -361,7 +365,7 @@
     <Error Condition="!Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets'))" />
-    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props'))" />
   </Target>
   <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.2.3.3\build\netstandard2.0\Microsoft.Testing.Platform.targets" Condition="Exists('..\packages\Microsoft.Testing.Platform.2.3.3\build\netstandard2.0\Microsoft.Testing.Platform.targets')" />
@@ -371,7 +375,6 @@
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
     <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.31.0.145097\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />

--- a/TaskMaster.Test/app.config
+++ b/TaskMaster.Test/app.config
@@ -3,27 +3,15 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Tasks.Extensions"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Runtime.CompilerServices.Unsafe"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Buffers"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -31,11 +19,7 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -43,504 +27,264 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Collections.Immutable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.AsyncInterfaces"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Json"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Diagnostics.DiagnosticSource"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encodings.Web"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Channels"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Graph.Core"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Newtonsoft.Json"
-          publicKeyToken="30ad4fe6b2a6aeed"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.60.0.0" newVersion="1.60.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory.Data"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="ExCSS" publicKeyToken="bdbe16be9b936b9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.3.2.0" newVersion="4.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Vectors"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encoding.CodePages"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.ClientModel"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Net.Http.WinHttpHandler"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.IdentityModel.Tokens.Jwt"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.JsonWebTokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Logging"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Tokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Validators"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Text"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Form"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Multipart"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.TimeProvider"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Tensors"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reflection.Metadata"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Json"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Authentication.Azure"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.ApplicationInsights"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Http.HttpClientLibrary"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Std.UriTemplate"
-          publicKeyToken="c118b0afb4598f9a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.HashCode"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Numerics"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Options"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Diagnostics.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Configuration"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Hosting.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Binder"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Formats.Asn1"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reactive"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Primitives"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Linq.AsyncEnumerable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="OpenTelemetry.PersistentStorage.Abstractions"
-          publicKeyToken="7bd6737fe5b67e3c"
-          culture="neutral"
-        />
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="OpenTelemetry.PersistentStorage.FileSystem"
-          publicKeyToken="7bd6737fe5b67e3c"
-          culture="neutral"
-        />
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client.Extensions.Msal"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.Cryptography.ProtectedData"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.AccessControl"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Azure.Monitor.OpenTelemetry.Exporter"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Cryptography"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/TaskMaster.Test/app.config
+++ b/TaskMaster.Test/app.config
@@ -3,15 +3,27 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Tasks.Extensions"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Runtime.CompilerServices.Unsafe"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Buffers"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -19,7 +31,11 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -27,11 +43,19 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Collections.Immutable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.AsyncInterfaces"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -39,35 +63,67 @@
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Json"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Diagnostics.DiagnosticSource"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encodings.Web"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Channels"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Graph.Core"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <assemblyIdentity
+          name="Newtonsoft.Json"
+          publicKeyToken="30ad4fe6b2a6aeed"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -75,7 +131,11 @@
         <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory.Data"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -83,207 +143,411 @@
         <bindingRedirect oldVersion="0.0.0.0-4.3.2.0" newVersion="4.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Vectors"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encoding.CodePages"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="System.ClientModel"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.Http.WinHttpHandler"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="System.IdentityModel.Tokens.Jwt"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.JsonWebTokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Logging"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Tokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Validators"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Text"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Form"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Multipart"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.TimeProvider"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Tensors"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reflection.Metadata"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Json"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Authentication.Azure"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.ApplicationInsights"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Http.HttpClientLibrary"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
+        <assemblyIdentity
+          name="Std.UriTemplate"
+          publicKeyToken="c118b0afb4598f9a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.HashCode"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Numerics"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Options"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Diagnostics.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Hosting.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Binder"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Formats.Asn1"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reactive"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Primitives"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Linq.AsyncEnumerable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.Abstractions"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.FileSystem"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client.Extensions.Msal"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.Cryptography.ProtectedData"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.AccessControl"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="Azure.Monitor.OpenTelemetry.Exporter"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Cryptography"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.ServerSentEvents"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>

--- a/TaskMaster.Test/packages.config
+++ b/TaskMaster.Test/packages.config
@@ -1,168 +1,72 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
-  <package id="Azure.Core" version="1.60.0" targetFramework="net481" />
+  <package id="Azure.Core" version="1.61.0" targetFramework="net481" />
   <package id="Azure.Monitor.OpenTelemetry.Exporter" version="1.8.3" targetFramework="net481" />
   <package id="Castle.Core" version="5.2.1" targetFramework="net481" />
   <package id="FluentAssertions" version="8.10.0" targetFramework="net481" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
   <package id="log4net.Ext.Json" version="3.0.3" targetFramework="net481" />
-  <package
-    id="Meziantou.Analyzer"
-    version="3.0.138"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
-    version="5.6.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package id="Microsoft.Extensions.Configuration" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Configuration.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.Binder"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Diagnostics.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.FileProviders.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Hosting.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Logging" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Logging.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Logging.Configuration"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Options" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Options.ConfigurationExtensions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Primitives" version="10.0.10" targetFramework="net481" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package
-    id="Microsoft.Identity.Client.Extensions.Msal"
-    version="4.87.0"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package
-    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
-    version="2.3.3"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Testing.Extensions.VSTestBridge"
-    version="2.3.3"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
+  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.8.1" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="18.8.1" targetFramework="net481" />
+  <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.9.0" targetFramework="net481" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
   <package id="Moq" version="4.20.72" targetFramework="net481" />
-  <package
-    id="MSTest.Analyzers"
-    version="4.3.3"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.Api.ProviderBuilderExtensions"
-    version="1.17.0"
-    targetFramework="net481"
-  />
+  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.PersistentStorage.Abstractions"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="OpenTelemetry.PersistentStorage.FileSystem"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="Roslynator.Analyzers"
-    version="4.15.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="SonarAnalyzer.CSharp"
-    version="10.31.0.145097"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
+  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
+  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
-  <package id="System.ClientModel" version="1.14.0" targetFramework="net481" />
-  <package id="System.Collections.Immutable" version="10.0.10" targetFramework="net481" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.10" targetFramework="net481" />
-  <package id="System.Formats.Asn1" version="10.0.10" targetFramework="net481" />
+  <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
+  <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.11" targetFramework="net481" />
+  <package id="System.Formats.Asn1" version="10.0.11" targetFramework="net481" />
   <package id="System.IO.FileSystem.AccessControl" version="5.0.0" targetFramework="net481" />
-  <package id="System.IO.Pipelines" version="10.0.10" targetFramework="net481" />
+  <package id="System.IO.Pipelines" version="10.0.11" targetFramework="net481" />
   <package id="System.Memory" version="4.6.3" targetFramework="net481" />
-  <package id="System.Memory.Data" version="10.0.10" targetFramework="net481" />
+  <package id="System.Memory.Data" version="10.0.11" targetFramework="net481" />
+  <package id="System.Net.ServerSentEvents" version="10.0.11" targetFramework="net481" />
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net481" />
-  <package id="System.Reflection.Metadata" version="10.0.10" targetFramework="net481" />
+  <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package
-    id="System.Security.Cryptography.ProtectedData"
-    version="10.0.10"
-    targetFramework="net481"
-  />
+  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
-  <package id="System.Text.Encodings.Web" version="10.0.10" targetFramework="net481" />
-  <package id="System.Text.Json" version="10.0.10" targetFramework="net481" />
+  <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
+  <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net481" />
   <package id="System.ValueTuple" version="4.6.2" targetFramework="net481" />
 </packages>

--- a/TaskMaster.Test/packages.config
+++ b/TaskMaster.Test/packages.config
@@ -7,48 +7,141 @@
   <package id="FluentAssertions" version="8.10.0" targetFramework="net481" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
   <package id="log4net.Ext.Json" version="3.0.3" targetFramework="net481" />
-  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Meziantou.Analyzer"
+    version="3.0.156"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
+    version="5.6.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Configuration.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.Binder"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Diagnostics.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.FileProviders.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Hosting.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Logging.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Logging.Configuration"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Options.ConfigurationExtensions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
+  <package
+    id="Microsoft.Identity.Client.Extensions.Msal"
+    version="4.87.0"
+    targetFramework="net481"
+  />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
+  <package
+    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
+    version="2.3.3"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Testing.Extensions.VSTestBridge"
+    version="2.3.3"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.9.0" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
   <package id="Moq" version="4.20.72" targetFramework="net481" />
-  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="MSTest.Analyzers"
+    version="4.3.3"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
+  <package
+    id="OpenTelemetry.Api.ProviderBuilderExtensions"
+    version="1.17.0"
+    targetFramework="net481"
+  />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
-  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
-  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="OpenTelemetry.PersistentStorage.Abstractions"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="OpenTelemetry.PersistentStorage.FileSystem"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="Roslynator.Analyzers"
+    version="4.16.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="SonarAnalyzer.CSharp"
+    version="10.32.0.713"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
   <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
   <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
@@ -63,7 +156,11 @@
   <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
+  <package
+    id="System.Security.Cryptography.ProtectedData"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
   <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
   <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />

--- a/TaskMaster/TaskMaster.csproj
+++ b/TaskMaster/TaskMaster.csproj
@@ -567,11 +567,11 @@
   <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
-    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
+    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
     <Analyzer Include="..\packages\AsyncFixer.2.1.0\analyzers\dotnet\cs\AsyncFixer.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />

--- a/TaskMaster/TaskMaster.csproj
+++ b/TaskMaster/TaskMaster.csproj
@@ -1,5 +1,5 @@
 <Project ToolsVersion="17.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" />
+  <Import Project="..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <!--
     This section defines project-level properties.
@@ -139,16 +139,14 @@
     <Reference Include="log4net.Ext.Json, Version=3.0.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.Ext.Json.3.0.3\lib\net462\log4net.Ext.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.10\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.Memory, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\Microsoft.Bcl.Memory.10.0.10\lib\net462\Microsoft.Bcl.Memory.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Bcl.Memory, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Memory.10.0.11\lib\net462\Microsoft.Bcl.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.TimeProvider, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.TimeProvider.10.0.10\lib\net462\Microsoft.Bcl.TimeProvider.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.TimeProvider, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.TimeProvider.10.0.11\lib\net462\Microsoft.Bcl.TimeProvider.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Analysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.Analysis.0.23.0\lib\netstandard2.0\Microsoft.Data.Analysis.dll</HintPath>
@@ -176,8 +174,8 @@
     <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.10.0.10\lib\net462\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.10.0.11\lib\net462\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
@@ -192,8 +190,8 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.10\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.11\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Diagnostics.Tracing, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Diagnostics.Tracing.4.3.0\lib\net462\System.Diagnostics.Tracing.dll</HintPath>
@@ -564,13 +562,12 @@
     <Error Condition="!Exists('..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets'))" />
     <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets'))" />
     <Error Condition="!Exists('..\packages\System.Reactive.7.0.0\build\System.Reactive.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Reactive.7.0.0\build\System.Reactive.targets'))" />
-    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props'))" />
   </Target>
   <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
     <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.31.0.145097\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
@@ -579,6 +576,7 @@
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\BannedSymbols.txt" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.32.0.713\analyzers\SonarAnalyzer.CSharp.dll" />
   </ItemGroup>
   <Import Project="..\packages\System.Reactive.7.0.0\build\System.Reactive.targets" Condition="Exists('..\packages\System.Reactive.7.0.0\build\System.Reactive.targets')" />
 </Project>

--- a/TaskMaster/app.config
+++ b/TaskMaster/app.config
@@ -1,33 +1,68 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <section name="TaskMaster.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+    <sectionGroup
+      name="userSettings"
+      type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+    >
+      <section
+        name="TaskMaster.Properties.Settings"
+        type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+        allowExeDefinition="MachineToLocalUser"
+        requirePermission="false"
+      />
     </sectionGroup>
-    <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <section name="TaskMaster.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <sectionGroup
+      name="applicationSettings"
+      type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+    >
+      <section
+        name="TaskMaster.Properties.Settings"
+        type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+        requirePermission="false"
+      />
     </sectionGroup>
   </configSections>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Buffers"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Runtime.CompilerServices.Unsafe"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Tasks.Extensions"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Channels"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -35,7 +70,11 @@
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.AsyncInterfaces"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -51,7 +90,11 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Collections.Immutable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -59,31 +102,59 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <assemblyIdentity
+          name="Newtonsoft.Json"
+          publicKeyToken="30ad4fe6b2a6aeed"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Graph.Core"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Diagnostics.DiagnosticSource"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Json"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encodings.Web"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -91,155 +162,307 @@
         <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory.Data"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Vectors"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encoding.CodePages"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="System.ClientModel"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.Http.WinHttpHandler"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="System.IdentityModel.Tokens.Jwt"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Tokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Validators"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Text"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Form"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Multipart"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.TimeProvider"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Tensors"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Json"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Authentication.Azure"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Http.HttpClientLibrary"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
+        <assemblyIdentity
+          name="Std.UriTemplate"
+          publicKeyToken="c118b0afb4598f9a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.HashCode"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Numerics"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Formats.Asn1"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Hosting.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Diagnostics.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Primitives"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reactive"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Linq.AsyncEnumerable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client.Extensions.Msal"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.Cryptography.ProtectedData"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.AccessControl"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Cryptography"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.ServerSentEvents"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>

--- a/TaskMaster/app.config
+++ b/TaskMaster/app.config
@@ -1,81 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <sectionGroup
-      name="userSettings"
-      type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-    >
-      <section
-        name="TaskMaster.Properties.Settings"
-        type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-        allowExeDefinition="MachineToLocalUser"
-        requirePermission="false"
-      />
+    <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <section name="TaskMaster.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
     </sectionGroup>
-    <sectionGroup
-      name="applicationSettings"
-      type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-    >
-      <section
-        name="TaskMaster.Properties.Settings"
-        type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-        requirePermission="false"
-      />
+    <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <section name="TaskMaster.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
     </sectionGroup>
   </configSections>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Buffers"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Runtime.CompilerServices.Unsafe"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Tasks.Extensions"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Channels"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.AsyncInterfaces"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="ExCSS" publicKeyToken="bdbe16be9b936b9a" culture="neutral" />
@@ -90,372 +51,196 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Collections.Immutable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Newtonsoft.Json"
-          publicKeyToken="30ad4fe6b2a6aeed"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Graph.Core"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Diagnostics.DiagnosticSource"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Json"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encodings.Web"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.60.0.0" newVersion="1.60.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory.Data"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Vectors"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encoding.CodePages"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.ClientModel"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Net.Http.WinHttpHandler"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.IdentityModel.Tokens.Jwt"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Tokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Validators"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Text"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Form"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Multipart"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.TimeProvider"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Tensors"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Json"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Authentication.Azure"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Http.HttpClientLibrary"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="Std.UriTemplate"
-          publicKeyToken="c118b0afb4598f9a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.HashCode"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Numerics"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Formats.Asn1"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Hosting.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Diagnostics.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Primitives"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reactive"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Linq.AsyncEnumerable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client.Extensions.Msal"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.Cryptography.ProtectedData"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.AccessControl"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Cryptography"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/TaskMaster/packages.config
+++ b/TaskMaster/packages.config
@@ -5,11 +5,21 @@
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
   <package id="log4net.Ext.Json" version="3.0.3" targetFramework="net481" />
-  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Meziantou.Analyzer"
+    version="3.0.156"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Bcl.Memory" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Bcl.TimeProvider" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
+    version="5.6.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.Data.Analysis" version="0.23.0" targetFramework="net481" />
   <package id="Microsoft.ML.DataView" version="5.0.0" targetFramework="net481" />
   <package id="Microsoft.NETCore.Platforms" version="7.0.4" targetFramework="net481" />
@@ -17,8 +27,18 @@
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net481" />
   <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net481" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net481" />
-  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
-  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Roslynator.Analyzers"
+    version="4.16.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="SonarAnalyzer.CSharp"
+    version="10.32.0.713"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="System.AppContext" version="4.3.0" targetFramework="net481" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
   <package id="System.Collections" version="4.3.0" targetFramework="net481" />
@@ -59,12 +79,20 @@
   <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="net481" />
   <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net481" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net481" />
-  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net481" />
+  <package
+    id="System.Runtime.InteropServices.RuntimeInformation"
+    version="4.3.0"
+    targetFramework="net481"
+  />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net481" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net481" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net481" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net481" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net481" />
+  <package
+    id="System.Security.Cryptography.X509Certificates"
+    version="4.3.2"
+    targetFramework="net481"
+  />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net481" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net481" />
   <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="net481" />

--- a/TaskMaster/packages.config
+++ b/TaskMaster/packages.config
@@ -5,21 +5,11 @@
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
   <package id="log4net.Ext.Json" version="3.0.3" targetFramework="net481" />
-  <package
-    id="Meziantou.Analyzer"
-    version="3.0.138"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.10" targetFramework="net481" />
-  <package id="Microsoft.Bcl.Memory" version="10.0.10" targetFramework="net481" />
-  <package id="Microsoft.Bcl.TimeProvider" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
-    version="5.6.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Bcl.Memory" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Bcl.TimeProvider" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
   <package id="Microsoft.Data.Analysis" version="0.23.0" targetFramework="net481" />
   <package id="Microsoft.ML.DataView" version="5.0.0" targetFramework="net481" />
   <package id="Microsoft.NETCore.Platforms" version="7.0.4" targetFramework="net481" />
@@ -27,27 +17,17 @@
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net481" />
   <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net481" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net481" />
-  <package
-    id="Roslynator.Analyzers"
-    version="4.15.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="SonarAnalyzer.CSharp"
-    version="10.31.0.145097"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net481" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
   <package id="System.Collections" version="4.3.0" targetFramework="net481" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net481" />
-  <package id="System.Collections.Immutable" version="10.0.10" targetFramework="net481" />
+  <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
   <package id="System.Console" version="4.3.1" targetFramework="net481" />
   <package id="System.Data.Common" version="4.3.0" targetFramework="net481" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net481" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.10" targetFramework="net481" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.11" targetFramework="net481" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net481" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net481" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net481" />
@@ -79,20 +59,12 @@
   <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="net481" />
   <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net481" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net481" />
-  <package
-    id="System.Runtime.InteropServices.RuntimeInformation"
-    version="4.3.0"
-    targetFramework="net481"
-  />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net481" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net481" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net481" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net481" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net481" />
-  <package
-    id="System.Security.Cryptography.X509Certificates"
-    version="4.3.2"
-    targetFramework="net481"
-  />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net481" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net481" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net481" />
   <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="net481" />

--- a/TaskTree.Test/TaskTree.Test.csproj
+++ b/TaskTree.Test/TaskTree.Test.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" />
+  <Import Project="..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" />
   <Import Project="..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props')" />
   <Import Project="..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props" Condition="Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.props" Condition="Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.props')" />
@@ -45,8 +45,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Azure.Core, Version=1.60.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Azure.Core.1.60.0\lib\net472\Azure.Core.dll</HintPath>
+    <Reference Include="Azure.Core, Version=1.61.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Core.1.61.0\lib\net472\Azure.Core.dll</HintPath>
     </Reference>
     <Reference Include="Azure.Monitor.OpenTelemetry.Exporter, Version=1.8.3.0, Culture=neutral, PublicKeyToken=92742159e12e44c8">
       <HintPath>..\packages\Azure.Monitor.OpenTelemetry.Exporter.1.8.3\lib\netstandard2.0\Azure.Monitor.OpenTelemetry.Exporter.dll</HintPath>
@@ -61,55 +61,54 @@
     <Reference Include="Microsoft.ApplicationInsights, Version=3.1.2.115, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.3.1.2\lib\net462\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.10\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.10\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.11\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.10\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.11\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.10\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.11\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.10\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.11\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.10\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.11\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Identity.Client, Version=4.87.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae">
       <HintPath>..\packages\Microsoft.Identity.Client.4.87.0\lib\net472\Microsoft.Identity.Client.dll</HintPath>
@@ -125,6 +124,18 @@
     </Reference>
     <Reference Include="Microsoft.Office.Interop.Outlook, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
       <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.TestPlatform.AdapterUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.18.9.0\lib\net462\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.TestPlatform.PlatformAbstractions, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="ObjectListView, Version=2.9.1.1072, Culture=neutral, PublicKeyToken=b1c5bf581481bcd4, processorArchitecture=MSIL">
       <HintPath>..\packages\ObjectListView.Official.2.9.1\lib\net20\ObjectListView.dll</HintPath>
@@ -143,18 +154,6 @@
     </Reference>
     <Reference Include="Microsoft.Testing.Platform, Version=2.3.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Testing.Platform.2.3.3\lib\netstandard2.0\Microsoft.Testing.Platform.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.TestPlatform.AdapterUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.18.8.1\lib\net462\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.TestPlatform.PlatformAbstractions, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.20.72.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.20.72\lib\net462\Moq.dll</HintPath>
@@ -187,44 +186,48 @@
     <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.ClientModel, Version=1.14.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ClientModel.1.14.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
+    <Reference Include="System.ClientModel, Version=1.15.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ClientModel.1.15.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.10.0.10\lib\net462\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.10.0.11\lib\net462\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.10\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.11\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Formats.Asn1, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Formats.Asn1.10.0.10\lib\net462\System.Formats.Asn1.dll</HintPath>
+    <Reference Include="System.Formats.Asn1, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Formats.Asn1.10.0.11\lib\net462\System.Formats.Asn1.dll</HintPath>
     </Reference>
     <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IO" />
     <Reference Include="System.IO.FileSystem.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.FileSystem.AccessControl.5.0.0\lib\net461\System.IO.FileSystem.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Pipelines, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Pipelines.10.0.10\lib\net462\System.IO.Pipelines.dll</HintPath>
+    <Reference Include="System.IO.Pipelines, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.10.0.11\lib\net462\System.IO.Pipelines.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="System.Memory.Data, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.Data.10.0.10\lib\net462\System.Memory.Data.dll</HintPath>
+    <Reference Include="System.Memory.Data, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.Data.10.0.11\lib\net462\System.Memory.Data.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.ServerSentEvents, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.ServerSentEvents.10.0.11\lib\net462\System.Net.ServerSentEvents.dll</HintPath>
+    </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.6.1\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.10.0.10\lib\net462\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.10.0.11\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -235,17 +238,17 @@
     <Reference Include="System.Security.AccessControl, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.AccessControl.6.0.1\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.10\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.11\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.10.0.10\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.10.0.11\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.10.0.10\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.10.0.11\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.3\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
@@ -283,6 +286,7 @@
   <ItemGroup>
     <Analyzer Include="..\packages\MSTest.Analyzers.4.3.3\analyzers\dotnet\cs\MSTest.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\MSTest.Analyzers.4.3.3\analyzers\dotnet\cs\MSTest.Analyzers.dll" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.32.0.713\analyzers\SonarAnalyzer.CSharp.dll" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -299,7 +303,7 @@
     <Error Condition="!Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets'))" />
-    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props'))" />
   </Target>
   <Import Project="..\packages\Microsoft.Testing.Platform.2.3.3\build\netstandard2.0\Microsoft.Testing.Platform.targets" Condition="Exists('..\packages\Microsoft.Testing.Platform.2.3.3\build\netstandard2.0\Microsoft.Testing.Platform.targets')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.targets" Condition="Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.targets')" />
@@ -309,7 +313,6 @@
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
     <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.31.0.145097\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />

--- a/TaskTree.Test/TaskTree.Test.csproj
+++ b/TaskTree.Test/TaskTree.Test.csproj
@@ -312,11 +312,11 @@
   <Import Project="..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets')" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
-    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
+    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
     <Analyzer Include="..\packages\AsyncFixer.2.1.0\analyzers\dotnet\cs\AsyncFixer.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />

--- a/TaskTree.Test/app.config
+++ b/TaskTree.Test/app.config
@@ -3,208 +3,108 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Tasks.Extensions"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Runtime.CompilerServices.Unsafe"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reflection.Metadata"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Diagnostics.DiagnosticSource"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Collections.Immutable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Buffers"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.ApplicationInsights"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Vectors"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.AsyncInterfaces"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Json"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Options"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Diagnostics.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Configuration"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Hosting.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Binder"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encodings.Web"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory.Data"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encoding.CodePages"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -215,300 +115,160 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Json"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Text"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Form"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Multipart"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Authentication.Azure"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.IdentityModel.Tokens.Jwt"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.JsonWebTokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Logging"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Tokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Http.HttpClientLibrary"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Net.Http.WinHttpHandler"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Validators"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Formats.Asn1"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.TimeProvider"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Tensors"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Channels"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="ExCSS" publicKeyToken="bdbe16be9b936b9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.3.2.0" newVersion="4.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reactive"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Graph.Core"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Primitives"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.ClientModel"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.60.0.0" newVersion="1.60.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="OpenTelemetry.PersistentStorage.Abstractions"
-          publicKeyToken="7bd6737fe5b67e3c"
-          culture="neutral"
-        />
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="OpenTelemetry.PersistentStorage.FileSystem"
-          publicKeyToken="7bd6737fe5b67e3c"
-          culture="neutral"
-        />
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Linq.AsyncEnumerable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client.Extensions.Msal"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.Cryptography.ProtectedData"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.AccessControl"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Azure.Monitor.OpenTelemetry.Exporter"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Std.UriTemplate"
-          publicKeyToken="c118b0afb4598f9a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Cryptography"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/TaskTree.Test/app.config
+++ b/TaskTree.Test/app.config
@@ -3,99 +3,195 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Tasks.Extensions"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Runtime.CompilerServices.Unsafe"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reflection.Metadata"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Diagnostics.DiagnosticSource"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Collections.Immutable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Buffers"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.ApplicationInsights"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Vectors"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.AsyncInterfaces"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Json"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Options"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Diagnostics.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Hosting.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Binder"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encodings.Web"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory.Data"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -103,7 +199,11 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encoding.CodePages"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -115,83 +215,163 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Json"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Text"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Form"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Multipart"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Authentication.Azure"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="System.IdentityModel.Tokens.Jwt"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.JsonWebTokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Logging"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Tokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Http.HttpClientLibrary"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.Http.WinHttpHandler"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Validators"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Formats.Asn1"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.TimeProvider"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Tensors"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Channels"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -199,27 +379,51 @@
         <bindingRedirect oldVersion="0.0.0.0-4.3.2.0" newVersion="4.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reactive"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Graph.Core"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Primitives"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="System.ClientModel"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -227,47 +431,91 @@
         <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.Abstractions"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.FileSystem"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Linq.AsyncEnumerable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client.Extensions.Msal"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.Cryptography.ProtectedData"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.AccessControl"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="Azure.Monitor.OpenTelemetry.Exporter"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
+        <assemblyIdentity
+          name="Std.UriTemplate"
+          publicKeyToken="c118b0afb4598f9a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Cryptography"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.ServerSentEvents"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>

--- a/TaskTree.Test/packages.config
+++ b/TaskTree.Test/packages.config
@@ -5,47 +5,140 @@
   <package id="Azure.Monitor.OpenTelemetry.Exporter" version="1.8.3" targetFramework="net481" />
   <package id="Castle.Core" version="5.2.1" targetFramework="net481" />
   <package id="FluentAssertions" version="8.10.0" targetFramework="net481" />
-  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Meziantou.Analyzer"
+    version="3.0.156"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
+    version="5.6.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Configuration.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.Binder"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Diagnostics.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.FileProviders.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Hosting.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Logging.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Logging.Configuration"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Options.ConfigurationExtensions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
+  <package
+    id="Microsoft.Identity.Client.Extensions.Msal"
+    version="4.87.0"
+    targetFramework="net481"
+  />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
+  <package
+    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
+    version="2.3.3"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Testing.Extensions.VSTestBridge"
+    version="2.3.3"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.9.0" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
   <package id="Moq" version="4.20.72" targetFramework="net481" />
-  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="MSTest.Analyzers"
+    version="4.3.3"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
+  <package
+    id="OpenTelemetry.Api.ProviderBuilderExtensions"
+    version="1.17.0"
+    targetFramework="net481"
+  />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
-  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
-  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="OpenTelemetry.PersistentStorage.Abstractions"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="OpenTelemetry.PersistentStorage.FileSystem"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="Roslynator.Analyzers"
+    version="4.16.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="SonarAnalyzer.CSharp"
+    version="10.32.0.713"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
   <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
   <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
@@ -60,7 +153,11 @@
   <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
+  <package
+    id="System.Security.Cryptography.ProtectedData"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
   <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
   <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />

--- a/TaskTree.Test/packages.config
+++ b/TaskTree.Test/packages.config
@@ -1,165 +1,69 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
-  <package id="Azure.Core" version="1.60.0" targetFramework="net481" />
+  <package id="Azure.Core" version="1.61.0" targetFramework="net481" />
   <package id="Azure.Monitor.OpenTelemetry.Exporter" version="1.8.3" targetFramework="net481" />
   <package id="Castle.Core" version="5.2.1" targetFramework="net481" />
   <package id="FluentAssertions" version="8.10.0" targetFramework="net481" />
-  <package
-    id="Meziantou.Analyzer"
-    version="3.0.138"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
-    version="5.6.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package id="Microsoft.Extensions.Configuration" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Configuration.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.Binder"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Diagnostics.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.FileProviders.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Hosting.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Logging" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Logging.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Logging.Configuration"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Options" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Options.ConfigurationExtensions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Primitives" version="10.0.10" targetFramework="net481" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package
-    id="Microsoft.Identity.Client.Extensions.Msal"
-    version="4.87.0"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package
-    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
-    version="2.3.3"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Testing.Extensions.VSTestBridge"
-    version="2.3.3"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
+  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.8.1" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="18.8.1" targetFramework="net481" />
+  <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.9.0" targetFramework="net481" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
   <package id="Moq" version="4.20.72" targetFramework="net481" />
-  <package
-    id="MSTest.Analyzers"
-    version="4.3.3"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.Api.ProviderBuilderExtensions"
-    version="1.17.0"
-    targetFramework="net481"
-  />
+  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.PersistentStorage.Abstractions"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="OpenTelemetry.PersistentStorage.FileSystem"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="Roslynator.Analyzers"
-    version="4.15.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="SonarAnalyzer.CSharp"
-    version="10.31.0.145097"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
+  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
+  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
-  <package id="System.ClientModel" version="1.14.0" targetFramework="net481" />
-  <package id="System.Collections.Immutable" version="10.0.10" targetFramework="net481" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.10" targetFramework="net481" />
-  <package id="System.Formats.Asn1" version="10.0.10" targetFramework="net481" />
+  <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
+  <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.11" targetFramework="net481" />
+  <package id="System.Formats.Asn1" version="10.0.11" targetFramework="net481" />
   <package id="System.IO.FileSystem.AccessControl" version="5.0.0" targetFramework="net481" />
-  <package id="System.IO.Pipelines" version="10.0.10" targetFramework="net481" />
+  <package id="System.IO.Pipelines" version="10.0.11" targetFramework="net481" />
   <package id="System.Memory" version="4.6.3" targetFramework="net481" />
-  <package id="System.Memory.Data" version="10.0.10" targetFramework="net481" />
+  <package id="System.Memory.Data" version="10.0.11" targetFramework="net481" />
+  <package id="System.Net.ServerSentEvents" version="10.0.11" targetFramework="net481" />
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net481" />
-  <package id="System.Reflection.Metadata" version="10.0.10" targetFramework="net481" />
+  <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package
-    id="System.Security.Cryptography.ProtectedData"
-    version="10.0.10"
-    targetFramework="net481"
-  />
+  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
-  <package id="System.Text.Encodings.Web" version="10.0.10" targetFramework="net481" />
-  <package id="System.Text.Json" version="10.0.10" targetFramework="net481" />
+  <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
+  <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net481" />
   <package id="System.ValueTuple" version="4.6.2" targetFramework="net481" />
 </packages>

--- a/TaskTree/TaskTree.csproj
+++ b/TaskTree/TaskTree.csproj
@@ -97,11 +97,11 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
-    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
+    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
     <Analyzer Include="..\packages\AsyncFixer.2.1.0\analyzers\dotnet\cs\AsyncFixer.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />

--- a/TaskTree/TaskTree.csproj
+++ b/TaskTree/TaskTree.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" />
+  <Import Project="..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -98,7 +98,6 @@
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
     <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.31.0.145097\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
@@ -107,11 +106,12 @@
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\BannedSymbols.txt" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.32.0.713\analyzers\SonarAnalyzer.CSharp.dll" />
   </ItemGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props'))" />
   </Target>
 </Project>

--- a/TaskTree/app.config
+++ b/TaskTree/app.config
@@ -3,35 +3,19 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Buffers"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Tasks.Extensions"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Runtime.CompilerServices.Unsafe"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -39,32 +23,20 @@
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.AsyncInterfaces"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Apache.Arrow" publicKeyToken="204f54e5a45c07df" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Collections.Immutable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Channels"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="ExCSS" publicKeyToken="bdbe16be9b936b9a" culture="neutral" />
@@ -79,360 +51,188 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Newtonsoft.Json"
-          publicKeyToken="30ad4fe6b2a6aeed"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Graph.Core"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Diagnostics.DiagnosticSource"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Json"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encodings.Web"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.60.0.0" newVersion="1.60.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory.Data"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Vectors"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encoding.CodePages"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.ClientModel"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Net.Http.WinHttpHandler"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.IdentityModel.Tokens.Jwt"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Tokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Validators"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Text"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Form"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Multipart"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.TimeProvider"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Tensors"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Json"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Authentication.Azure"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Http.HttpClientLibrary"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Std.UriTemplate"
-          publicKeyToken="c118b0afb4598f9a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.HashCode"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Numerics"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reactive"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Formats.Asn1"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Hosting.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Diagnostics.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Primitives"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Linq.AsyncEnumerable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client.Extensions.Msal"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.Cryptography.ProtectedData"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.AccessControl"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Cryptography"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/TaskTree/app.config
+++ b/TaskTree/app.config
@@ -3,19 +3,35 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Buffers"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Tasks.Extensions"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Runtime.CompilerServices.Unsafe"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -23,7 +39,11 @@
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.AsyncInterfaces"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -31,11 +51,19 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Collections.Immutable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Channels"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -51,31 +79,59 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <assemblyIdentity
+          name="Newtonsoft.Json"
+          publicKeyToken="30ad4fe6b2a6aeed"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Graph.Core"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Diagnostics.DiagnosticSource"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Json"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encodings.Web"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -83,155 +139,307 @@
         <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory.Data"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Vectors"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encoding.CodePages"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="System.ClientModel"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.Http.WinHttpHandler"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="System.IdentityModel.Tokens.Jwt"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Tokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Validators"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Text"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Form"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Multipart"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.TimeProvider"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Tensors"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Json"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Authentication.Azure"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Http.HttpClientLibrary"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
+        <assemblyIdentity
+          name="Std.UriTemplate"
+          publicKeyToken="c118b0afb4598f9a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.HashCode"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Numerics"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reactive"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Formats.Asn1"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Hosting.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Diagnostics.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Primitives"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Linq.AsyncEnumerable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client.Extensions.Msal"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.Cryptography.ProtectedData"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.AccessControl"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Cryptography"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.ServerSentEvents"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>

--- a/TaskTree/packages.config
+++ b/TaskTree/packages.config
@@ -3,9 +3,29 @@
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
   <package id="log4net.Ext.Json" version="3.0.3" targetFramework="net481" />
-  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
-  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Meziantou.Analyzer"
+    version="3.0.156"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
+    version="5.6.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net481" />
-  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
-  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Roslynator.Analyzers"
+    version="4.16.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="SonarAnalyzer.CSharp"
+    version="10.32.0.713"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
 </packages>

--- a/TaskTree/packages.config
+++ b/TaskTree/packages.config
@@ -3,29 +3,9 @@
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
   <package id="log4net.Ext.Json" version="3.0.3" targetFramework="net481" />
-  <package
-    id="Meziantou.Analyzer"
-    version="3.0.138"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
-    version="5.6.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net481" />
-  <package
-    id="Roslynator.Analyzers"
-    version="4.15.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="SonarAnalyzer.CSharp"
-    version="10.31.0.145097"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
 </packages>

--- a/TaskVisualization.Test/TaskVisualization.Test.csproj
+++ b/TaskVisualization.Test/TaskVisualization.Test.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" />
+  <Import Project="..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" />
   <Import Project="..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props')" />
   <Import Project="..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props" Condition="Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.props" Condition="Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.props')" />
@@ -80,8 +80,8 @@
     <Compile Include="TaskControllerAcceleratorKeyboard.StaTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Azure.Core, Version=1.60.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Azure.Core.1.60.0\lib\net472\Azure.Core.dll</HintPath>
+    <Reference Include="Azure.Core, Version=1.61.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Core.1.61.0\lib\net472\Azure.Core.dll</HintPath>
     </Reference>
     <Reference Include="Azure.Monitor.OpenTelemetry.Exporter, Version=1.8.3.0, Culture=neutral, PublicKeyToken=92742159e12e44c8">
       <HintPath>..\packages\Azure.Monitor.OpenTelemetry.Exporter.1.8.3\lib\netstandard2.0\Azure.Monitor.OpenTelemetry.Exporter.dll</HintPath>
@@ -96,55 +96,54 @@
     <Reference Include="Microsoft.ApplicationInsights, Version=3.1.2.115, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.3.1.2\lib\net462\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.10\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.10\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.11\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.10\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.11\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.10\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.11\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.10\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.11\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.10\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.11\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Identity.Client, Version=4.87.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae">
       <HintPath>..\packages\Microsoft.Identity.Client.4.87.0\lib\net472\Microsoft.Identity.Client.dll</HintPath>
@@ -177,16 +176,16 @@
       <HintPath>..\packages\Microsoft.Testing.Platform.2.3.3\lib\netstandard2.0\Microsoft.Testing.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.AdapterUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.18.8.1\lib\net462\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.18.9.0\lib\net462\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.PlatformAbstractions, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.20.72.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.20.72\lib\net462\Moq.dll</HintPath>
@@ -219,43 +218,47 @@
     <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.ClientModel, Version=1.14.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ClientModel.1.14.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
+    <Reference Include="System.ClientModel, Version=1.15.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ClientModel.1.15.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.10.0.10\lib\net462\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.10.0.11\lib\net462\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.10\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.11\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Formats.Asn1, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Formats.Asn1.10.0.10\lib\net462\System.Formats.Asn1.dll</HintPath>
+    <Reference Include="System.Formats.Asn1, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Formats.Asn1.10.0.11\lib\net462\System.Formats.Asn1.dll</HintPath>
     </Reference>
     <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IO" />
     <Reference Include="System.IO.FileSystem.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.FileSystem.AccessControl.5.0.0\lib\net461\System.IO.FileSystem.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Pipelines, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Pipelines.10.0.10\lib\net462\System.IO.Pipelines.dll</HintPath>
+    <Reference Include="System.IO.Pipelines, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.10.0.11\lib\net462\System.IO.Pipelines.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="System.Memory.Data, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.Data.10.0.10\lib\net462\System.Memory.Data.dll</HintPath>
+    <Reference Include="System.Memory.Data, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.Data.10.0.11\lib\net462\System.Memory.Data.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.ServerSentEvents, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.ServerSentEvents.10.0.11\lib\net462\System.Net.ServerSentEvents.dll</HintPath>
+    </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.6.1\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.10.0.10\lib\net462\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.10.0.11\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -266,17 +269,17 @@
     <Reference Include="System.Security.AccessControl, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.AccessControl.6.0.1\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.10\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.11\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.10.0.10\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.10.0.11\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.10.0.10\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.10.0.11\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.3\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
@@ -307,6 +310,7 @@
   <ItemGroup>
     <Analyzer Include="..\packages\MSTest.Analyzers.4.3.3\analyzers\dotnet\cs\MSTest.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\MSTest.Analyzers.4.3.3\analyzers\dotnet\cs\MSTest.Analyzers.dll" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.32.0.713\analyzers\SonarAnalyzer.CSharp.dll" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -323,7 +327,7 @@
     <Error Condition="!Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets'))" />
-    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props'))" />
   </Target>
   <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.2.3.3\build\netstandard2.0\Microsoft.Testing.Platform.targets" Condition="Exists('..\packages\Microsoft.Testing.Platform.2.3.3\build\netstandard2.0\Microsoft.Testing.Platform.targets')" />
@@ -333,7 +337,6 @@
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
     <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.31.0.145097\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />

--- a/TaskVisualization.Test/TaskVisualization.Test.csproj
+++ b/TaskVisualization.Test/TaskVisualization.Test.csproj
@@ -336,11 +336,11 @@
   <Import Project="..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets')" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
-    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
+    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
     <Analyzer Include="..\packages\AsyncFixer.2.1.0\analyzers\dotnet\cs\AsyncFixer.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />

--- a/TaskVisualization.Test/app.config
+++ b/TaskVisualization.Test/app.config
@@ -3,19 +3,35 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Tasks.Extensions"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Buffers"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Runtime.CompilerServices.Unsafe"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -27,15 +43,27 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Collections.Immutable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Channels"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.AsyncInterfaces"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -51,31 +79,59 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <assemblyIdentity
+          name="Newtonsoft.Json"
+          publicKeyToken="30ad4fe6b2a6aeed"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Graph.Core"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Diagnostics.DiagnosticSource"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Json"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encodings.Web"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -83,211 +139,419 @@
         <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory.Data"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Vectors"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encoding.CodePages"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="System.ClientModel"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.Http.WinHttpHandler"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="System.IdentityModel.Tokens.Jwt"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.JsonWebTokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Logging"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Tokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Validators"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Text"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Form"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Multipart"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.TimeProvider"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Tensors"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reflection.Metadata"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Json"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Authentication.Azure"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.ApplicationInsights"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Http.HttpClientLibrary"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
+        <assemblyIdentity
+          name="Std.UriTemplate"
+          publicKeyToken="c118b0afb4598f9a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.HashCode"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Numerics"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Options"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Diagnostics.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Hosting.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Binder"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reactive"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Formats.Asn1"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Primitives"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Linq.AsyncEnumerable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.Abstractions"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.FileSystem"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client.Extensions.Msal"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.Cryptography.ProtectedData"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.AccessControl"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="Azure.Monitor.OpenTelemetry.Exporter"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Cryptography"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.ServerSentEvents"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>

--- a/TaskVisualization.Test/app.config
+++ b/TaskVisualization.Test/app.config
@@ -3,35 +3,19 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Tasks.Extensions"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Buffers"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Runtime.CompilerServices.Unsafe"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -43,28 +27,16 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Collections.Immutable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Channels"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.AsyncInterfaces"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="ExCSS" publicKeyToken="bdbe16be9b936b9a" culture="neutral" />
@@ -79,472 +51,244 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Newtonsoft.Json"
-          publicKeyToken="30ad4fe6b2a6aeed"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Graph.Core"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Diagnostics.DiagnosticSource"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Json"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encodings.Web"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.60.0.0" newVersion="1.60.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory.Data"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Vectors"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encoding.CodePages"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.ClientModel"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Net.Http.WinHttpHandler"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.IdentityModel.Tokens.Jwt"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.JsonWebTokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Logging"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Tokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Validators"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Text"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Form"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Multipart"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.TimeProvider"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Tensors"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reflection.Metadata"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Json"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Authentication.Azure"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.ApplicationInsights"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Http.HttpClientLibrary"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Std.UriTemplate"
-          publicKeyToken="c118b0afb4598f9a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.HashCode"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Numerics"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Options"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Diagnostics.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Configuration"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Hosting.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Binder"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reactive"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Formats.Asn1"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Primitives"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Linq.AsyncEnumerable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="OpenTelemetry.PersistentStorage.Abstractions"
-          publicKeyToken="7bd6737fe5b67e3c"
-          culture="neutral"
-        />
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="OpenTelemetry.PersistentStorage.FileSystem"
-          publicKeyToken="7bd6737fe5b67e3c"
-          culture="neutral"
-        />
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client.Extensions.Msal"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.Cryptography.ProtectedData"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.AccessControl"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Azure.Monitor.OpenTelemetry.Exporter"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Cryptography"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/TaskVisualization.Test/packages.config
+++ b/TaskVisualization.Test/packages.config
@@ -5,47 +5,140 @@
   <package id="Azure.Monitor.OpenTelemetry.Exporter" version="1.8.3" targetFramework="net481" />
   <package id="Castle.Core" version="5.2.1" targetFramework="net481" />
   <package id="FluentAssertions" version="8.10.0" targetFramework="net481" />
-  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Meziantou.Analyzer"
+    version="3.0.156"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
+    version="5.6.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Configuration.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.Binder"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Diagnostics.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.FileProviders.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Hosting.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Logging.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Logging.Configuration"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Options.ConfigurationExtensions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
+  <package
+    id="Microsoft.Identity.Client.Extensions.Msal"
+    version="4.87.0"
+    targetFramework="net481"
+  />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
+  <package
+    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
+    version="2.3.3"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Testing.Extensions.VSTestBridge"
+    version="2.3.3"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.9.0" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
   <package id="Moq" version="4.20.72" targetFramework="net481" />
-  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="MSTest.Analyzers"
+    version="4.3.3"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
+  <package
+    id="OpenTelemetry.Api.ProviderBuilderExtensions"
+    version="1.17.0"
+    targetFramework="net481"
+  />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
-  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
-  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="OpenTelemetry.PersistentStorage.Abstractions"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="OpenTelemetry.PersistentStorage.FileSystem"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="Roslynator.Analyzers"
+    version="4.16.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="SonarAnalyzer.CSharp"
+    version="10.32.0.713"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
   <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
   <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
@@ -60,7 +153,11 @@
   <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
+  <package
+    id="System.Security.Cryptography.ProtectedData"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
   <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
   <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />

--- a/TaskVisualization.Test/packages.config
+++ b/TaskVisualization.Test/packages.config
@@ -1,165 +1,69 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
-  <package id="Azure.Core" version="1.60.0" targetFramework="net481" />
+  <package id="Azure.Core" version="1.61.0" targetFramework="net481" />
   <package id="Azure.Monitor.OpenTelemetry.Exporter" version="1.8.3" targetFramework="net481" />
   <package id="Castle.Core" version="5.2.1" targetFramework="net481" />
   <package id="FluentAssertions" version="8.10.0" targetFramework="net481" />
-  <package
-    id="Meziantou.Analyzer"
-    version="3.0.138"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
-    version="5.6.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package id="Microsoft.Extensions.Configuration" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Configuration.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.Binder"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Diagnostics.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.FileProviders.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Hosting.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Logging" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Logging.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Logging.Configuration"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Options" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Options.ConfigurationExtensions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Primitives" version="10.0.10" targetFramework="net481" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package
-    id="Microsoft.Identity.Client.Extensions.Msal"
-    version="4.87.0"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package
-    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
-    version="2.3.3"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Testing.Extensions.VSTestBridge"
-    version="2.3.3"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
+  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.8.1" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="18.8.1" targetFramework="net481" />
+  <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.9.0" targetFramework="net481" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
   <package id="Moq" version="4.20.72" targetFramework="net481" />
-  <package
-    id="MSTest.Analyzers"
-    version="4.3.3"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.Api.ProviderBuilderExtensions"
-    version="1.17.0"
-    targetFramework="net481"
-  />
+  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.PersistentStorage.Abstractions"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="OpenTelemetry.PersistentStorage.FileSystem"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="Roslynator.Analyzers"
-    version="4.15.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="SonarAnalyzer.CSharp"
-    version="10.31.0.145097"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
+  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
+  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
-  <package id="System.ClientModel" version="1.14.0" targetFramework="net481" />
-  <package id="System.Collections.Immutable" version="10.0.10" targetFramework="net481" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.10" targetFramework="net481" />
-  <package id="System.Formats.Asn1" version="10.0.10" targetFramework="net481" />
+  <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
+  <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.11" targetFramework="net481" />
+  <package id="System.Formats.Asn1" version="10.0.11" targetFramework="net481" />
   <package id="System.IO.FileSystem.AccessControl" version="5.0.0" targetFramework="net481" />
-  <package id="System.IO.Pipelines" version="10.0.10" targetFramework="net481" />
+  <package id="System.IO.Pipelines" version="10.0.11" targetFramework="net481" />
   <package id="System.Memory" version="4.6.3" targetFramework="net481" />
-  <package id="System.Memory.Data" version="10.0.10" targetFramework="net481" />
+  <package id="System.Memory.Data" version="10.0.11" targetFramework="net481" />
+  <package id="System.Net.ServerSentEvents" version="10.0.11" targetFramework="net481" />
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net481" />
-  <package id="System.Reflection.Metadata" version="10.0.10" targetFramework="net481" />
+  <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package
-    id="System.Security.Cryptography.ProtectedData"
-    version="10.0.10"
-    targetFramework="net481"
-  />
+  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
-  <package id="System.Text.Encodings.Web" version="10.0.10" targetFramework="net481" />
-  <package id="System.Text.Json" version="10.0.10" targetFramework="net481" />
+  <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
+  <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net481" />
   <package id="System.ValueTuple" version="4.6.2" targetFramework="net481" />
 </packages>

--- a/TaskVisualization/TaskVisualization.csproj
+++ b/TaskVisualization/TaskVisualization.csproj
@@ -147,11 +147,11 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
-    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
+    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
     <Analyzer Include="..\packages\AsyncFixer.2.1.0\analyzers\dotnet\cs\AsyncFixer.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />

--- a/TaskVisualization/TaskVisualization.csproj
+++ b/TaskVisualization/TaskVisualization.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" />
+  <Import Project="..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -148,7 +148,6 @@
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
     <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.31.0.145097\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
@@ -157,11 +156,12 @@
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\BannedSymbols.txt" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.32.0.713\analyzers\SonarAnalyzer.CSharp.dll" />
   </ItemGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props'))" />
   </Target>
 </Project>

--- a/TaskVisualization/app.config
+++ b/TaskVisualization/app.config
@@ -3,35 +3,19 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Buffers"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Tasks.Extensions"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Runtime.CompilerServices.Unsafe"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -43,28 +27,16 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Collections.Immutable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Channels"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.AsyncInterfaces"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="ExCSS" publicKeyToken="bdbe16be9b936b9a" culture="neutral" />
@@ -79,360 +51,188 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Newtonsoft.Json"
-          publicKeyToken="30ad4fe6b2a6aeed"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Graph.Core"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Diagnostics.DiagnosticSource"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Json"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encodings.Web"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.60.0.0" newVersion="1.60.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory.Data"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Vectors"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encoding.CodePages"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.ClientModel"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Net.Http.WinHttpHandler"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.IdentityModel.Tokens.Jwt"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Tokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Validators"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Text"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Form"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Multipart"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.TimeProvider"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Tensors"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Json"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Authentication.Azure"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Http.HttpClientLibrary"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Std.UriTemplate"
-          publicKeyToken="c118b0afb4598f9a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.HashCode"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Numerics"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reactive"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Formats.Asn1"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Hosting.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Diagnostics.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Primitives"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Linq.AsyncEnumerable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client.Extensions.Msal"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.Cryptography.ProtectedData"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.AccessControl"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Cryptography"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/TaskVisualization/app.config
+++ b/TaskVisualization/app.config
@@ -3,19 +3,35 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Buffers"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Tasks.Extensions"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Runtime.CompilerServices.Unsafe"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -27,15 +43,27 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Collections.Immutable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Channels"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.AsyncInterfaces"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -51,31 +79,59 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <assemblyIdentity
+          name="Newtonsoft.Json"
+          publicKeyToken="30ad4fe6b2a6aeed"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Graph.Core"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Diagnostics.DiagnosticSource"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Json"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encodings.Web"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -83,155 +139,307 @@
         <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory.Data"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Vectors"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encoding.CodePages"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="System.ClientModel"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.Http.WinHttpHandler"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="System.IdentityModel.Tokens.Jwt"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Tokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Validators"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Text"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Form"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Multipart"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.TimeProvider"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Tensors"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Json"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Authentication.Azure"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Http.HttpClientLibrary"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
+        <assemblyIdentity
+          name="Std.UriTemplate"
+          publicKeyToken="c118b0afb4598f9a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.HashCode"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Numerics"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reactive"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Formats.Asn1"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Hosting.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Diagnostics.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Primitives"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Linq.AsyncEnumerable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client.Extensions.Msal"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.Cryptography.ProtectedData"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.AccessControl"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Cryptography"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.ServerSentEvents"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>

--- a/TaskVisualization/packages.config
+++ b/TaskVisualization/packages.config
@@ -3,10 +3,30 @@
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
   <package id="log4net.Ext.Json" version="3.0.3" targetFramework="net481" />
-  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
-  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Meziantou.Analyzer"
+    version="3.0.156"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
+    version="5.6.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net481" />
-  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
-  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Roslynator.Analyzers"
+    version="4.16.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="SonarAnalyzer.CSharp"
+    version="10.32.0.713"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="System.Interactive" version="7.0.1" targetFramework="net481" />
 </packages>

--- a/TaskVisualization/packages.config
+++ b/TaskVisualization/packages.config
@@ -3,30 +3,10 @@
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
   <package id="log4net.Ext.Json" version="3.0.3" targetFramework="net481" />
-  <package
-    id="Meziantou.Analyzer"
-    version="3.0.138"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
-    version="5.6.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net481" />
-  <package
-    id="Roslynator.Analyzers"
-    version="4.15.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="SonarAnalyzer.CSharp"
-    version="10.31.0.145097"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
   <package id="System.Interactive" version="7.0.1" targetFramework="net481" />
 </packages>

--- a/ToDoModel.Test/ToDoModel.Test.csproj
+++ b/ToDoModel.Test/ToDoModel.Test.csproj
@@ -354,11 +354,11 @@
   <Import Project="..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets')" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
-    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
+    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
     <Analyzer Include="..\packages\AsyncFixer.2.1.0\analyzers\dotnet\cs\AsyncFixer.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />

--- a/ToDoModel.Test/ToDoModel.Test.csproj
+++ b/ToDoModel.Test/ToDoModel.Test.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" />
+  <Import Project="..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" />
   <Import Project="..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props')" />
   <Import Project="..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props" Condition="Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.props" Condition="Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.props')" />
@@ -83,8 +83,8 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Azure.Core, Version=1.60.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Azure.Core.1.60.0\lib\net472\Azure.Core.dll</HintPath>
+    <Reference Include="Azure.Core, Version=1.61.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Core.1.61.0\lib\net472\Azure.Core.dll</HintPath>
     </Reference>
     <Reference Include="Azure.Monitor.OpenTelemetry.Exporter, Version=1.8.3.0, Culture=neutral, PublicKeyToken=92742159e12e44c8">
       <HintPath>..\packages\Azure.Monitor.OpenTelemetry.Exporter.1.8.3\lib\netstandard2.0\Azure.Monitor.OpenTelemetry.Exporter.dll</HintPath>
@@ -105,55 +105,54 @@
     <Reference Include="Microsoft.ApplicationInsights, Version=3.1.2.115, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.3.1.2\lib\net462\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.10\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.10\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.11\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.10\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.11\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.10\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.11\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.10\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.11\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.10\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.11\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Identity.Client, Version=4.87.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae">
       <HintPath>..\packages\Microsoft.Identity.Client.4.87.0\lib\net472\Microsoft.Identity.Client.dll</HintPath>
@@ -186,16 +185,16 @@
       <HintPath>..\packages\Microsoft.Testing.Platform.2.3.3\lib\netstandard2.0\Microsoft.Testing.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.AdapterUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.18.8.1\lib\net462\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.18.9.0\lib\net462\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.PlatformAbstractions, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Reflection, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Reflection.2.0.0\lib\net40\Mono.Reflection.dll</HintPath>
@@ -234,43 +233,47 @@
     <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.ClientModel, Version=1.14.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ClientModel.1.14.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
+    <Reference Include="System.ClientModel, Version=1.15.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ClientModel.1.15.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.10.0.10\lib\net462\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.10.0.11\lib\net462\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.10\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.11\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Formats.Asn1, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Formats.Asn1.10.0.10\lib\net462\System.Formats.Asn1.dll</HintPath>
+    <Reference Include="System.Formats.Asn1, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Formats.Asn1.10.0.11\lib\net462\System.Formats.Asn1.dll</HintPath>
     </Reference>
     <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IO" />
     <Reference Include="System.IO.FileSystem.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.FileSystem.AccessControl.5.0.0\lib\net461\System.IO.FileSystem.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Pipelines, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Pipelines.10.0.10\lib\net462\System.IO.Pipelines.dll</HintPath>
+    <Reference Include="System.IO.Pipelines, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.10.0.11\lib\net462\System.IO.Pipelines.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="System.Memory.Data, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.Data.10.0.10\lib\net462\System.Memory.Data.dll</HintPath>
+    <Reference Include="System.Memory.Data, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.Data.10.0.11\lib\net462\System.Memory.Data.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.ServerSentEvents, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.ServerSentEvents.10.0.11\lib\net462\System.Net.ServerSentEvents.dll</HintPath>
+    </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.6.1\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.10.0.10\lib\net462\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.10.0.11\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -281,17 +284,17 @@
     <Reference Include="System.Security.AccessControl, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.AccessControl.6.0.1\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.10\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.11\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.10.0.10\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.10.0.11\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.10.0.10\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.10.0.11\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.3\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
@@ -325,6 +328,7 @@
   <ItemGroup>
     <Analyzer Include="..\packages\MSTest.Analyzers.4.3.3\analyzers\dotnet\cs\MSTest.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\MSTest.Analyzers.4.3.3\analyzers\dotnet\cs\MSTest.Analyzers.dll" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.32.0.713\analyzers\SonarAnalyzer.CSharp.dll" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -341,7 +345,7 @@
     <Error Condition="!Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets'))" />
-    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props'))" />
   </Target>
   <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.2.3.3\build\netstandard2.0\Microsoft.Testing.Platform.targets" Condition="Exists('..\packages\Microsoft.Testing.Platform.2.3.3\build\netstandard2.0\Microsoft.Testing.Platform.targets')" />
@@ -351,7 +355,6 @@
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
     <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.31.0.145097\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />

--- a/ToDoModel.Test/app.config
+++ b/ToDoModel.Test/app.config
@@ -3,35 +3,19 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Tasks.Extensions"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Buffers"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Runtime.CompilerServices.Unsafe"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -39,32 +23,20 @@
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.AsyncInterfaces"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Apache.Arrow" publicKeyToken="204f54e5a45c07df" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Collections.Immutable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Channels"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="ExCSS" publicKeyToken="bdbe16be9b936b9a" culture="neutral" />
@@ -79,472 +51,244 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Newtonsoft.Json"
-          publicKeyToken="30ad4fe6b2a6aeed"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Graph.Core"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Diagnostics.DiagnosticSource"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Json"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encodings.Web"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.60.0.0" newVersion="1.60.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory.Data"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Vectors"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encoding.CodePages"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.ClientModel"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Net.Http.WinHttpHandler"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.IdentityModel.Tokens.Jwt"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.JsonWebTokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Logging"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Tokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Validators"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Text"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Form"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Multipart"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.TimeProvider"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reflection.Metadata"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Tensors"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Json"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Authentication.Azure"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.ApplicationInsights"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Http.HttpClientLibrary"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Std.UriTemplate"
-          publicKeyToken="c118b0afb4598f9a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.HashCode"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Numerics"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Options"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Diagnostics.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Configuration"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Hosting.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Binder"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reactive"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Primitives"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Formats.Asn1"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Linq.AsyncEnumerable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="OpenTelemetry.PersistentStorage.Abstractions"
-          publicKeyToken="7bd6737fe5b67e3c"
-          culture="neutral"
-        />
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="OpenTelemetry.PersistentStorage.FileSystem"
-          publicKeyToken="7bd6737fe5b67e3c"
-          culture="neutral"
-        />
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client.Extensions.Msal"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.Cryptography.ProtectedData"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.AccessControl"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Azure.Monitor.OpenTelemetry.Exporter"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Cryptography"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/ToDoModel.Test/app.config
+++ b/ToDoModel.Test/app.config
@@ -3,19 +3,35 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Tasks.Extensions"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Buffers"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Runtime.CompilerServices.Unsafe"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -23,7 +39,11 @@
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.AsyncInterfaces"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -31,11 +51,19 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Collections.Immutable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Channels"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -51,31 +79,59 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <assemblyIdentity
+          name="Newtonsoft.Json"
+          publicKeyToken="30ad4fe6b2a6aeed"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Graph.Core"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Diagnostics.DiagnosticSource"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Json"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encodings.Web"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -83,211 +139,419 @@
         <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory.Data"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Vectors"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encoding.CodePages"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="System.ClientModel"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.Http.WinHttpHandler"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="System.IdentityModel.Tokens.Jwt"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.JsonWebTokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Logging"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Tokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Validators"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Text"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Form"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Multipart"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.TimeProvider"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reflection.Metadata"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Tensors"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Json"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Authentication.Azure"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.ApplicationInsights"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Http.HttpClientLibrary"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
+        <assemblyIdentity
+          name="Std.UriTemplate"
+          publicKeyToken="c118b0afb4598f9a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.HashCode"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Numerics"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Options"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Diagnostics.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Hosting.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Binder"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reactive"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Primitives"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Formats.Asn1"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Linq.AsyncEnumerable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.Abstractions"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.FileSystem"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client.Extensions.Msal"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.Cryptography.ProtectedData"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.AccessControl"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="Azure.Monitor.OpenTelemetry.Exporter"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Cryptography"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.ServerSentEvents"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>

--- a/ToDoModel.Test/packages.config
+++ b/ToDoModel.Test/packages.config
@@ -1,167 +1,71 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
-  <package id="Azure.Core" version="1.60.0" targetFramework="net481" />
+  <package id="Azure.Core" version="1.61.0" targetFramework="net481" />
   <package id="Azure.Monitor.OpenTelemetry.Exporter" version="1.8.3" targetFramework="net481" />
   <package id="Castle.Core" version="5.2.1" targetFramework="net481" />
   <package id="FluentAssertions" version="8.10.0" targetFramework="net481" />
-  <package
-    id="Meziantou.Analyzer"
-    version="3.0.138"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
-    version="5.6.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package id="Microsoft.Extensions.Configuration" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Configuration.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.Binder"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Diagnostics.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.FileProviders.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Hosting.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Logging" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Logging.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Logging.Configuration"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Options" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Options.ConfigurationExtensions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Primitives" version="10.0.10" targetFramework="net481" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package
-    id="Microsoft.Identity.Client.Extensions.Msal"
-    version="4.87.0"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package
-    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
-    version="2.3.3"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Testing.Extensions.VSTestBridge"
-    version="2.3.3"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
+  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.8.1" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="18.8.1" targetFramework="net481" />
+  <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.9.0" targetFramework="net481" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
   <package id="Mono.Reflection" version="2.0.0" targetFramework="net481" />
   <package id="Moq" version="4.20.72" targetFramework="net481" />
-  <package
-    id="MSTest.Analyzers"
-    version="4.3.3"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.Api.ProviderBuilderExtensions"
-    version="1.17.0"
-    targetFramework="net481"
-  />
+  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.PersistentStorage.Abstractions"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="OpenTelemetry.PersistentStorage.FileSystem"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="Roslynator.Analyzers"
-    version="4.15.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="SonarAnalyzer.CSharp"
-    version="10.31.0.145097"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
+  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
+  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
-  <package id="System.ClientModel" version="1.14.0" targetFramework="net481" />
-  <package id="System.Collections.Immutable" version="10.0.10" targetFramework="net481" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.10" targetFramework="net481" />
-  <package id="System.Formats.Asn1" version="10.0.10" targetFramework="net481" />
+  <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
+  <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.11" targetFramework="net481" />
+  <package id="System.Formats.Asn1" version="10.0.11" targetFramework="net481" />
   <package id="System.IO.FileSystem.AccessControl" version="5.0.0" targetFramework="net481" />
-  <package id="System.IO.Pipelines" version="10.0.10" targetFramework="net481" />
+  <package id="System.IO.Pipelines" version="10.0.11" targetFramework="net481" />
   <package id="System.Memory" version="4.6.3" targetFramework="net481" />
-  <package id="System.Memory.Data" version="10.0.10" targetFramework="net481" />
+  <package id="System.Memory.Data" version="10.0.11" targetFramework="net481" />
+  <package id="System.Net.ServerSentEvents" version="10.0.11" targetFramework="net481" />
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net481" />
-  <package id="System.Reflection.Metadata" version="10.0.10" targetFramework="net481" />
+  <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package
-    id="System.Security.Cryptography.ProtectedData"
-    version="10.0.10"
-    targetFramework="net481"
-  />
+  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
-  <package id="System.Text.Encodings.Web" version="10.0.10" targetFramework="net481" />
-  <package id="System.Text.Json" version="10.0.10" targetFramework="net481" />
+  <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
+  <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net481" />
   <package id="System.ValueTuple" version="4.6.2" targetFramework="net481" />
 </packages>

--- a/ToDoModel.Test/packages.config
+++ b/ToDoModel.Test/packages.config
@@ -5,49 +5,142 @@
   <package id="Azure.Monitor.OpenTelemetry.Exporter" version="1.8.3" targetFramework="net481" />
   <package id="Castle.Core" version="5.2.1" targetFramework="net481" />
   <package id="FluentAssertions" version="8.10.0" targetFramework="net481" />
-  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Meziantou.Analyzer"
+    version="3.0.156"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
+    version="5.6.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Configuration.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.Binder"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Diagnostics.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.FileProviders.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Hosting.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Logging.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Logging.Configuration"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Options.ConfigurationExtensions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
+  <package
+    id="Microsoft.Identity.Client.Extensions.Msal"
+    version="4.87.0"
+    targetFramework="net481"
+  />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
+  <package
+    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
+    version="2.3.3"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Testing.Extensions.VSTestBridge"
+    version="2.3.3"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.9.0" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
   <package id="Mono.Reflection" version="2.0.0" targetFramework="net481" />
   <package id="Moq" version="4.20.72" targetFramework="net481" />
-  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="MSTest.Analyzers"
+    version="4.3.3"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
+  <package
+    id="OpenTelemetry.Api.ProviderBuilderExtensions"
+    version="1.17.0"
+    targetFramework="net481"
+  />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
-  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
-  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="OpenTelemetry.PersistentStorage.Abstractions"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="OpenTelemetry.PersistentStorage.FileSystem"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="Roslynator.Analyzers"
+    version="4.16.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="SonarAnalyzer.CSharp"
+    version="10.32.0.713"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
   <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
   <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
@@ -62,7 +155,11 @@
   <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
+  <package
+    id="System.Security.Cryptography.ProtectedData"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
   <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
   <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />

--- a/ToDoModel/ToDoModel.csproj
+++ b/ToDoModel/ToDoModel.csproj
@@ -186,11 +186,11 @@
   </Target>
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
-    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
+    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
     <Analyzer Include="..\packages\AsyncFixer.2.1.0\analyzers\dotnet\cs\AsyncFixer.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />

--- a/ToDoModel/ToDoModel.csproj
+++ b/ToDoModel/ToDoModel.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" />
+  <Import Project="..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -47,13 +47,11 @@
     <Reference Include="log4net.Ext.Json, Version=3.0.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.Ext.Json.3.0.3\lib\net462\log4net.Ext.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.10\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.Memory, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\Microsoft.Bcl.Memory.10.0.10\lib\net462\Microsoft.Bcl.Memory.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Bcl.Memory, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Memory.10.0.11\lib\net462\Microsoft.Bcl.Memory.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Office.Interop.Outlook, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
       <EmbedInteropTypes>False</EmbedInteropTypes>
@@ -184,12 +182,11 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets'))" />
     <Error Condition="!Exists('..\packages\System.Reactive.7.0.0\build\System.Reactive.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Reactive.7.0.0\build\System.Reactive.targets'))" />
-    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props'))" />
   </Target>
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
     <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.31.0.145097\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
@@ -198,6 +195,7 @@
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\BannedSymbols.txt" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.32.0.713\analyzers\SonarAnalyzer.CSharp.dll" />
   </ItemGroup>
   <Import Project="..\packages\System.Reactive.7.0.0\build\System.Reactive.targets" Condition="Exists('..\packages\System.Reactive.7.0.0\build\System.Reactive.targets')" />
 </Project>

--- a/ToDoModel/app.config
+++ b/ToDoModel/app.config
@@ -1,50 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <sectionGroup
-      name="userSettings"
-      type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-    >
-      <section
-        name="ToDoModel.Properties.Settings"
-        type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-        allowExeDefinition="MachineToLocalUser"
-        requirePermission="false"
-      />
+    <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <section name="ToDoModel.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
     </sectionGroup>
   </configSections>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Runtime.CompilerServices.Unsafe"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Buffers"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Tasks.Extensions"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -52,32 +28,20 @@
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.AsyncInterfaces"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Apache.Arrow" publicKeyToken="204f54e5a45c07df" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Collections.Immutable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Channels"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="ExCSS" publicKeyToken="bdbe16be9b936b9a" culture="neutral" />
@@ -92,360 +56,188 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Newtonsoft.Json"
-          publicKeyToken="30ad4fe6b2a6aeed"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Graph.Core"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Diagnostics.DiagnosticSource"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Json"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encodings.Web"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.60.0.0" newVersion="1.60.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory.Data"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Vectors"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encoding.CodePages"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.ClientModel"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Net.Http.WinHttpHandler"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.IdentityModel.Tokens.Jwt"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Tokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Validators"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Text"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Form"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Multipart"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.TimeProvider"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Tensors"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Json"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Authentication.Azure"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Http.HttpClientLibrary"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="Std.UriTemplate"
-          publicKeyToken="c118b0afb4598f9a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.HashCode"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Numerics"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reactive"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Formats.Asn1"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Hosting.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Diagnostics.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Primitives"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Linq.AsyncEnumerable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client.Extensions.Msal"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.Cryptography.ProtectedData"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.AccessControl"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Cryptography"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/ToDoModel/app.config
+++ b/ToDoModel/app.config
@@ -1,26 +1,50 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <section name="ToDoModel.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+    <sectionGroup
+      name="userSettings"
+      type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+    >
+      <section
+        name="ToDoModel.Properties.Settings"
+        type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+        allowExeDefinition="MachineToLocalUser"
+        requirePermission="false"
+      />
     </sectionGroup>
   </configSections>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Runtime.CompilerServices.Unsafe"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Buffers"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Tasks.Extensions"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -28,7 +52,11 @@
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.AsyncInterfaces"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -36,11 +64,19 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Collections.Immutable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Channels"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -56,31 +92,59 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <assemblyIdentity
+          name="Newtonsoft.Json"
+          publicKeyToken="30ad4fe6b2a6aeed"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Graph.Core"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Diagnostics.DiagnosticSource"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Json"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encodings.Web"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -88,155 +152,307 @@
         <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory.Data"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Vectors"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encoding.CodePages"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="System.ClientModel"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.Http.WinHttpHandler"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="System.IdentityModel.Tokens.Jwt"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Tokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Validators"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Text"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Form"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Multipart"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.TimeProvider"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Tensors"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Json"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Authentication.Azure"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Http.HttpClientLibrary"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
+        <assemblyIdentity
+          name="Std.UriTemplate"
+          publicKeyToken="c118b0afb4598f9a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.HashCode"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Numerics"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reactive"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Formats.Asn1"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Hosting.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Diagnostics.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Primitives"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Linq.AsyncEnumerable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client.Extensions.Msal"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.Cryptography.ProtectedData"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.AccessControl"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Cryptography"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.ServerSentEvents"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>

--- a/ToDoModel/packages.config
+++ b/ToDoModel/packages.config
@@ -5,35 +5,15 @@
   <package id="FSharp.Core" version="11.0.100" targetFramework="net481" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
   <package id="log4net.Ext.Json" version="3.0.3" targetFramework="net481" />
-  <package
-    id="Meziantou.Analyzer"
-    version="3.0.138"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.10" targetFramework="net481" />
-  <package id="Microsoft.Bcl.Memory" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
-    version="5.6.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Bcl.Memory" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
   <package id="Mono.Reflection" version="2.0.0" targetFramework="net481" />
   <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net481" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net481" />
-  <package
-    id="Roslynator.Analyzers"
-    version="4.15.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="SonarAnalyzer.CSharp"
-    version="10.31.0.145097"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
   <package id="System.Interactive" version="7.0.1" targetFramework="net481" />
   <package id="System.Interactive.Async" version="7.0.1" targetFramework="net481" />

--- a/ToDoModel/packages.config
+++ b/ToDoModel/packages.config
@@ -5,15 +5,35 @@
   <package id="FSharp.Core" version="11.0.100" targetFramework="net481" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
   <package id="log4net.Ext.Json" version="3.0.3" targetFramework="net481" />
-  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Meziantou.Analyzer"
+    version="3.0.156"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Bcl.Memory" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
+    version="5.6.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Mono.Reflection" version="2.0.0" targetFramework="net481" />
   <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net481" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net481" />
-  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
-  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Roslynator.Analyzers"
+    version="4.16.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="SonarAnalyzer.CSharp"
+    version="10.32.0.713"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
   <package id="System.Interactive" version="7.0.1" targetFramework="net481" />
   <package id="System.Interactive.Async" version="7.0.1" targetFramework="net481" />

--- a/UtilitiesCS.Test/Extensions/AsyncSerialization_Tests.cs
+++ b/UtilitiesCS.Test/Extensions/AsyncSerialization_Tests.cs
@@ -427,23 +427,41 @@ namespace UtilitiesCS.Test.Extensions
             jobName.Should().Contain("Copy");
         }
 
+        /// <summary>
+        /// Locates the multi-megabyte Microsoft.Graph XML documentation file used as a
+        /// read-only large-file fixture. The package version is discovered rather than
+        /// hard-coded so that a NuGet upgrade does not break these tests.
+        /// </summary>
         private static FileInfo GetLargeTextFixture()
         {
             var current = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
 
             while (current is not null)
             {
-                var candidate = Path.Combine(
-                    current.FullName,
-                    "packages",
-                    "Microsoft.Graph.6.2.0",
-                    "lib",
-                    "netstandard2.0",
-                    "Microsoft.Graph.xml"
-                );
-                if (File.Exists(candidate))
+                var packages = new DirectoryInfo(Path.Combine(current.FullName, "packages"));
+                if (packages.Exists)
                 {
-                    return new FileInfo(candidate);
+                    // Ordinal sort keeps selection deterministic when several versions of the
+                    // package are present in the shared packages folder.
+                    var versionDirectories = packages.GetDirectories("Microsoft.Graph.*");
+                    Array.Sort(
+                        versionDirectories,
+                        (left, right) => string.CompareOrdinal(left.Name, right.Name)
+                    );
+
+                    foreach (var versionDirectory in versionDirectories)
+                    {
+                        var candidate = Path.Combine(
+                            versionDirectory.FullName,
+                            "lib",
+                            "netstandard2.0",
+                            "Microsoft.Graph.xml"
+                        );
+                        if (File.Exists(candidate))
+                        {
+                            return new FileInfo(candidate);
+                        }
+                    }
                 }
 
                 current = current.Parent;

--- a/UtilitiesCS.Test/UtilitiesCS.Test.csproj
+++ b/UtilitiesCS.Test/UtilitiesCS.Test.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" />
+  <Import Project="..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" />
   <Import Project="..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props')" />
   <Import Project="..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props" Condition="Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.props" Condition="Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.props')" />
@@ -546,8 +546,8 @@
     <None Include="Resources\EmailHtmlBodyWithDownloadableLinks.html" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Azure.Core, Version=1.60.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Azure.Core.1.60.0\lib\net472\Azure.Core.dll</HintPath>
+    <Reference Include="Azure.Core, Version=1.61.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Core.1.61.0\lib\net472\Azure.Core.dll</HintPath>
     </Reference>
     <Reference Include="Azure.Monitor.OpenTelemetry.Exporter, Version=1.8.3.0, Culture=neutral, PublicKeyToken=92742159e12e44c8">
       <HintPath>..\packages\Azure.Monitor.OpenTelemetry.Exporter.1.8.3\lib\netstandard2.0\Azure.Monitor.OpenTelemetry.Exporter.dll</HintPath>
@@ -574,78 +574,75 @@
     <Reference Include="Microsoft.ApplicationInsights, Version=3.1.2.115, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.3.1.2\lib\net462\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.10\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.Cryptography, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.Cryptography.10.0.10\lib\net462\Microsoft.Bcl.Cryptography.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.Cryptography, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Cryptography.10.0.11\lib\net462\Microsoft.Bcl.Cryptography.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.HashCode, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.HashCode.6.0.0\lib\net462\Microsoft.Bcl.HashCode.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.Memory, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\Microsoft.Bcl.Memory.10.0.10\lib\net462\Microsoft.Bcl.Memory.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Bcl.Memory, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Memory.10.0.11\lib\net462\Microsoft.Bcl.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.TimeProvider, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.TimeProvider.10.0.10\lib\net462\Microsoft.Bcl.TimeProvider.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.TimeProvider, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.TimeProvider.10.0.11\lib\net462\Microsoft.Bcl.TimeProvider.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Analysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.Analysis.0.23.0\lib\netstandard2.0\Microsoft.Data.Analysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.10\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.11\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.10\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.11\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.10\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.11\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.10\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.11\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.10\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.11\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.TimeProvider.Testing, Version=10.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.TimeProvider.Testing.10.8.0\lib\net462\Microsoft.Extensions.TimeProvider.Testing.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.TimeProvider.Testing, Version=10.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.TimeProvider.Testing.10.9.0\lib\net462\Microsoft.Extensions.TimeProvider.Testing.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Graph, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Graph.6.2.0\lib\netstandard2.0\Microsoft.Graph.dll</HintPath>
+    <Reference Include="Microsoft.Graph, Version=6.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Graph.6.5.0\lib\netstandard2.0\Microsoft.Graph.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Graph.Core, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Graph.Core.4.0.1\lib\net462\Microsoft.Graph.Core.dll</HintPath>
@@ -739,16 +736,16 @@
       <HintPath>..\packages\Microsoft.Testing.Platform.2.3.3\lib\netstandard2.0\Microsoft.Testing.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.AdapterUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.18.8.1\lib\net462\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.18.9.0\lib\net462\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.PlatformAbstractions, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="MSTest.TestFramework, Version=4.3.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.4.3.3\lib\net462\MSTest.TestFramework.dll</HintPath>
@@ -802,24 +799,24 @@
     <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.ClientModel, Version=1.14.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ClientModel.1.14.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
+    <Reference Include="System.ClientModel, Version=1.15.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ClientModel.1.15.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.10.0.10\lib\net462\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.10.0.11\lib\net462\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.10\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.11\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Drawing.Design" />
-    <Reference Include="System.Formats.Asn1, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Formats.Asn1.10.0.10\lib\net462\System.Formats.Asn1.dll</HintPath>
+    <Reference Include="System.Formats.Asn1, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Formats.Asn1.10.0.11\lib\net462\System.Formats.Asn1.dll</HintPath>
     </Reference>
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.IdentityModel.Tokens.Jwt, Version=8.22.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
@@ -832,11 +829,12 @@
     <Reference Include="System.Interactive.Async, Version=7.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Interactive.Async.7.0.1\lib\net48\System.Interactive.Async.dll</HintPath>
     </Reference>
+    <Reference Include="System.IO" />
     <Reference Include="System.IO.FileSystem.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.FileSystem.AccessControl.5.0.0\lib\net461\System.IO.FileSystem.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Pipelines, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Pipelines.10.0.10\lib\net462\System.IO.Pipelines.dll</HintPath>
+    <Reference Include="System.IO.Pipelines, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.10.0.11\lib\net462\System.IO.Pipelines.dll</HintPath>
     </Reference>
     <Reference Include="System.Linq, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Linq.4.3.0\lib\net463\System.Linq.dll</HintPath>
@@ -849,12 +847,15 @@
     <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="System.Memory.Data, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.Data.10.0.10\lib\net462\System.Memory.Data.dll</HintPath>
+    <Reference Include="System.Memory.Data, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.Data.10.0.11\lib\net462\System.Memory.Data.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.WinHttpHandler, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Net.Http.WinHttpHandler.10.0.10\lib\net462\System.Net.Http.WinHttpHandler.dll</HintPath>
+    <Reference Include="System.Net.Http.WinHttpHandler, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.WinHttpHandler.10.0.11\lib\net462\System.Net.Http.WinHttpHandler.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.ServerSentEvents, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.ServerSentEvents.10.0.11\lib\net462\System.Net.ServerSentEvents.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -866,8 +867,8 @@
     <Reference Include="System.Reactive.Async, Version=6.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reactive.Async.6.0.0-alpha.18\lib\netstandard2.0\System.Reactive.Async.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.10.0.10\lib\net462\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.10.0.11\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -879,21 +880,20 @@
       <HintPath>..\packages\System.Security.AccessControl.6.0.1\lib\net461\System.Security.AccessControl.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.10\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.11\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encoding.CodePages, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encoding.CodePages.10.0.10\lib\net462\System.Text.Encoding.CodePages.dll</HintPath>
+    <Reference Include="System.Text.Encoding.CodePages, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encoding.CodePages.10.0.11\lib\net462\System.Text.Encoding.CodePages.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.10.0.10\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.10.0.11\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.10.0.10\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.10.0.11\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.3\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
@@ -930,6 +930,7 @@
   <ItemGroup>
     <Analyzer Include="..\packages\MSTest.Analyzers.4.3.3\analyzers\dotnet\cs\MSTest.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\MSTest.Analyzers.4.3.3\analyzers\dotnet\cs\MSTest.Analyzers.dll" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.32.0.713\analyzers\SonarAnalyzer.CSharp.dll" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -947,7 +948,7 @@
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets'))" />
     <Error Condition="!Exists('..\packages\System.Reactive.7.0.0\build\System.Reactive.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Reactive.7.0.0\build\System.Reactive.targets'))" />
-    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props'))" />
   </Target>
   <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.2.3.3\build\netstandard2.0\Microsoft.Testing.Platform.targets" Condition="Exists('..\packages\Microsoft.Testing.Platform.2.3.3\build\netstandard2.0\Microsoft.Testing.Platform.targets')" />
@@ -957,7 +958,6 @@
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
     <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.31.0.145097\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />

--- a/UtilitiesCS.Test/UtilitiesCS.Test.csproj
+++ b/UtilitiesCS.Test/UtilitiesCS.Test.csproj
@@ -957,11 +957,11 @@
   <Import Project="..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets')" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
-    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
+    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
     <Analyzer Include="..\packages\AsyncFixer.2.1.0\analyzers\dotnet\cs\AsyncFixer.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />

--- a/UtilitiesCS.Test/app.config
+++ b/UtilitiesCS.Test/app.config
@@ -3,35 +3,19 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Buffers"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Runtime.CompilerServices.Unsafe"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Tasks.Extensions"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -43,28 +27,16 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Collections.Immutable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Channels"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.AsyncInterfaces"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="ExCSS" publicKeyToken="bdbe16be9b936b9a" culture="neutral" />
@@ -79,504 +51,260 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Newtonsoft.Json"
-          publicKeyToken="30ad4fe6b2a6aeed"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Graph.Core"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Diagnostics.DiagnosticSource"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Json"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encodings.Web"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.60.0.0" newVersion="1.60.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory.Data"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Vectors"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Tokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.IdentityModel.Tokens.Jwt"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.JsonWebTokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Logging"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.ClientModel"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Net.Http.WinHttpHandler"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Validators"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Text"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Form"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Multipart"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.TimeProvider"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Tensors"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reflection.Metadata"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Json"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Authentication.Azure"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Http.HttpClientLibrary"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="Std.UriTemplate"
-          publicKeyToken="c118b0afb4598f9a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.ApplicationInsights"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.HashCode"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Numerics"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Options"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Diagnostics.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Configuration"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Hosting.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Binder"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reactive"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Formats.Asn1"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Primitives"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Linq.AsyncEnumerable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Interactive"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Interactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Interactive.Async"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Interactive.Async" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Linq.Async"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Linq.Async" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encoding.CodePages"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="OpenTelemetry.PersistentStorage.Abstractions"
-          publicKeyToken="7bd6737fe5b67e3c"
-          culture="neutral"
-        />
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="OpenTelemetry.PersistentStorage.FileSystem"
-          publicKeyToken="7bd6737fe5b67e3c"
-          culture="neutral"
-        />
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Web.WebView2.Core"
-          publicKeyToken="2a8ab48044d2601e"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Web.WebView2.Core" publicKeyToken="2a8ab48044d2601e" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.0.4078.44" newVersion="1.0.4078.44" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client.Extensions.Msal"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.Cryptography.ProtectedData"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.AccessControl"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Azure.Monitor.OpenTelemetry.Exporter"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Cryptography"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/UtilitiesCS.Test/app.config
+++ b/UtilitiesCS.Test/app.config
@@ -3,19 +3,35 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Buffers"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Runtime.CompilerServices.Unsafe"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Tasks.Extensions"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -27,15 +43,27 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Collections.Immutable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Channels"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.AsyncInterfaces"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -51,31 +79,59 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <assemblyIdentity
+          name="Newtonsoft.Json"
+          publicKeyToken="30ad4fe6b2a6aeed"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Graph.Core"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Diagnostics.DiagnosticSource"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Json"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encodings.Web"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -83,227 +139,451 @@
         <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory.Data"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Vectors"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Tokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="System.IdentityModel.Tokens.Jwt"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.JsonWebTokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Logging"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="System.ClientModel"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.Http.WinHttpHandler"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Validators"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Text"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Form"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Multipart"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.TimeProvider"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Tensors"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reflection.Metadata"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Json"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Authentication.Azure"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Http.HttpClientLibrary"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
+        <assemblyIdentity
+          name="Std.UriTemplate"
+          publicKeyToken="c118b0afb4598f9a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.ApplicationInsights"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.HashCode"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Numerics"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Options"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Diagnostics.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Hosting.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Binder"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reactive"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Formats.Asn1"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Primitives"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Linq.AsyncEnumerable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Interactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Interactive"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Interactive.Async" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Interactive.Async"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Linq.Async" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Linq.Async"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encoding.CodePages"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.Abstractions"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.FileSystem"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Web.WebView2.Core" publicKeyToken="2a8ab48044d2601e" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Web.WebView2.Core"
+          publicKeyToken="2a8ab48044d2601e"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.0.4078.44" newVersion="1.0.4078.44" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client.Extensions.Msal"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.Cryptography.ProtectedData"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.AccessControl"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="Azure.Monitor.OpenTelemetry.Exporter"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Cryptography"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.ServerSentEvents"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>

--- a/UtilitiesCS.Test/packages.config
+++ b/UtilitiesCS.Test/packages.config
@@ -9,40 +9,106 @@
   <package id="FluentAssertions" version="8.10.0" targetFramework="net481" />
   <package id="FSharp.Core" version="11.0.100" targetFramework="net481" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
-  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Meziantou.Analyzer"
+    version="3.0.156"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Bcl.Cryptography" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Bcl.HashCode" version="6.0.0" targetFramework="net481" />
   <package id="Microsoft.Bcl.Memory" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Bcl.TimeProvider" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
+    version="5.6.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.Data.Analysis" version="0.23.0" targetFramework="net481" />
   <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Configuration.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.Binder"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Diagnostics.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.FileProviders.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Hosting.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Logging.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Logging.Configuration"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Options.ConfigurationExtensions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.TimeProvider.Testing" version="10.9.0" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.TimeProvider.Testing"
+    version="10.9.0"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Graph" version="6.5.0" targetFramework="net481" />
   <package id="Microsoft.Graph.Core" version="4.0.1" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
+  <package
+    id="Microsoft.Identity.Client.Extensions.Msal"
+    version="4.87.0"
+    targetFramework="net481"
+  />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.JsonWebTokens" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Logging" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Protocols" version="8.22.0" targetFramework="net481" />
-  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="8.22.0" targetFramework="net481" />
+  <package
+    id="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+    version="8.22.0"
+    targetFramework="net481"
+  />
   <package id="Microsoft.IdentityModel.Tokens" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Validators" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IO.RecyclableMemoryStream" version="3.0.1" targetFramework="net481" />
@@ -55,27 +121,62 @@
   <package id="Microsoft.Kiota.Serialization.Text" version="2.0.0" targetFramework="net481" />
   <package id="Microsoft.ML.DataView" version="5.0.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
+  <package
+    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
+    version="2.3.3"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Testing.Extensions.VSTestBridge"
+    version="2.3.3"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.9.0" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
   <package id="Mono.Reflection" version="2.0.0" targetFramework="net481" />
   <package id="Moq" version="4.20.72" targetFramework="net481" />
-  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="MSTest.Analyzers"
+    version="4.3.3"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net481" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
+  <package
+    id="OpenTelemetry.Api.ProviderBuilderExtensions"
+    version="1.17.0"
+    targetFramework="net481"
+  />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
-  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
-  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="OpenTelemetry.PersistentStorage.Abstractions"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="OpenTelemetry.PersistentStorage.FileSystem"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="Roslynator.Analyzers"
+    version="4.16.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="SonarAnalyzer.CSharp"
+    version="10.32.0.713"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Std.UriTemplate" version="2.0.12" targetFramework="net481" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
   <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
@@ -99,7 +200,11 @@
   <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
+  <package
+    id="System.Security.Cryptography.ProtectedData"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
   <package id="System.Text.Encoding.CodePages" version="10.0.11" targetFramework="net481" />
   <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />

--- a/UtilitiesCS.Test/packages.config
+++ b/UtilitiesCS.Test/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
-  <package id="Azure.Core" version="1.60.0" targetFramework="net481" />
+  <package id="Azure.Core" version="1.61.0" targetFramework="net481" />
   <package id="Azure.Monitor.OpenTelemetry.Exporter" version="1.8.3" targetFramework="net481" />
   <package id="C.math.NET" version="1.1" targetFramework="net481" />
   <package id="Castle.Core" version="5.2.1" targetFramework="net481" />
@@ -9,106 +9,40 @@
   <package id="FluentAssertions" version="8.10.0" targetFramework="net481" />
   <package id="FSharp.Core" version="11.0.100" targetFramework="net481" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
-  <package
-    id="Meziantou.Analyzer"
-    version="3.0.138"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.10" targetFramework="net481" />
-  <package id="Microsoft.Bcl.Cryptography" version="10.0.10" targetFramework="net481" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Bcl.Cryptography" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Bcl.HashCode" version="6.0.0" targetFramework="net481" />
-  <package id="Microsoft.Bcl.Memory" version="10.0.10" targetFramework="net481" />
-  <package id="Microsoft.Bcl.TimeProvider" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
-    version="5.6.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Microsoft.Bcl.Memory" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Bcl.TimeProvider" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
   <package id="Microsoft.Data.Analysis" version="0.23.0" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Configuration.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.Binder"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Diagnostics.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.FileProviders.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Hosting.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Logging" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Logging.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Logging.Configuration"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Options" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Options.ConfigurationExtensions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Primitives" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.TimeProvider.Testing"
-    version="10.8.0"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Graph" version="6.2.0" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.TimeProvider.Testing" version="10.9.0" targetFramework="net481" />
+  <package id="Microsoft.Graph" version="6.5.0" targetFramework="net481" />
   <package id="Microsoft.Graph.Core" version="4.0.1" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package
-    id="Microsoft.Identity.Client.Extensions.Msal"
-    version="4.87.0"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.JsonWebTokens" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Logging" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Protocols" version="8.22.0" targetFramework="net481" />
-  <package
-    id="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-    version="8.22.0"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Tokens" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Validators" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IO.RecyclableMemoryStream" version="3.0.1" targetFramework="net481" />
@@ -121,93 +55,55 @@
   <package id="Microsoft.Kiota.Serialization.Text" version="2.0.0" targetFramework="net481" />
   <package id="Microsoft.ML.DataView" version="5.0.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package
-    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
-    version="2.3.3"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Testing.Extensions.VSTestBridge"
-    version="2.3.3"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
+  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.8.1" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="18.8.1" targetFramework="net481" />
+  <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.9.0" targetFramework="net481" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
   <package id="Mono.Reflection" version="2.0.0" targetFramework="net481" />
   <package id="Moq" version="4.20.72" targetFramework="net481" />
-  <package
-    id="MSTest.Analyzers"
-    version="4.3.3"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net481" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.Api.ProviderBuilderExtensions"
-    version="1.17.0"
-    targetFramework="net481"
-  />
+  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.PersistentStorage.Abstractions"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="OpenTelemetry.PersistentStorage.FileSystem"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="Roslynator.Analyzers"
-    version="4.15.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="SonarAnalyzer.CSharp"
-    version="10.31.0.145097"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
+  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
+  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
   <package id="Std.UriTemplate" version="2.0.12" targetFramework="net481" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
-  <package id="System.ClientModel" version="1.14.0" targetFramework="net481" />
-  <package id="System.Collections.Immutable" version="10.0.10" targetFramework="net481" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.10" targetFramework="net481" />
-  <package id="System.Formats.Asn1" version="10.0.10" targetFramework="net481" />
+  <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
+  <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.11" targetFramework="net481" />
+  <package id="System.Formats.Asn1" version="10.0.11" targetFramework="net481" />
   <package id="System.IdentityModel.Tokens.Jwt" version="8.22.0" targetFramework="net481" />
   <package id="System.Interactive" version="7.0.1" targetFramework="net481" />
   <package id="System.Interactive.Async" version="7.0.1" targetFramework="net481" />
   <package id="System.IO.FileSystem.AccessControl" version="5.0.0" targetFramework="net481" />
-  <package id="System.IO.Pipelines" version="10.0.10" targetFramework="net481" />
+  <package id="System.IO.Pipelines" version="10.0.11" targetFramework="net481" />
   <package id="System.Linq" version="4.3.0" targetFramework="net481" />
   <package id="System.Linq.Async" version="7.0.1" targetFramework="net481" />
   <package id="System.Memory" version="4.6.3" targetFramework="net481" />
-  <package id="System.Memory.Data" version="10.0.10" targetFramework="net481" />
-  <package id="System.Net.Http.WinHttpHandler" version="10.0.10" targetFramework="net481" />
+  <package id="System.Memory.Data" version="10.0.11" targetFramework="net481" />
+  <package id="System.Net.Http.WinHttpHandler" version="10.0.11" targetFramework="net481" />
+  <package id="System.Net.ServerSentEvents" version="10.0.11" targetFramework="net481" />
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net481" />
   <package id="System.Reactive" version="7.0.0" targetFramework="net481" />
   <package id="System.Reactive.Async" version="6.0.0-alpha.18" targetFramework="net481" />
-  <package id="System.Reflection.Metadata" version="10.0.10" targetFramework="net481" />
+  <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package
-    id="System.Security.Cryptography.ProtectedData"
-    version="10.0.10"
-    targetFramework="net481"
-  />
+  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
-  <package id="System.Text.Encoding.CodePages" version="10.0.10" targetFramework="net481" />
-  <package id="System.Text.Encodings.Web" version="10.0.10" targetFramework="net481" />
-  <package id="System.Text.Json" version="10.0.10" targetFramework="net481" />
+  <package id="System.Text.Encoding.CodePages" version="10.0.11" targetFramework="net481" />
+  <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
+  <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net481" />
   <package id="System.ValueTuple" version="4.6.2" targetFramework="net481" />
 </packages>

--- a/UtilitiesCS/UtilitiesCS.csproj
+++ b/UtilitiesCS/UtilitiesCS.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" />
+  <Import Project="..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" />
   <Import Project="..\packages\Microsoft.ML.5.0.0\build\netstandard2.0\Microsoft.ML.props" Condition="Exists('..\packages\Microsoft.ML.5.0.0\build\netstandard2.0\Microsoft.ML.props')" />
   <Import Project="..\packages\Microsoft.ML.CpuMath.5.0.0\build\netstandard2.0\Microsoft.ML.CpuMath.props" Condition="Exists('..\packages\Microsoft.ML.CpuMath.5.0.0\build\netstandard2.0\Microsoft.ML.CpuMath.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -38,8 +38,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AngleSharp, Version=1.7.0.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
-      <HintPath>..\packages\AngleSharp.1.7.0\lib\net472\AngleSharp.dll</HintPath>
+    <Reference Include="AngleSharp, Version=1.7.1.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
+      <HintPath>..\packages\AngleSharp.1.7.1\lib\net472\AngleSharp.dll</HintPath>
     </Reference>
     <Reference Include="Apache.Arrow, Version=23.0.0.0, Culture=neutral, PublicKeyToken=204f54e5a45c07df, processorArchitecture=MSIL">
       <HintPath>..\packages\Apache.Arrow.23.0.0\lib\net462\Apache.Arrow.dll</HintPath>
@@ -47,8 +47,8 @@
     <Reference Include="Apache.Arrow.Scalars, Version=23.0.0.0, Culture=neutral, PublicKeyToken=204f54e5a45c07df, processorArchitecture=MSIL">
       <HintPath>..\packages\Apache.Arrow.Scalars.23.0.0\lib\net462\Apache.Arrow.Scalars.dll</HintPath>
     </Reference>
-    <Reference Include="Azure.Core, Version=1.60.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Azure.Core.1.60.0\lib\net472\Azure.Core.dll</HintPath>
+    <Reference Include="Azure.Core, Version=1.61.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Core.1.61.0\lib\net472\Azure.Core.dll</HintPath>
     </Reference>
     <Reference Include="C.math, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\C.math.NET.1.1\lib\net20\C.math.dll</HintPath>
@@ -78,57 +78,55 @@
     <Reference Include="log4net.Ext.Json, Version=3.0.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.Ext.Json.3.0.3\lib\net462\log4net.Ext.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.10\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.Cryptography, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.Cryptography.10.0.10\lib\net462\Microsoft.Bcl.Cryptography.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.Cryptography, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Cryptography.10.0.11\lib\net462\Microsoft.Bcl.Cryptography.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.HashCode, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.HashCode.6.0.0\lib\net462\Microsoft.Bcl.HashCode.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.Memory, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\packages\Microsoft.Bcl.Memory.10.0.10\lib\net462\Microsoft.Bcl.Memory.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Bcl.Memory, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Memory.10.0.11\lib\net462\Microsoft.Bcl.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.Numerics, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.Numerics.10.0.10\lib\net462\Microsoft.Bcl.Numerics.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.Numerics, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Numerics.10.0.11\lib\net462\Microsoft.Bcl.Numerics.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.TimeProvider, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.TimeProvider.10.0.10\lib\net462\Microsoft.Bcl.TimeProvider.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.TimeProvider, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.TimeProvider.10.0.11\lib\net462\Microsoft.Bcl.TimeProvider.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.Data.Analysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.Analysis.0.23.0\lib\netstandard2.0\Microsoft.Data.Analysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.10\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.11\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.10\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.11\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Graph, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Graph.6.2.0\lib\netstandard2.0\Microsoft.Graph.dll</HintPath>
+    <Reference Include="Microsoft.Graph, Version=6.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Graph.6.5.0\lib\netstandard2.0\Microsoft.Graph.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Graph.Core, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Graph.Core.4.0.1\lib\net462\Microsoft.Graph.Core.dll</HintPath>
@@ -300,14 +298,14 @@
     <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.ClientModel, Version=1.14.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ClientModel.1.14.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
+    <Reference Include="System.ClientModel, Version=1.15.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ClientModel.1.15.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
     </Reference>
-    <Reference Include="System.CodeDom, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.CodeDom.10.0.10\lib\net462\System.CodeDom.dll</HintPath>
+    <Reference Include="System.CodeDom, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.CodeDom.10.0.11\lib\net462\System.CodeDom.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.10.0.10\lib\net462\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.10.0.11\lib\net462\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -323,8 +321,8 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.10\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.11\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Diagnostics.Tracing, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Diagnostics.Tracing.4.3.0\lib\net462\System.Diagnostics.Tracing.dll</HintPath>
@@ -333,11 +331,11 @@
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Drawing.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Drawing.Common.10.0.10\lib\net462\System.Drawing.Common.dll</HintPath>
+      <HintPath>..\packages\System.Drawing.Common.10.0.11\lib\net462\System.Drawing.Common.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing.Design" />
-    <Reference Include="System.Formats.Asn1, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Formats.Asn1.10.0.10\lib\net462\System.Formats.Asn1.dll</HintPath>
+    <Reference Include="System.Formats.Asn1, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Formats.Asn1.10.0.11\lib\net462\System.Formats.Asn1.dll</HintPath>
     </Reference>
     <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
@@ -384,8 +382,8 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Pipelines, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Pipelines.10.0.10\lib\net462\System.IO.Pipelines.dll</HintPath>
+    <Reference Include="System.IO.Pipelines, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.10.0.11\lib\net462\System.IO.Pipelines.dll</HintPath>
     </Reference>
     <Reference Include="System.Linq, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Linq.4.3.0\lib\net463\System.Linq.dll</HintPath>
@@ -403,16 +401,19 @@
     <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="System.Memory.Data, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.Data.10.0.10\lib\net462\System.Memory.Data.dll</HintPath>
+    <Reference Include="System.Memory.Data, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.Data.10.0.11\lib\net462\System.Memory.Data.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http.WinHttpHandler, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Net.Http.WinHttpHandler.10.0.10\lib\net462\System.Net.Http.WinHttpHandler.dll</HintPath>
+    <Reference Include="System.Net.Http.WinHttpHandler, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.WinHttpHandler.10.0.11\lib\net462\System.Net.Http.WinHttpHandler.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.ServerSentEvents, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.ServerSentEvents.10.0.11\lib\net462\System.Net.ServerSentEvents.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
@@ -420,8 +421,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Tensors, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Numerics.Tensors.10.0.10\lib\net462\System.Numerics.Tensors.dll</HintPath>
+    <Reference Include="System.Numerics.Tensors, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Tensors.10.0.11\lib\net462\System.Numerics.Tensors.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.6.1\lib\net462\System.Numerics.Vectors.dll</HintPath>
@@ -479,8 +480,8 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.10\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.11\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
@@ -490,25 +491,25 @@
     <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encoding.CodePages, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encoding.CodePages.10.0.10\lib\net462\System.Text.Encoding.CodePages.dll</HintPath>
+    <Reference Include="System.Text.Encoding.CodePages, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encoding.CodePages.10.0.11\lib\net462\System.Text.Encoding.CodePages.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.10.0.10\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.10.0.11\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.10.0.10\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.10.0.11\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.RegularExpressions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Text.RegularExpressions.4.3.1\lib\net463\System.Text.RegularExpressions.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Threading.Channels, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Channels.10.0.10\lib\net462\System.Threading.Channels.dll</HintPath>
+    <Reference Include="System.Threading.Channels, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Channels.10.0.11\lib\net462\System.Threading.Channels.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Dataflow, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Dataflow.10.0.10\lib\net462\System.Threading.Tasks.Dataflow.dll</HintPath>
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Dataflow.10.0.11\lib\net462\System.Threading.Tasks.Dataflow.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.3\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
@@ -1288,8 +1289,8 @@
     <Error Condition="!Exists('..\packages\Microsoft.ML.5.0.0\build\netstandard2.0\Microsoft.ML.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ML.5.0.0\build\netstandard2.0\Microsoft.ML.targets'))" />
     <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets'))" />
     <Error Condition="!Exists('..\packages\System.Reactive.7.0.0\build\System.Reactive.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Reactive.7.0.0\build\System.Reactive.targets'))" />
-    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.4129.50\build\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.4129.50\build\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props'))" />
   </Target>
   <Import Project="..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets" Condition="Exists('..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" />
   <Import Project="..\packages\Tesseract.5.2.0\build\Tesseract.targets" Condition="Exists('..\packages\Tesseract.5.2.0\build\Tesseract.targets')" />
@@ -1298,7 +1299,6 @@
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
     <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.31.0.145097\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
@@ -1307,6 +1307,7 @@
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\BannedSymbols.txt" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.32.0.713\analyzers\SonarAnalyzer.CSharp.dll" />
   </ItemGroup>
   <Import Project="..\packages\System.Reactive.7.0.0\build\System.Reactive.targets" Condition="Exists('..\packages\System.Reactive.7.0.0\build\System.Reactive.targets')" />
   <Import Project="..\packages\Microsoft.Web.WebView2.1.0.4129.50\build\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.4129.50\build\Microsoft.Web.WebView2.targets')" />

--- a/UtilitiesCS/UtilitiesCS.csproj
+++ b/UtilitiesCS/UtilitiesCS.csproj
@@ -1298,11 +1298,11 @@
   <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
-    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
+    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
     <Analyzer Include="..\packages\AsyncFixer.2.1.0\analyzers\dotnet\cs\AsyncFixer.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />

--- a/UtilitiesCS/app.config
+++ b/UtilitiesCS/app.config
@@ -1,50 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <sectionGroup
-      name="userSettings"
-      type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-    >
-      <section
-        name="UtilitiesCS.Properties.Settings"
-        type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-        allowExeDefinition="MachineToLocalUser"
-        requirePermission="false"
-      />
+    <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <section name="UtilitiesCS.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
     </sectionGroup>
   </configSections>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Runtime.CompilerServices.Unsafe"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Buffers"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Tasks.Extensions"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -56,28 +32,16 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Collections.Immutable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Channels"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.AsyncInterfaces"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="ExCSS" publicKeyToken="bdbe16be9b936b9a" culture="neutral" />
@@ -92,380 +56,200 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Newtonsoft.Json"
-          publicKeyToken="30ad4fe6b2a6aeed"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Graph.Core"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Diagnostics.DiagnosticSource"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Json"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encodings.Web"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.60.0.0" newVersion="1.60.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory.Data"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Vectors"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encoding.CodePages"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.ClientModel"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Net.Http.WinHttpHandler"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.IdentityModel.Tokens.Jwt"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Tokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Validators"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Text"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Form"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Multipart"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.TimeProvider"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Tensors"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Json"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Authentication.Azure"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Std.UriTemplate"
-          publicKeyToken="c118b0afb4598f9a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Http.HttpClientLibrary"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.HashCode"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Numerics"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reactive"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Formats.Asn1"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Hosting.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Diagnostics.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Primitives"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity
-          name="System.Linq.AsyncEnumerable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client.Extensions.Msal"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.Cryptography.ProtectedData"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.AccessControl"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Cryptography"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.JsonWebTokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Logging"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="AngleSharp" publicKeyToken="e83494dcdc6d31ea" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.6.0.0" newVersion="1.6.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>
     <gcAllowVeryLargeObjects enabled="true" />

--- a/UtilitiesCS/app.config
+++ b/UtilitiesCS/app.config
@@ -1,26 +1,50 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <section name="UtilitiesCS.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+    <sectionGroup
+      name="userSettings"
+      type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+    >
+      <section
+        name="UtilitiesCS.Properties.Settings"
+        type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+        allowExeDefinition="MachineToLocalUser"
+        requirePermission="false"
+      />
     </sectionGroup>
   </configSections>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Runtime.CompilerServices.Unsafe"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Buffers"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Tasks.Extensions"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -32,15 +56,27 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Collections.Immutable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Channels"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.AsyncInterfaces"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -56,31 +92,59 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <assemblyIdentity
+          name="Newtonsoft.Json"
+          publicKeyToken="30ad4fe6b2a6aeed"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Graph.Core"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Diagnostics.DiagnosticSource"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Json"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encodings.Web"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -88,159 +152,315 @@
         <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory.Data"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Vectors"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encoding.CodePages"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="System.ClientModel"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.Http.WinHttpHandler"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="System.IdentityModel.Tokens.Jwt"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Tokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Validators"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Text"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Form"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Multipart"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.TimeProvider"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Tensors"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Json"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Authentication.Azure"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
+        <assemblyIdentity
+          name="Std.UriTemplate"
+          publicKeyToken="c118b0afb4598f9a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Http.HttpClientLibrary"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.HashCode"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Numerics"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reactive"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Formats.Asn1"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Hosting.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Diagnostics.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Primitives"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Linq.AsyncEnumerable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client.Extensions.Msal"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.Cryptography.ProtectedData"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.AccessControl"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Cryptography"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.JsonWebTokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Logging"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -248,7 +468,11 @@
         <bindingRedirect oldVersion="0.0.0.0-1.6.0.0" newVersion="1.6.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.ServerSentEvents"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>

--- a/UtilitiesCS/packages.config
+++ b/UtilitiesCS/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AngleSharp" version="1.7.0" targetFramework="net481" />
+  <package id="AngleSharp" version="1.7.1" targetFramework="net481" />
   <package id="Apache.Arrow" version="23.0.0" targetFramework="net481" />
   <package id="Apache.Arrow.Scalars" version="23.0.0" targetFramework="net481" />
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
-  <package id="Azure.Core" version="1.60.0" targetFramework="net481" />
+  <package id="Azure.Core" version="1.61.0" targetFramework="net481" />
   <package id="C.math.NET" version="1.1" targetFramework="net481" />
   <package id="Deedle" version="3.0.0" targetFramework="net481" />
   <package id="ExCSS" version="4.3.2" targetFramework="net481" />
@@ -14,74 +14,32 @@
   <package id="Generic.Math" version="1.0.2" targetFramework="net481" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
   <package id="log4net.Ext.Json" version="3.0.3" targetFramework="net481" />
-  <package
-    id="Meziantou.Analyzer"
-    version="3.0.138"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.10" targetFramework="net481" />
-  <package id="Microsoft.Bcl.Cryptography" version="10.0.10" targetFramework="net481" />
+  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Bcl.Cryptography" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Bcl.HashCode" version="6.0.0" targetFramework="net481" />
-  <package id="Microsoft.Bcl.Memory" version="10.0.10" targetFramework="net481" />
-  <package id="Microsoft.Bcl.Numerics" version="10.0.10" targetFramework="net481" />
-  <package id="Microsoft.Bcl.TimeProvider" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
-    version="5.6.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Microsoft.Bcl.Memory" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Bcl.Numerics" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Bcl.TimeProvider" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
   <package id="Microsoft.Data.Analysis" version="0.23.0" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Configuration.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Diagnostics.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.FileProviders.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Hosting.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Logging.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Options" version="10.0.10" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Primitives" version="10.0.10" targetFramework="net481" />
-  <package id="Microsoft.Graph" version="6.2.0" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Graph" version="6.5.0" targetFramework="net481" />
   <package id="Microsoft.Graph.Core" version="4.0.1" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package
-    id="Microsoft.Identity.Client.Extensions.Msal"
-    version="4.87.0"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.JsonWebTokens" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Logging" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Protocols" version="8.22.0" targetFramework="net481" />
-  <package
-    id="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-    version="8.22.0"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Tokens" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Validators" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IO.RecyclableMemoryStream" version="3.0.1" targetFramework="net481" />
@@ -104,35 +62,25 @@
   <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net481" />
   <package id="Newtonsoft.Json.Bson" version="1.0.3" targetFramework="net481" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net481" />
-  <package
-    id="Roslynator.Analyzers"
-    version="4.15.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="SonarAnalyzer.CSharp"
-    version="10.31.0.145097"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
   <package id="Std.UriTemplate" version="2.0.12" targetFramework="net481" />
   <package id="Svg" version="3.4.8" targetFramework="net481" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net481" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
-  <package id="System.ClientModel" version="1.14.0" targetFramework="net481" />
-  <package id="System.CodeDom" version="10.0.10" targetFramework="net481" />
+  <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
+  <package id="System.CodeDom" version="10.0.11" targetFramework="net481" />
   <package id="System.Collections" version="4.3.0" targetFramework="net481" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net481" />
-  <package id="System.Collections.Immutable" version="10.0.10" targetFramework="net481" />
+  <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
   <package id="System.Console" version="4.3.1" targetFramework="net481" />
   <package id="System.Data.Common" version="4.3.0" targetFramework="net481" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net481" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.10" targetFramework="net481" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.11" targetFramework="net481" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net481" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net481" />
-  <package id="System.Drawing.Common" version="10.0.10" targetFramework="net481" />
-  <package id="System.Formats.Asn1" version="10.0.10" targetFramework="net481" />
+  <package id="System.Drawing.Common" version="10.0.11" targetFramework="net481" />
+  <package id="System.Formats.Asn1" version="10.0.11" targetFramework="net481" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net481" />
   <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net481" />
   <package id="System.IdentityModel.Tokens.Jwt" version="8.22.0" targetFramework="net481" />
@@ -144,17 +92,18 @@
   <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net481" />
   <package id="System.IO.FileSystem.AccessControl" version="5.0.0" targetFramework="net481" />
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net481" />
-  <package id="System.IO.Pipelines" version="10.0.10" targetFramework="net481" />
+  <package id="System.IO.Pipelines" version="10.0.11" targetFramework="net481" />
   <package id="System.Linq" version="4.3.0" targetFramework="net481" />
   <package id="System.Linq.Async" version="7.0.1" targetFramework="net481" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net481" />
   <package id="System.Memory" version="4.6.3" targetFramework="net481" />
-  <package id="System.Memory.Data" version="10.0.10" targetFramework="net481" />
+  <package id="System.Memory.Data" version="10.0.11" targetFramework="net481" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net481" />
-  <package id="System.Net.Http.WinHttpHandler" version="10.0.10" targetFramework="net481" />
+  <package id="System.Net.Http.WinHttpHandler" version="10.0.11" targetFramework="net481" />
   <package id="System.Net.Primitives" version="4.3.1" targetFramework="net481" />
+  <package id="System.Net.ServerSentEvents" version="10.0.11" targetFramework="net481" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net481" />
-  <package id="System.Numerics.Tensors" version="10.0.10" targetFramework="net481" />
+  <package id="System.Numerics.Tensors" version="10.0.11" targetFramework="net481" />
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net481" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net481" />
   <package id="System.Reactive" version="7.0.0" targetFramework="net481" />
@@ -169,37 +118,25 @@
   <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="net481" />
   <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net481" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net481" />
-  <package
-    id="System.Runtime.InteropServices.RuntimeInformation"
-    version="4.3.0"
-    targetFramework="net481"
-  />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net481" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net481" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net481" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net481" />
-  <package
-    id="System.Security.Cryptography.ProtectedData"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="System.Security.Cryptography.X509Certificates"
-    version="4.3.2"
-    targetFramework="net481"
-  />
+  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net481" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net481" />
-  <package id="System.Text.Encoding.CodePages" version="10.0.10" targetFramework="net481" />
+  <package id="System.Text.Encoding.CodePages" version="10.0.11" targetFramework="net481" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net481" />
-  <package id="System.Text.Encodings.Web" version="10.0.10" targetFramework="net481" />
-  <package id="System.Text.Json" version="10.0.10" targetFramework="net481" />
+  <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
+  <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />
   <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="net481" />
   <package id="System.Threading" version="4.3.0" targetFramework="net481" />
-  <package id="System.Threading.Channels" version="10.0.10" targetFramework="net481" />
+  <package id="System.Threading.Channels" version="10.0.11" targetFramework="net481" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net481" />
-  <package id="System.Threading.Tasks.Dataflow" version="10.0.10" targetFramework="net481" />
+  <package id="System.Threading.Tasks.Dataflow" version="10.0.11" targetFramework="net481" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net481" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net481" />
   <package id="System.ValueTuple" version="4.6.2" targetFramework="net481" />

--- a/UtilitiesCS/packages.config
+++ b/UtilitiesCS/packages.config
@@ -14,32 +14,74 @@
   <package id="Generic.Math" version="1.0.2" targetFramework="net481" />
   <package id="log4net" version="3.3.2" targetFramework="net481" />
   <package id="log4net.Ext.Json" version="3.0.3" targetFramework="net481" />
-  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Meziantou.Analyzer"
+    version="3.0.156"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Bcl.Cryptography" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Bcl.HashCode" version="6.0.0" targetFramework="net481" />
   <package id="Microsoft.Bcl.Memory" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Bcl.Numerics" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Bcl.TimeProvider" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
+    version="5.6.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.Data.Analysis" version="0.23.0" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Configuration.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Diagnostics.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.FileProviders.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Hosting.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Logging.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Graph" version="6.5.0" targetFramework="net481" />
   <package id="Microsoft.Graph.Core" version="4.0.1" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
+  <package
+    id="Microsoft.Identity.Client.Extensions.Msal"
+    version="4.87.0"
+    targetFramework="net481"
+  />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.JsonWebTokens" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Logging" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Protocols" version="8.22.0" targetFramework="net481" />
-  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="8.22.0" targetFramework="net481" />
+  <package
+    id="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+    version="8.22.0"
+    targetFramework="net481"
+  />
   <package id="Microsoft.IdentityModel.Tokens" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Validators" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.IO.RecyclableMemoryStream" version="3.0.1" targetFramework="net481" />
@@ -62,8 +104,18 @@
   <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net481" />
   <package id="Newtonsoft.Json.Bson" version="1.0.3" targetFramework="net481" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net481" />
-  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
-  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Roslynator.Analyzers"
+    version="4.16.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="SonarAnalyzer.CSharp"
+    version="10.32.0.713"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Std.UriTemplate" version="2.0.12" targetFramework="net481" />
   <package id="Svg" version="3.4.8" targetFramework="net481" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net481" />
@@ -118,14 +170,26 @@
   <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="net481" />
   <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net481" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net481" />
-  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net481" />
+  <package
+    id="System.Runtime.InteropServices.RuntimeInformation"
+    version="4.3.0"
+    targetFramework="net481"
+  />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net481" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net481" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net481" />
-  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net481" />
+  <package
+    id="System.Security.Cryptography.ProtectedData"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="System.Security.Cryptography.X509Certificates"
+    version="4.3.2"
+    targetFramework="net481"
+  />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net481" />
   <package id="System.Text.Encoding.CodePages" version="10.0.11" targetFramework="net481" />

--- a/VBFunctions.Test/VBFunctions.Test.csproj
+++ b/VBFunctions.Test/VBFunctions.Test.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" />
+  <Import Project="..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" />
   <Import Project="..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props')" />
   <Import Project="..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props" Condition="Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.props" Condition="Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.3.3\build\Microsoft.Testing.Platform.MSBuild.props')" />
@@ -46,8 +46,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Azure.Core, Version=1.60.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Azure.Core.1.60.0\lib\net472\Azure.Core.dll</HintPath>
+    <Reference Include="Azure.Core, Version=1.61.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Core.1.61.0\lib\net472\Azure.Core.dll</HintPath>
     </Reference>
     <Reference Include="Azure.Monitor.OpenTelemetry.Exporter, Version=1.8.3.0, Culture=neutral, PublicKeyToken=92742159e12e44c8">
       <HintPath>..\packages\Azure.Monitor.OpenTelemetry.Exporter.1.8.3\lib\netstandard2.0\Azure.Monitor.OpenTelemetry.Exporter.dll</HintPath>
@@ -56,55 +56,54 @@
     <Reference Include="Microsoft.ApplicationInsights, Version=3.1.2.115, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.3.1.2\lib\net462\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.10\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.10\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.10\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.10.0.11\lib\net462\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.10\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.10.0.11\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.10\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.10\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.10.0.11\lib\net462\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.10\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.11\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.10\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.10.0.11\lib\net462\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.10, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.10\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.11\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Identity.Client, Version=4.87.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae">
       <HintPath>..\packages\Microsoft.Identity.Client.4.87.0\lib\net472\Microsoft.Identity.Client.dll</HintPath>
@@ -134,16 +133,16 @@
       <HintPath>..\packages\Microsoft.Testing.Platform.2.3.3\lib\netstandard2.0\Microsoft.Testing.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.AdapterUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.18.8.1\lib\net462\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.18.9.0\lib\net462\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.PlatformAbstractions, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.8.1\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.9.0\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="MSTest.TestFramework, Version=4.3.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.4.3.3\lib\net462\MSTest.TestFramework.dll</HintPath>
@@ -173,44 +172,48 @@
     <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.ClientModel, Version=1.14.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ClientModel.1.14.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
+    <Reference Include="System.ClientModel, Version=1.15.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ClientModel.1.15.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.10.0.10\lib\net462\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.10.0.11\lib\net462\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.10\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.11\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Formats.Asn1, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Formats.Asn1.10.0.10\lib\net462\System.Formats.Asn1.dll</HintPath>
+    <Reference Include="System.Formats.Asn1, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Formats.Asn1.10.0.11\lib\net462\System.Formats.Asn1.dll</HintPath>
     </Reference>
     <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IO" />
     <Reference Include="System.IO.FileSystem.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.FileSystem.AccessControl.5.0.0\lib\net461\System.IO.FileSystem.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Pipelines, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Pipelines.10.0.10\lib\net462\System.IO.Pipelines.dll</HintPath>
+    <Reference Include="System.IO.Pipelines, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.10.0.11\lib\net462\System.IO.Pipelines.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="System.Memory.Data, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.Data.10.0.10\lib\net462\System.Memory.Data.dll</HintPath>
+    <Reference Include="System.Memory.Data, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.Data.10.0.11\lib\net462\System.Memory.Data.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.ServerSentEvents, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.ServerSentEvents.10.0.11\lib\net462\System.Net.ServerSentEvents.dll</HintPath>
+    </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.6.1\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.10.0.10\lib\net462\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.10.0.11\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -221,17 +224,17 @@
     <Reference Include="System.Security.AccessControl, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.AccessControl.6.0.1\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.10, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.10\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.11\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.10.0.10\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.10.0.11\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=10.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.10.0.10\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.10.0.11\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.3\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
@@ -262,6 +265,7 @@
   <ItemGroup>
     <Analyzer Include="..\packages\MSTest.Analyzers.4.3.3\analyzers\dotnet\cs\MSTest.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\MSTest.Analyzers.4.3.3\analyzers\dotnet\cs\MSTest.Analyzers.dll" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.32.0.713\analyzers\SonarAnalyzer.CSharp.dll" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -278,7 +282,7 @@
     <Error Condition="!Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Extensions.Telemetry.2.3.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets'))" />
-    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props'))" />
   </Target>
   <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.2.3.3\build\netstandard2.0\Microsoft.Testing.Platform.targets" Condition="Exists('..\packages\Microsoft.Testing.Platform.2.3.3\build\netstandard2.0\Microsoft.Testing.Platform.targets')" />
@@ -288,7 +292,6 @@
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
     <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.31.0.145097\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />

--- a/VBFunctions.Test/VBFunctions.Test.csproj
+++ b/VBFunctions.Test/VBFunctions.Test.csproj
@@ -291,11 +291,11 @@
   <Import Project="..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.4.3.3\build\net462\MSTest.TestAdapter.targets')" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
-    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
+    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
     <Analyzer Include="..\packages\AsyncFixer.2.1.0\analyzers\dotnet\cs\AsyncFixer.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />

--- a/VBFunctions.Test/app.config
+++ b/VBFunctions.Test/app.config
@@ -3,11 +3,19 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Buffers"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Runtime.CompilerServices.Unsafe"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -19,7 +27,11 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -27,43 +39,83 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Collections.Immutable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Channels"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.AsyncInterfaces"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <assemblyIdentity
+          name="Newtonsoft.Json"
+          publicKeyToken="30ad4fe6b2a6aeed"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Graph.Core"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Diagnostics.DiagnosticSource"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Json"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encodings.Web"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
@@ -75,215 +127,427 @@
         <bindingRedirect oldVersion="0.0.0.0-4.3.2.0" newVersion="4.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Memory.Data"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Abstractions"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Vectors"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Text.Encoding.CodePages"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Threading.Tasks.Extensions"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="System.ClientModel"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.Http.WinHttpHandler"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="System.IdentityModel.Tokens.Jwt"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.JsonWebTokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Logging"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Tokens"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Validators"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.IdentityModel.Protocols"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Text"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Form"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Multipart"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.TimeProvider"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Numerics.Tensors"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reflection.Metadata"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Serialization.Json"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Authentication.Azure"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.ApplicationInsights"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
+        <assemblyIdentity
+          name="Std.UriTemplate"
+          publicKeyToken="c118b0afb4598f9a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Memory"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Kiota.Http.HttpClientLibrary"
+          publicKeyToken="31bf3856ad364e35"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.HashCode"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Numerics"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Options"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Diagnostics.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.DependencyInjection"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging.Configuration"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Logging"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Hosting.Abstractions"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.Binder"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <assemblyIdentity
+          name="System.Reactive"
+          publicKeyToken="94bc3704cddfc263"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Formats.Asn1"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Primitives"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Linq.AsyncEnumerable"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.Abstractions"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
+        <assemblyIdentity
+          name="OpenTelemetry.PersistentStorage.FileSystem"
+          publicKeyToken="7bd6737fe5b67e3c"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Identity.Client.Extensions.Msal"
+          publicKeyToken="0a613f4dd989e8ae"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.Cryptography.ProtectedData"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <assemblyIdentity
+          name="System.Security.AccessControl"
+          publicKeyToken="b03f5f7f11d50a3a"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <assemblyIdentity
+          name="Azure.Monitor.OpenTelemetry.Exporter"
+          publicKeyToken="92742159e12e44c8"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Bcl.Cryptography"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity
+          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
+          publicKeyToken="adb9793829ddae60"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity
+          name="System.Net.ServerSentEvents"
+          publicKeyToken="cc7b13ffcd2ddd51"
+          culture="neutral"
+        />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>

--- a/VBFunctions.Test/app.config
+++ b/VBFunctions.Test/app.config
@@ -3,19 +3,11 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Buffers"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Runtime.CompilerServices.Unsafe"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -27,11 +19,7 @@
         <bindingRedirect oldVersion="0.0.0.0-3.3.2.0" newVersion="3.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -39,508 +27,264 @@
         <bindingRedirect oldVersion="0.0.0.0-23.0.0.0" newVersion="23.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Collections.Immutable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Channels"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.AsyncInterfaces"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Newtonsoft.Json"
-          publicKeyToken="30ad4fe6b2a6aeed"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Graph.Core"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Clients.ActiveDirectory"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.22.0.0" newVersion="2.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Diagnostics.DiagnosticSource"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Json"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encodings.Web"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.60.0.0" newVersion="1.60.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.61.0.0" newVersion="1.61.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="ExCSS" publicKeyToken="bdbe16be9b936b9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.3.2.0" newVersion="4.3.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Memory.Data"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Abstractions"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Vectors"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Text.Encoding.CodePages"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Threading.Tasks.Extensions"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.ClientModel"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Net.Http.WinHttpHandler"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.IdentityModel.Tokens.Jwt"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.JsonWebTokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Logging"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols.OpenIdConnect"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Tokens"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Validators"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Validators" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.IdentityModel.Protocols"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Text"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Form"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Multipart"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.TimeProvider"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.TimeProvider" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Numerics.Tensors"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Numerics.Tensors" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reflection.Metadata"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Serialization.Json"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Authentication.Azure"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.ApplicationInsights"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.2.115" newVersion="3.1.2.115" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Std.UriTemplate"
-          publicKeyToken="c118b0afb4598f9a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Std.UriTemplate" publicKeyToken="c118b0afb4598f9a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Memory"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Kiota.Http.HttpClientLibrary"
-          publicKeyToken="31bf3856ad364e35"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.22.0.0" newVersion="1.22.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.HashCode"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Numerics"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Bcl.Numerics" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Options"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Diagnostics.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.DependencyInjection"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging.Configuration"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Logging"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Hosting.Abstractions"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.Binder"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Reactive"
-          publicKeyToken="94bc3704cddfc263"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Reactive" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Formats.Asn1"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Primitives"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Linq.AsyncEnumerable"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Linq.AsyncEnumerable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="OpenTelemetry.PersistentStorage.Abstractions"
-          publicKeyToken="7bd6737fe5b67e3c"
-          culture="neutral"
-        />
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.Abstractions" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="OpenTelemetry.PersistentStorage.FileSystem"
-          publicKeyToken="7bd6737fe5b67e3c"
-          culture="neutral"
-        />
+        <assemblyIdentity name="OpenTelemetry.PersistentStorage.FileSystem" publicKeyToken="7bd6737fe5b67e3c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.1.1228" newVersion="1.1.1.1228" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Identity.Client.Extensions.Msal"
-          publicKeyToken="0a613f4dd989e8ae"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.87.0.0" newVersion="4.87.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.Cryptography.ProtectedData"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="System.Security.AccessControl"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"
-        />
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Azure.Monitor.OpenTelemetry.Exporter"
-          publicKeyToken="92742159e12e44c8"
-          culture="neutral"
-        />
+        <assemblyIdentity name="Azure.Monitor.OpenTelemetry.Exporter" publicKeyToken="92742159e12e44c8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Bcl.Cryptography"
-          publicKeyToken="cc7b13ffcd2ddd51"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity
-          name="Microsoft.Extensions.Configuration.EnvironmentVariables"
-          publicKeyToken="adb9793829ddae60"
-          culture="neutral"
-        />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/VBFunctions.Test/packages.config
+++ b/VBFunctions.Test/packages.config
@@ -1,162 +1,66 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
-  <package id="Azure.Core" version="1.60.0" targetFramework="net481" />
+  <package id="Azure.Core" version="1.61.0" targetFramework="net481" />
   <package id="Azure.Monitor.OpenTelemetry.Exporter" version="1.8.3" targetFramework="net481" />
-  <package
-    id="Meziantou.Analyzer"
-    version="3.0.138"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
-    version="5.6.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package id="Microsoft.Extensions.Configuration" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Configuration.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.Binder"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.DependencyInjection.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Diagnostics.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.FileProviders.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Hosting.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Logging" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Logging.Abstractions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Extensions.Logging.Configuration"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Options" version="10.0.10" targetFramework="net481" />
-  <package
-    id="Microsoft.Extensions.Options.ConfigurationExtensions"
-    version="10.0.10"
-    targetFramework="net481"
-  />
-  <package id="Microsoft.Extensions.Primitives" version="10.0.10" targetFramework="net481" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package
-    id="Microsoft.Identity.Client.Extensions.Msal"
-    version="4.87.0"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package
-    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
-    version="2.3.3"
-    targetFramework="net481"
-  />
-  <package
-    id="Microsoft.Testing.Extensions.VSTestBridge"
-    version="2.3.3"
-    targetFramework="net481"
-  />
+  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
+  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.8.1" targetFramework="net481" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="18.8.1" targetFramework="net481" />
-  <package
-    id="MSTest.Analyzers"
-    version="4.3.3"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.9.0" targetFramework="net481" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
+  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.Api.ProviderBuilderExtensions"
-    version="1.17.0"
-    targetFramework="net481"
-  />
+  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package
-    id="OpenTelemetry.PersistentStorage.Abstractions"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="OpenTelemetry.PersistentStorage.FileSystem"
-    version="1.1.1"
-    targetFramework="net481"
-  />
-  <package
-    id="Roslynator.Analyzers"
-    version="4.15.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="SonarAnalyzer.CSharp"
-    version="10.31.0.145097"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
+  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
+  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
-  <package id="System.ClientModel" version="1.14.0" targetFramework="net481" />
-  <package id="System.Collections.Immutable" version="10.0.10" targetFramework="net481" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.10" targetFramework="net481" />
-  <package id="System.Formats.Asn1" version="10.0.10" targetFramework="net481" />
+  <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
+  <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.11" targetFramework="net481" />
+  <package id="System.Formats.Asn1" version="10.0.11" targetFramework="net481" />
   <package id="System.IO.FileSystem.AccessControl" version="5.0.0" targetFramework="net481" />
-  <package id="System.IO.Pipelines" version="10.0.10" targetFramework="net481" />
+  <package id="System.IO.Pipelines" version="10.0.11" targetFramework="net481" />
   <package id="System.Memory" version="4.6.3" targetFramework="net481" />
-  <package id="System.Memory.Data" version="10.0.10" targetFramework="net481" />
+  <package id="System.Memory.Data" version="10.0.11" targetFramework="net481" />
+  <package id="System.Net.ServerSentEvents" version="10.0.11" targetFramework="net481" />
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net481" />
-  <package id="System.Reflection.Metadata" version="10.0.10" targetFramework="net481" />
+  <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package
-    id="System.Security.Cryptography.ProtectedData"
-    version="10.0.10"
-    targetFramework="net481"
-  />
+  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
-  <package id="System.Text.Encodings.Web" version="10.0.10" targetFramework="net481" />
-  <package id="System.Text.Json" version="10.0.10" targetFramework="net481" />
+  <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
+  <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net481" />
   <package id="System.ValueTuple" version="4.6.2" targetFramework="net481" />
 </packages>

--- a/VBFunctions.Test/packages.config
+++ b/VBFunctions.Test/packages.config
@@ -3,46 +3,139 @@
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
   <package id="Azure.Core" version="1.61.0" targetFramework="net481" />
   <package id="Azure.Monitor.OpenTelemetry.Exporter" version="1.8.3" targetFramework="net481" />
-  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Meziantou.Analyzer"
+    version="3.0.156"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.ApplicationInsights" version="3.1.2" targetFramework="net481" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
+    version="5.6.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="Microsoft.Extensions.Configuration" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.Binder" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Configuration.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.Binder"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Configuration.EnvironmentVariables"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.DependencyInjection.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Diagnostics.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.FileProviders.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Hosting.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Logging" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Logging.Configuration" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Logging.Abstractions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Extensions.Logging.Configuration"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net481" />
-  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.11" targetFramework="net481" />
+  <package
+    id="Microsoft.Extensions.Options.ConfigurationExtensions"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net481" />
   <package id="Microsoft.Identity.Client" version="4.87.0" targetFramework="net481" />
-  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.87.0" targetFramework="net481" />
+  <package
+    id="Microsoft.Identity.Client.Extensions.Msal"
+    version="4.87.0"
+    targetFramework="net481"
+  />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net481" />
   <package id="Microsoft.Testing.Extensions.Telemetry" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.TrxReport.Abstractions" version="2.3.3" targetFramework="net481" />
-  <package id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" targetFramework="net481" />
+  <package
+    id="Microsoft.Testing.Extensions.TrxReport.Abstractions"
+    version="2.3.3"
+    targetFramework="net481"
+  />
+  <package
+    id="Microsoft.Testing.Extensions.VSTestBridge"
+    version="2.3.3"
+    targetFramework="net481"
+  />
   <package id="Microsoft.Testing.Platform" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.9.0" targetFramework="net481" />
   <package id="Microsoft.TestPlatform.ObjectModel" version="18.9.0" targetFramework="net481" />
-  <package id="MSTest.Analyzers" version="4.3.3" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="MSTest.Analyzers"
+    version="4.3.3"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="MSTest.TestAdapter" version="4.3.3" targetFramework="net481" />
   <package id="MSTest.TestFramework" version="4.3.3" targetFramework="net481" />
   <package id="OpenTelemetry" version="1.17.0" targetFramework="net481" />
   <package id="OpenTelemetry.Api" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.Api.ProviderBuilderExtensions" version="1.17.0" targetFramework="net481" />
+  <package
+    id="OpenTelemetry.Api.ProviderBuilderExtensions"
+    version="1.17.0"
+    targetFramework="net481"
+  />
   <package id="OpenTelemetry.Extensions.Hosting" version="1.17.0" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.Abstractions" version="1.1.1" targetFramework="net481" />
-  <package id="OpenTelemetry.PersistentStorage.FileSystem" version="1.1.1" targetFramework="net481" />
-  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
-  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="OpenTelemetry.PersistentStorage.Abstractions"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="OpenTelemetry.PersistentStorage.FileSystem"
+    version="1.1.1"
+    targetFramework="net481"
+  />
+  <package
+    id="Roslynator.Analyzers"
+    version="4.16.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="SonarAnalyzer.CSharp"
+    version="10.32.0.713"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
   <package id="System.Buffers" version="4.6.1" targetFramework="net481" />
   <package id="System.ClientModel" version="1.15.0" targetFramework="net481" />
   <package id="System.Collections.Immutable" version="10.0.11" targetFramework="net481" />
@@ -57,7 +150,11 @@
   <package id="System.Reflection.Metadata" version="10.0.11" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net481" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net481" />
-  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net481" />
+  <package
+    id="System.Security.Cryptography.ProtectedData"
+    version="10.0.11"
+    targetFramework="net481"
+  />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net481" />
   <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net481" />
   <package id="System.Text.Json" version="10.0.11" targetFramework="net481" />

--- a/VBFunctions/VBFunctions.csproj
+++ b/VBFunctions/VBFunctions.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" />
+  <Import Project="..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props" Condition="Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -56,7 +56,6 @@
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
     <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.31.0.145097\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
     <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
@@ -65,11 +64,12 @@
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\BannedSymbols.txt" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.10.32.0.713\analyzers\SonarAnalyzer.CSharp.dll" />
   </ItemGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.138\build\Meziantou.Analyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Meziantou.Analyzer.3.0.156\build\Meziantou.Analyzer.props'))" />
   </Target>
 </Project>

--- a/VBFunctions/VBFunctions.csproj
+++ b/VBFunctions/VBFunctions.csproj
@@ -55,11 +55,11 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <!-- Issue #181: analyzer-only references (first-party scope). Severities are set to suggestion in .editorconfig so none break the nullable TreatWarningsAsErrors build. -->
-    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.138\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
-    <Analyzer Include="..\packages\Roslynator.Analyzers.4.15.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
+    <Analyzer Include="..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll" />
+    <Analyzer Include="..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll" />
     <Analyzer Include="..\packages\AsyncFixer.2.1.0\analyzers\dotnet\cs\AsyncFixer.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.5.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />

--- a/VBFunctions/packages.config
+++ b/VBFunctions/packages.config
@@ -1,8 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
-  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
-  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
-  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
-  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
+  <package
+    id="Meziantou.Analyzer"
+    version="3.0.156"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
+    version="5.6.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="Roslynator.Analyzers"
+    version="4.16.0"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
+  <package
+    id="SonarAnalyzer.CSharp"
+    version="10.32.0.713"
+    targetFramework="net481"
+    developmentDependency="true"
+  />
 </packages>

--- a/VBFunctions/packages.config
+++ b/VBFunctions/packages.config
@@ -1,28 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncFixer" version="2.1.0" targetFramework="net481" developmentDependency="true" />
-  <package
-    id="Meziantou.Analyzer"
-    version="3.0.138"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="Microsoft.CodeAnalysis.BannedApiAnalyzers"
-    version="5.6.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="Roslynator.Analyzers"
-    version="4.15.0"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
-  <package
-    id="SonarAnalyzer.CSharp"
-    version="10.31.0.145097"
-    targetFramework="net481"
-    developmentDependency="true"
-  />
+  <package id="Meziantou.Analyzer" version="3.0.156" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="5.6.0" targetFramework="net481" developmentDependency="true" />
+  <package id="Roslynator.Analyzers" version="4.16.0" targetFramework="net481" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="10.32.0.713" targetFramework="net481" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
# Summary

- Upgrades **46 NuGet packages** across all 17 projects to their latest available versions; **1 package added** as a new transitive dependency, **0 removed**.
- The dominant group is the `Microsoft.Extensions.*` / `System.*` runtime family moving `10.0.10 → 10.0.11` (~35 packages); the largest single jump is `Microsoft.Graph 6.2.0 → 6.5.0`.
- No target framework change (all projects stay on `net481`), and no `Compile`, `None`, or `ProjectReference` item changes — **no source file is added, removed, or moved**.
- Assembly binding redirects grow from **978 to 1026** entries (+48), matching the upgraded and newly-introduced assemblies.
- The raw diff (`+2695 / −7141`) overstates the change: most of it is NuGet rewriting multi-line XML attributes onto single lines. **This reformatting is what breaks `format-check`** — see Verification.

# Why

Routine dependency maintenance: take every package that has an available update, so the solution stays current on the runtime, Graph SDK, test platform, and analyzer packages rather than accumulating drift.

No PR Intent fields were supplied in the context bundle, and no issue is referenced by the commit, so the motivation above is inferred from the commit and the diff only.

# What Changed

## Runtime and BCL family — `10.0.10 → 10.0.11`

`Microsoft.Bcl.AsyncInterfaces`, `Microsoft.Bcl.Cryptography`, `Microsoft.Bcl.Memory`, `Microsoft.Bcl.Numerics`, `Microsoft.Bcl.TimeProvider`, `Microsoft.Extensions.Configuration` (+ `.Abstractions`, `.Binder`, `.EnvironmentVariables`), `Microsoft.Extensions.DependencyInjection` (+ `.Abstractions`), `Microsoft.Extensions.Diagnostics.Abstractions`, `Microsoft.Extensions.FileProviders.Abstractions`, `Microsoft.Extensions.Hosting.Abstractions`, `Microsoft.Extensions.Logging` (+ `.Abstractions`, `.Configuration`), `Microsoft.Extensions.Options` (+ `.ConfigurationExtensions`), `Microsoft.Extensions.Primitives`, `System.CodeDom`, `System.Collections.Immutable`, `System.Diagnostics.DiagnosticSource`, `System.Drawing.Common`, `System.Formats.Asn1`, `System.IO.Pipelines`, `System.Memory.Data`, `System.Net.Http.WinHttpHandler`, `System.Numerics.Tensors`, `System.Reflection.Metadata`, `System.Security.Cryptography.ProtectedData`, `System.Text.Encoding.CodePages`, `System.Text.Encodings.Web`, `System.Text.Json`, `System.Threading.Channels`, `System.Threading.Tasks.Dataflow`.

## Graph and Azure client stack

| Package | From | To |
|---|---|---|
| `Microsoft.Graph` | 6.2.0 | 6.5.0 |
| `Azure.Core` | 1.60.0 | 1.61.0 |
| `System.ClientModel` | 1.14.0 | 1.15.0 |
| `System.Net.ServerSentEvents` | *(absent)* | **added** |

`System.Net.ServerSentEvents` is the only new package id. It arrives as a transitive dependency of the upgraded client stack and receives a binding redirect in all 16 `app.config` files.

## Test and analyzer tooling

| Package | From | To |
|---|---|---|
| `Microsoft.TestPlatform.ObjectModel` | 18.8.1 | 18.9.0 |
| `Microsoft.TestPlatform.AdapterUtilities` | 18.8.1 | 18.9.0 |
| `Microsoft.Extensions.TimeProvider.Testing` | 10.8.0 | 10.9.0 |
| `SonarAnalyzer.CSharp` | 10.31.0.145097 | 10.32.0.713 |
| `Meziantou.Analyzer` | 3.0.138 | 3.0.156 |
| `Roslynator.Analyzers` | 4.15.0 | 4.16.0 |
| `AngleSharp` | 1.7.0 | 1.7.1 |

## Files touched (50)

- **17 `.csproj`** — `<Reference>` assembly versions, `HintPath` package-folder paths, and analyzer `<Import>` props/targets paths only.
- **17 `packages.config`** — package version attributes.
- **16 `app.config`** — `bindingRedirect` / `assemblyIdentity` entries.

# Architecture / How It Fits Together

Nothing structural changes. These are `packages.config`-style (non-SDK, non-PackageReference) .NET Framework projects, so each upgrade touches three coordinated places per project:

1. `packages.config` records the resolved package version.
2. `.csproj` carries a matching `<Reference>` with the strong-name version and a `HintPath` into `..\packages\<Id>.<Version>\`.
3. `app.config` carries a `bindingRedirect` so the loaded assembly version resolves at runtime.

All three stayed consistent in this change: no package id resolves to more than one version anywhere in the solution, so there is no split-version hazard between projects.

# Verification

## Completed (from CI on `8f30fd53`)

| Check | Result |
|---|---|
| `actionlint` | **PASS** |
| `build-analyzers` — build with analyzers and code style enforcement | **PASS** |
| `build-nullable` — build with nullable warnings as errors | **PASS** |
| `mstest-coverage` — MSTest suite with coverage | **PASS** |
| `format-check` — CSharpier `dotnet csharpier check .` | **FAIL** |

The three upgraded analyzer packages (Sonar, Meziantou, Roslynator) did **not** introduce new build-breaking diagnostics — `build-analyzers` and `build-nullable` are both green — which is the main risk this kind of upgrade usually carries.

## The one failure

`format-check` fails on **33 files** — every `app.config` and `packages.config` in the diff. The cause is purely stylistic: the repository formats these XML files with one attribute per line, and the NuGet package manager rewrote them with all attributes on a single line. CSharpier reports `Was not formatted` for 32 of them and `The file did not end with a single newline` for `VBFunctions.Test\packages.config`. No `.csproj` file is flagged.

**Fix:** run `dotnet csharpier .` at the repo root and commit the result. That restores the repo's XML style without altering any package version.

## Recommended

```
dotnet csharpier .                 # then commit — clears the format-check failure
dotnet tool run csharpier --check .
msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true
vstest.console.exe <test-assembly-paths> /EnableCodeCoverage
```

Beyond the toolchain, a manual smoke test of the Outlook add-in is worth doing: binding-redirect changes are not exercised by the unit test suite, and this PR touches redirects in every project.

# Backward Compatibility / Migration Notes

- No public API of this repository changes.
- No target framework change — all projects remain `net481`.
- `Microsoft.Graph 6.2.0 → 6.5.0` is the only multi-minor jump. It is within the same major version, so no breaking change is expected, but it is the upgrade most worth a second look.
- Because these are `packages.config` projects, anyone with an existing working copy should restore packages before building, as the `..\packages\<Id>.<Version>\` folder names have changed.

# Risks and Mitigations

- **Binding redirect regressions at runtime.** 48 new `dependentAssembly` entries and ~394 redirects retargeted to `10.0.0.11`. Unit tests do not exercise the add-in's real assembly-load path.
  *Mitigation:* CI builds and the MSTest suite pass; smoke-test the add-in in Outlook before merging. Rollback is a single-commit revert.
- **`Microsoft.Graph` 6.2.0 → 6.5.0 behavior drift.** Three minor versions of the Graph SDK.
  *Mitigation:* review any Graph call sites for changed defaults; the build and test suite are green.
- **`format-check` is red**, so the PR is not mergeable under a required-checks policy.
  *Mitigation:* one `dotnet csharpier .` commit, as above. No package version is affected.
- **Reformatting hides semantic change from reviewers.** The raw diff is ~9,800 changed lines, of which the meaningful portion is far smaller.
  *Mitigation:* review with `git diff -w` or read the tables above rather than the raw diff.

# Review Guide

The raw diff is large and almost entirely mechanical. Suggested order:

1. **Start with the tables above** — they are the complete semantic change set (46 upgrades, 1 addition, 0 removals).
2. **`packages.config` files** — the source of truth for versions. Small and readable.
3. **One `.csproj`**, e.g. `UtilitiesCS/UtilitiesCS.csproj` (the largest at 139 lines changed) — confirm `<Reference>` versions and `HintPath` values agree with `packages.config`. The other 16 follow the same pattern.
4. **One `app.config`**, e.g. `TaskMaster/app.config` — confirm redirects match. Verified across all 16: 394 redirects added at `10.0.0.11`, 357 removed at `10.0.0.10`, 48 net-new `dependentAssembly` blocks.
5. **Skip the reformatting noise.** `git diff -w` collapses most of it; the multi-line-to-single-line attribute rewrite accounts for the bulk of the `−7141` deletions.

# Follow-ups

- Commit a `dotnet csharpier .` pass to clear `format-check` (required before merge).
- Consider whether the NuGet package manager should be configured to preserve the repo's XML formatting, or whether `csharpier` should run automatically after a package operation — this reformatting churn will recur on every future upgrade PR.
- Smoke-test the Outlook add-in against the new binding redirects.

# GitHub Auto-close

None — the context bundle records no verified or author-asserted autoclose issues, and the commit references no issue.
