### PR TITLE
docs: restore 61 promoted potential records stranded on an unmerged branch

### DIFF
--- a/docs/features/potential/promoted/2026-08-07-breadcrumb-capturecurrentortests-silently-degrades-in-production.md
+++ b/docs/features/potential/promoted/2026-08-07-breadcrumb-capturecurrentortests-silently-degrades-in-production.md
@@ -1,0 +1,139 @@
+# breadcrumb-capturecurrentortests-silently-degrades-in-production (Issue #475)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/breadcrumb-capturecurrentortests-silently-degrades-in-production/ (Issue #475)
+- Work Mode: full-bug
+- Discovered during: preparation research for issue #455 (epic #136, child F13)
+
+- Issue: #475
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/475
+- Last Updated: 2026-08-08
+## Summary
+
+`BreadcrumbPopupUiOperations.CaptureCurrentOrTests()` inverts a deliberate fail-fast guard into a
+silent degradation. When no `SynchronizationContext` is present it falls back to a **test-mode**
+dispatcher whose documented contract is to *report* cross-thread work rather than schedule it. Four
+production call sites use this method, so on any thread without a synchronization context the
+breadcrumb popup silently never opens: no exception, no user-visible error, only a log line.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Runtime: .NET Framework 4.8.1 WinForms VSTO add-in with Microsoft WebView2
+- Affected path: QuickFiler breadcrumb folder-selector drop-down construction
+
+## Suspected Cause
+
+`QuickFiler/Viewers/BreadcrumbUiDispatcher.cs:43-54` establishes the intended production contract —
+fail fast:
+
+```csharp
+internal static BreadcrumbUiDispatcher CaptureCurrent()
+{
+    SynchronizationContext context =
+        SynchronizationContext.Current
+        ?? throw new InvalidOperationException(
+            "Breadcrumb UI components must be constructed on an owning UI synchronization context."
+        );
+    ...
+}
+```
+
+`QuickFiler/Viewers/BreadcrumbPopupUiOperations.cs:86-89` overrides that contract:
+
+```csharp
+internal static BreadcrumbPopupUiOperations CaptureCurrentOrTests() =>
+    SynchronizationContext.Current == null
+        ? CreateForCurrentThreadTests()
+        : CaptureCurrent();
+```
+
+The fallback target is documented at `BreadcrumbUiDispatcher.cs:58-60` as:
+
+> Creates an owner-thread-only boundary for host-neutral unit tests without a UI pump.
+> Cross-thread work is reported instead of being scheduled on a generic context.
+
+So the exact condition the production guard was written to reject — a missing synchronization
+context — is the condition that silently selects a dispatcher that does not marshal.
+
+## Production Call Sites (verified 2026-08-07)
+
+```
+QuickFiler/Viewers/BreadcrumbDropDownHost.cs:98
+QuickFiler/Viewers/BreadcrumbDropDownHost.cs:118
+QuickFiler/Viewers/ItemViewer.Breadcrumb.cs:156
+QuickFiler/Viewers/ItemViewer.Breadcrumb.cs:192
+```
+
+None is test-only. `CreateForCurrentThreadTests()` is named for test use but is reachable from all
+four.
+
+## Steps to Reproduce
+
+1. Construct the breadcrumb drop-down host from a thread where `SynchronizationContext.Current` is
+   null — for example a thread-pool continuation, a background worker, or any path that has lost
+   the WinForms context.
+2. Request the drop-down open.
+3. Observe that no popup appears, no exception is raised, and the only trace is a reported failure
+   through the dispatcher's error sink.
+
+## Expected Behavior
+
+Production construction off the owning UI synchronization context is a programming error and should
+fail fast with the `InvalidOperationException` that `CaptureCurrent()` already defines. The
+test-mode dispatcher should not be reachable from production call sites.
+
+## Actual Behavior
+
+The construction succeeds, the drop-down is wired to a dispatcher that reports rather than
+marshals, and the feature silently does nothing.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+Severity is High because the failure mode is silent and user-facing: the folder selector simply
+does not open, with no diagnostic surfaced to the user and no exception to correlate in a crash
+report. It also violates `CLAUDE.md` § "Error Handling" ("fail fast and explicitly; do not silently
+ignore errors") and `.claude/rules/general-code-change.md` § "Error Handling and Logging".
+
+There is a secondary design concern: a test-only affordance is reachable from production code. The
+repository's determinism guidance expects test seams to be injected by the test, not selected at
+runtime by probing ambient state.
+
+## Suggested Remediation
+
+Preferred: delete `CaptureCurrentOrTests()` and have the four production call sites use
+`CaptureCurrent()`, restoring fail-fast. Tests construct `BreadcrumbPopupUiOperations` through its
+existing injectable constructor (`BreadcrumbPopupUiOperations.cs:62-78`) or supply a fake
+`SynchronizationContext`, both of which are already used by the existing test suite — so no test
+loses its seam.
+
+Alternative, if some production path genuinely runs without a context: make that path explicit by
+passing the dispatcher in, rather than probing `SynchronizationContext.Current` inside a static
+factory.
+
+## Why this is not fixed under epic #136
+
+Epic #136 child F13 (issue #455) carries a hard no-behavior-change NFR. Restoring the throw changes
+observable behavior on the affected paths, so it belongs in its own issue.
+
+Note also that `ItemViewer.Breadcrumb.cs` is assigned to child F14, not F13, so two of the four call
+sites are outside F13's file assignment. This reinforces that the fix belongs in a standalone issue
+rather than inside either child.
+
+## Related
+
+- Issue #455 — F13, breadcrumb drop-down and WebView2 host coverage (where this was found).
+- Issue #136 — parent epic.
+- Issue #462 — breadcrumb drop-down coordinator stale `_closePending`; a second silent-failure mode
+  in the same open/close path. Worth scheduling together.
+
+## Next Step
+
+- [ ] Promote to GitHub issue
+- [ ] Confirm whether any production path legitimately runs without a synchronization context

--- a/docs/features/potential/promoted/2026-08-07-breadcrumb-dropdown-coordinator-stale-closepending-drops-reopen.md
+++ b/docs/features/potential/promoted/2026-08-07-breadcrumb-dropdown-coordinator-stale-closepending-drops-reopen.md
@@ -1,0 +1,144 @@
+# breadcrumb-dropdown-coordinator-stale-closepending-drops-reopen (Issue #462)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/breadcrumb-dropdown-coordinator-stale-closepending-drops-reopen/ (Issue #462)
+- Work Mode: full-bug
+- Discovered during: preparation research for issue #455 (epic #136, child F13)
+
+- Issue: #462
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/462
+- Last Updated: 2026-08-08
+## Summary
+
+`BreadcrumbDropDownOpenCoordinator.CloseCore` never clears its `_closePending` flag on the
+**successful** close path. The flag latches `true` after the first close that actually closes the
+host and is never reset. `RequestOpen` consults that stale flag and can silently return a
+already-closed sentinel task instead of opening the drop-down, dropping a legitimate reopen
+request with no error and no log.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Runtime: .NET Framework 4.8.1 WinForms VSTO add-in with Microsoft WebView2
+- Affected path: QuickFiler item folder-selector breadcrumb drop-down open/close lifetime
+
+## Suspected Cause
+
+`QuickFiler/Viewers/BreadcrumbDropDownOpenCoordinator.cs:237-267`:
+
+```csharp
+private bool CloseCore(BreadcrumbDropDownCloseReason reason)
+{
+    lock (_sync)
+    {
+        if (_released)
+            return false;
+        if (_closePending)
+            return true;
+        _closePending = true;          // :245  latched here
+    }
+    bool closed;
+    try
+    {
+        closed = _host.Close(reason);
+    }
+    catch
+    {
+        ClearClosePending();           // :254  cleared on throw
+        throw;
+    }
+    if (closed)
+    {
+        lock (_sync)
+            _generation++;
+        return true;                   // :261  returns WITHOUT ClearClosePending()
+    }
+    ClearClosePending();               // :263  cleared on the not-closed path
+    ...
+}
+```
+
+Every exit path clears `_closePending` **except** the successful one at `:257-261`. That is the
+inverted case: the successful close is exactly the path after which the coordinator should be
+ready to accept a new open.
+
+The stale flag is then read by `RequestOpen` at `:92-93`:
+
+```csharp
+if (_closePending && _host.IsOpen)
+    return ClosedTask;
+```
+
+## Steps to Reproduce
+
+1. Open the breadcrumb drop-down so `_host.IsOpen` is true.
+2. Close it through a path that reaches `CloseCore` and where `_host.Close(reason)` returns `true`.
+   `_closePending` is now permanently `true`.
+3. Cause the host to become open again through a path that does not route through
+   `CloseCore`/`RequestOpen` — for example `SetDroppedDown(true)` at `:108-112`, where
+   `_openSelector()` reports no change and `_isSelectorOpen()` is true.
+4. Call `RequestOpen`.
+5. Observe that the guard at `:92` is satisfied (`_closePending` stale-true and `_host.IsOpen`
+   true) and `ClosedTask` is returned. The open request is discarded silently.
+
+## Expected Behavior
+
+`_closePending` describes an in-flight close. Once `_host.Close` has completed successfully the
+close is no longer pending, so a subsequent `RequestOpen` should proceed and open the drop-down.
+
+## Actual Behavior
+
+`_closePending` remains `true` for the remaining lifetime of the coordinator, so `RequestOpen` can
+short-circuit to `ClosedTask` whenever the host is open.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+The user-visible symptom is a folder-selector drop-down that intermittently refuses to reopen until
+the viewer is recycled. The failure is silent — no exception, no log line — which makes it
+expensive to diagnose from a bug report. Severity is Medium because reaching the state requires the
+specific reopen path in step 3 rather than the common open/close cycle.
+
+## Additional Note — this is also the file's coverage gap
+
+The same condition is one of the four uncovered branch outcomes measured in this file
+(`BreadcrumbDropDownOpenCoordinator.cs`, 98.25% line / 92.05% branch in the committed Cobertura at
+`docs/features/active/2026-08-06-quickfiler-high-confidence-queue-init-stall-424/evidence/qa-gates/coverage-final.cobertura.xml`).
+The branch is uncovered precisely because no test asserts the post-close reopen contract. The
+coverage gap and the defect are the same finding, which is why a coverage-only change cannot close
+it: writing the test that covers the branch would assert the current, incorrect behavior.
+
+## Suggested Remediation
+
+Call `ClearClosePending()` on the successful-close path before returning `true` at `:261`, or
+restructure so the flag is cleared in a `finally`. Then add a regression test asserting that
+`RequestOpen` opens after a successful `CloseCore`.
+
+Related nearby observations, worth reconciling in the same change:
+
+- `_host.IsOpen` is evaluated while holding `_sync` at `:92`, inconsistent with `CloseCore`'s
+  deliberate decision to call `_host.Close` **outside** the lock at `:250`. That asymmetry is a
+  lock-ordering hazard (`Coordinator._sync` -> host lock).
+- `Close` is a *claim* rather than a completion: `CloseCore` returns `true` at `:243-244` when a
+  close is already pending, so callers cannot distinguish "closed" from "someone else is closing".
+
+## Why this is not fixed under epic #136
+
+Epic #136 child F13 (issue #455) carries a hard no-behavior-change NFR. Clearing the flag changes
+observable drop-down open/close behavior, so it belongs in its own issue.
+
+## Related
+
+- Issue #455 — F13, breadcrumb drop-down and WebView2 host coverage (where this was found).
+- Issue #136 — parent epic.
+- Issue #440 — open breadcrumb arrow-key navigation bug in adjacent territory; reconcile scheduling.
+
+## Next Step
+
+- [ ] Promote to GitHub issue
+- [ ] Reconcile against F13's plan before scheduling, since F13 adds tests over this file

--- a/docs/features/potential/promoted/2026-08-07-efc-controllers-null-guard-and-async-void-boundary-defects.md
+++ b/docs/features/potential/promoted/2026-08-07-efc-controllers-null-guard-and-async-void-boundary-defects.md
@@ -1,0 +1,120 @@
+# efc-controllers-null-guard-and-async-void-boundary-defects (Issue #464)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/efc-controllers-null-guard-and-async-void-boundary-defects/ (Issue #464)
+- Work Mode: full-bug
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #464
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/464
+- Last Updated: 2026-08-08
+## Summary
+
+Across `EfcFormController` and `EfcItemController`, theme and dark-mode property accessors lack the
+null guards their already-merged QFC twins have, and several `async void` handlers rethrow from their
+catch blocks — which terminates the host process rather than surfacing a handled error.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Runtime: .NET Framework 4.8.1 WinForms VSTO add-in
+- UI path: `QuickFiler/Controllers/EfcFormController.cs`, `QuickFiler/Controllers/EfcItemController.cs`
+- Data source or fixture: n/a
+
+## Steps to Reproduce
+
+1. Reach the post-`Cleanup` state on either controller, where `_globals` and `_themes` are null.
+2. Read `DarkMode` or `ActiveTheme`.
+3. Observe `NullReferenceException` / `ArgumentNullException` where the QFC twin returns a default.
+
+For the `async void` path: cause any of the listed button handlers to fault and observe that the
+rethrow terminates the host rather than being contained.
+
+## Expected Behavior
+
+- Theme and dark-mode accessors return their cached default when their dependencies are null, matching
+  the merged QFC implementations.
+- A faulted UI event handler logs and contains the error; it does not terminate the Outlook host.
+- Fire-and-forget tasks carry an explicit logged error boundary.
+
+## Actual Behavior
+
+**A — missing null guards on the EFC side.**
+`EfcFormController.cs:276-283` passes `_globals.Ol` eagerly as a `params object[]` element, so the
+getter throws `NullReferenceException` when `_globals` is null. `EfcFormController.cs:257` uses
+`strict: true` with `_themes` as the sole dependency, so the getter throws `ArgumentNullException`
+(`Initializer.cs:310-321`) when `_themes` is null. `EfcFormController.cs:269` dereferences a null
+`_themes`. The already-merged twin guards all three: `QfcFormController.cs:103-105`
+(`_themes is null ? _activeTheme : ...`), `:123` (`if (_themes is not null && _themes.TryGetValue(...))`),
+`:134` (`_globals?.Ol is null ? _darkMode : ...`).
+
+The same eager-argument shape appears at `EfcItemController.cs:441-448`: `DarkMode`'s getter passes
+`_globals.Ol` as a dependency argument, evaluated **before** `Initializer.DependenciesNotNull` can
+inspect it, so the post-`Cleanup` state throws instead of returning the intended `false` default.
+`DarkMode_Changed` (`:803`) is compile-time-safe via `nameof`, but `:805` (`_globals.Ol.DarkMode`) is not.
+
+**B — `async void` rethrow terminates the host.**
+`EfcFormController.cs:424-428`, `:440-444`, `:456-460`, `:516-520`, `:529-533` each perform
+`logger.Error(...); throw;` inside an `async void` method. A rethrow from `async void` is posted to the
+synchronization context as an unhandled exception.
+
+**C — unobserved fire-and-forget task.** `EfcFormController.cs:97` and `:117` use
+`_ = PopulateFolderCombobox()`. `PopulateFolderCombobox` (`:1024-1038`) has no `try`/`catch`, so a
+failure inside `InitFolderHandlerAsync` or `FolderHelper.FolderArray` faults an unobserved `Task` and
+the folder list silently stays empty. The sibling fire-and-forget at `:853` does carry a logged
+boundary in `InitializeBreadcrumbHostAsync` (`:858-868`).
+
+**D — `async void` lambdas in keyboard actions.** `EfcItemController.cs:741`, `:882`, `:887`, `:704`,
+`:711`, `:716`. `CharActions` is `KbdActions<char, KaChar, Action<char>>` (`IQfcKeyboardHandler.cs:21`),
+so `async (x) => await JumpToAsync(...)` compiles as an `async void` lambda: any fault is raised on the
+thread pool and crashes the process rather than surfacing to the caller.
+
+**E — stack-trace-destroying rethrow.** `EfcItemController.cs:777` does `throw (e.InitializationException)`,
+rethrowing a captured exception and resetting its stack trace, from inside a WebView2 event handler on
+the UI thread.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Code-read evidence recorded above (verified 2026-08-07 against the working tree).
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+The `async void` rethrows can terminate the Outlook host process. The missing null guards make
+post-cleanup property reads throw where the QFC equivalents return safely.
+
+## Suspected Cause / Notes
+
+The QFC controllers received defensive null guards in earlier work; the EFC twins were not updated at
+the same time, so the two sides of an otherwise-parallel design have diverged. Using the merged QFC
+implementations as the reference is the lowest-risk route.
+
+The `async void` items are a boundary-design problem rather than a regression: `logger.Error(...); throw;`
+looks like correct propagation but has no caller to propagate to.
+
+Related open issue: #451 `Bug: efc-home-controller-metrics-inert-duration` covers a separate EFC-family
+defect.
+
+Discovered during preparation of issue #452 (epic #136) per-file coverage research. Out of scope there
+under that feature's no-behavior-change constraint.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Port the `QfcFormController.cs:103-105,123,134` guard shapes to the EFC accessors
+- [ ] Replace `logger.Error(...); throw;` in `async void` handlers with log-and-contain
+- [ ] Give `PopulateFolderCombobox` an explicit logged error boundary
+- [ ] Use `ExceptionDispatchInfo.Capture(...).Throw()` or wrap in `InvalidOperationException` at `EfcItemController.cs:777`
+- [ ] Unit coverage: post-cleanup property reads; faulting handler does not escape; faulting fire-and-forget logs
+- [ ] Manual verification: induced handler failure logs without terminating Outlook
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-efc-dead-code-and-latent-nre-traps.md
+++ b/docs/features/potential/promoted/2026-08-07-efc-dead-code-and-latent-nre-traps.md
@@ -1,0 +1,113 @@
+# efc-dead-code-and-latent-nre-traps (Issue #466)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/efc-dead-code-and-latent-nre-traps/ (Issue #466)
+- Work Mode: full-bug
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #466
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/466
+- Last Updated: 2026-08-08
+## Summary
+
+`EfcViewer.SetController` is never called, so `EfcViewer._formController` is permanently null and
+`EditFiltersMenuItem_Click` carries a latent `NullReferenceException` that a routine Designer
+regeneration would arm. Several other EFC members and one orphaned file are dead code.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Runtime: .NET Framework 4.8.1 WinForms VSTO add-in
+- UI path: `QuickFiler/Viewers/EfcViewer.cs`, `QuickFiler/Controllers/EfcItemController.cs`
+- Data source or fixture: n/a
+
+## Steps to Reproduce
+
+The trap is currently unreachable by design; it is armed by a maintenance action:
+
+1. Open `EfcViewer` in the Visual Studio Designer and re-generate `EfcViewer.Designer.cs`, or otherwise
+   wire `EditFiltersMenuItem.Click` to `EfcViewer.EditFiltersMenuItem_Click`.
+2. Open the Email Filer viewer and choose the Edit Filters menu item.
+3. Observe `NullReferenceException`.
+
+## Expected Behavior
+
+Either the controller is wired into the viewer so the Edit Filters command works, or the dead member
+and its unreachable handler are removed so no trap remains.
+
+## Actual Behavior
+
+**A — dead `SetController`, permanently null field.** `EfcViewer.cs:50-53` declares
+`internal void SetController(EfcFormController controller)`. A repository-wide search for
+`SetController` finds call sites only in `QfcFormController.cs:44`, `QfcFormViewer.cs:46`,
+`QfcFormViewerDark.cs:31`, `QfcFormViewerExpanded.cs:31`, and the non-compiled `Legacy/` and
+`EfcViewer3.cs` files. **`EfcFormController` never calls it**, unlike its QFC twin. Consequently
+`EfcViewer._formController` (`EfcViewer.cs:48`) is always null and
+`EfcViewer.EditFiltersMenuItem_Click` (`EfcViewer.cs:157-160`) would throw.
+
+The handler is currently unreachable: `EfcViewer.Designer.cs` never wires `EditFiltersMenuItem.Click`.
+Verified — across 4,277 lines the only references are the declaration at `:67`, the `DropDownItems`
+add at `:4123`, three property assignments at `:4136-4138`, and the field at `:4275`. There is no
+`+=` at all. So this is dead code carrying a latent trap, not a live crash.
+
+**B — zero-call-site members in `EfcItemController`.** `InitializeWebView()` (`:174-205`) and
+`RegisterActions(...)` (`:680-692`) have no call sites repo-wide (verified by grep across `QuickFiler/`
+and `QuickFiler.Test/`). `_selectorsCtrls` (`:381`) is initialized to `null` and never assigned before
+being passed to `SetupThemes` as the `selectors` argument (`:97`, `:144`).
+
+**C — unused constructor overload.** The `EfcItemController`
+`(globals, homeController, parent, itemViewer, dataModel, bool async, token)` overload (`:44-57`) has
+zero call sites; only the 6-argument (`:30`) and 5-argument (`:59`) forms are used, by
+`EfcFormController.cs:87` and `:69`.
+
+**D — orphaned uncompiled files.** `QuickFiler/Viewers/EfcViewer3.cs` and its siblings are present in
+the working tree but carry no `<Compile Include>` entry in `QuickFiler/QuickFiler.csproj`. `EfcViewer3.cs`
+nonetheless carries an `[ExcludeFromCodeCoverage]` attribute at `:17`, which is misleading — an
+uncompiled file needs no exemption.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Code-read evidence recorded above (verified 2026-08-07 against the working tree).
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+Nothing fails today. The severity is the maintenance trap: the Edit Filters command is silently
+non-functional, and the natural act of re-wiring it in the Designer converts that into a crash.
+
+## Suspected Cause / Notes
+
+The EFC viewer appears to have been modelled on the QFC viewer, which does call `SetController`, but
+the corresponding call was never added on the EFC side. The dead members in `EfcItemController` look
+like superseded initialization paths left behind after refactors.
+
+Deciding between "wire it up" and "delete it" requires knowing whether the Edit Filters command is
+intended to be available on this form — a product question, not a mechanical one, which is why this is
+promoted rather than fixed opportunistically.
+
+Note that `EfcViewer3.cs`'s attribute contributed to an inflated exemption count in earlier surveys;
+the epic manifest for #136 records the correction (21 real attributes on compiled files, not 33).
+
+Discovered during preparation of issue #452 (epic #136) per-file coverage research. Out of scope there
+under that feature's no-behavior-change constraint.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Decide whether the Edit Filters command should be available on `EfcViewer`; wire or remove accordingly
+- [ ] Remove the zero-call-site members and constructor overload, or document why they are retained
+- [ ] Resolve `_selectorsCtrls` — assign it or stop passing it
+- [ ] Delete the orphaned `EfcViewer3.*` files, or add them to the project if they are still wanted
+- [ ] Unit coverage: whichever disposition is chosen for the Edit Filters path
+- [ ] Manual verification: Edit Filters menu item behaves as decided
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-efc-form-controller-lifecycle-and-selection-defects.md
+++ b/docs/features/potential/promoted/2026-08-07-efc-form-controller-lifecycle-and-selection-defects.md
@@ -1,0 +1,106 @@
+# efc-form-controller-lifecycle-and-selection-defects (Issue #465)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/efc-form-controller-lifecycle-and-selection-defects/ (Issue #465)
+- Work Mode: full-bug
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #465
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/465
+- Last Updated: 2026-08-08
+## Summary
+
+Four independent defects in `EfcFormController`: a non-idempotent `Cleanup()` reachable twice from one
+user gesture, a cross-thread WinForms control read inside `Task.Run`, duplicate "Trash to Delete" rows
+accumulating on repeated delete actions, and an inconsistent banner-prefix test across three sites.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Runtime: .NET Framework 4.8.1 WinForms VSTO add-in
+- UI path: `QuickFiler/Controllers/EfcFormController.cs`
+- Data source or fixture: an Email Filer session with folder suggestions populated
+
+## Steps to Reproduce
+
+**A — double cleanup.** Trigger the OK action with the Return key while the OK button `Click`
+subscription is also live; observe the second `ActionOkAsync` dereference a nulled field.
+
+**C — duplicate trash rows.** Invoke the delete action twice (via the `'T'` keyboard action or the
+delete button) and observe two `"Trash to Delete"` rows in the folder list.
+
+## Expected Behavior
+
+- `Cleanup()` is idempotent, or is guarded so it cannot run twice for one gesture.
+- WinForms control properties are read only on the UI thread.
+- The trash row appears at most once regardless of how many times delete is invoked.
+- A row's banner-prefix classification is identical everywhere it is tested.
+
+## Actual Behavior
+
+**A — `Cleanup()` is not idempotent and has no re-entrancy guard (`EfcFormController.cs:189-196`).**
+A second invocation dereferences the already-nulled `_globals` at `:191`. Two independent paths can
+invoke the OK action for a single user gesture: the always-on Return key binding (`:365`,
+`new KaKeyAsync("Collection", Keys.Return, (k) => ActionOkAsync())`) and the OK button `Click`
+subscription (`:391`). If both fire, the second `ActionOkAsync` throws `NullReferenceException` at
+`:705` on the nulled `_formViewer`. `EfcHomeController.TryBeginExecuteMoves`
+(`EfcHomeController.ExecuteMoves.cs:48-57`) shows the `_isExecuting`-style guard this path lacks.
+
+**B — cross-thread control read (`EfcFormController.cs:800-803`).** `RefreshSuggestionsAsync`
+evaluates `_formViewer.SearchText.Text` **inside** the `Task.Run` lambda. Reading `Control.Text` off
+the UI thread is an illegal cross-thread control access. `SearchText_TextChanged` (`:558`) reads the
+same property correctly on the UI thread.
+
+**C — duplicate trash rows (`EfcFormController.cs:742-750`).** `ActionDeleteAsync` reads `_folderRows`,
+inserts `"Trash to Delete"` at index 0, and rebinds. `BindFolderRows` (`:881`) then stores the *result*
+— which now contains the trash row — back into `_folderRows`. A second invocation inserts a second
+trash row. No dedupe guard exists.
+
+**D — inconsistent banner-prefix detection.** `IsValidSelection` (`:1049`) tests
+`Substring(0, 3) == "==="` (three characters); `ActionOkAsync` (`:708`) tests `StartsWith("====")`
+(four); `BreadcrumbRowBuilder.BannerPrefix` (`BreadcrumbRowBuilder.cs:19`) is `"===="` (four). A row
+beginning with exactly three `=` is rejected by `IsValidSelection` but accepted by `ActionOkAsync` and
+classified as a suggestion by the row builder.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Code-read evidence recorded above (verified 2026-08-07 against the working tree).
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+Defect A is an unhandled exception on the primary filing gesture. Defect B is an illegal cross-thread
+access whose symptom is intermittent and environment-dependent, which makes it hard to attribute.
+
+## Suspected Cause / Notes
+
+Defects A and C share a root shape: an action that mutates shared state without a guard against being
+run twice. Defect B is a `Task.Run` lambda that captured more than the intended work — only the
+computation needed to move off the UI thread, not the control read that feeds it.
+
+Defect D is a literal-duplication problem; `BreadcrumbRowBuilder.BannerPrefix` already exists as the
+single source of truth and should be referenced by both controller sites.
+
+Discovered during preparation of issue #452 (epic #136) per-file coverage research. Out of scope there
+under that feature's no-behavior-change constraint.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Add an `_isExecuting`-style re-entrancy guard mirroring `EfcHomeController.TryBeginExecuteMoves`
+- [ ] Hoist the `SearchText.Text` read out of the `Task.Run` lambda onto the UI thread
+- [ ] Add a dedupe guard before inserting the trash row, or stop writing the bound result back to `_folderRows`
+- [ ] Reference `BreadcrumbRowBuilder.BannerPrefix` from both controller sites
+- [ ] Unit coverage: double OK gesture; refresh-suggestions threading; repeated delete; three- and four-`=` rows
+- [ ] Manual verification: repeated delete shows one trash row; filing via Return and via OK button both succeed
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-efc-home-controller-metrics-inert-duration.md
+++ b/docs/features/potential/promoted/2026-08-07-efc-home-controller-metrics-inert-duration.md
@@ -1,0 +1,107 @@
+# efc-home-controller-metrics-inert-duration (Issue #451)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/efc-home-controller-metrics-inert-duration/ (Issue #451)
+- Discovered by: research for [#437](https://github.com/drmoisan/TaskMaster/issues/437) (`quickfiler-efc-home-controller-coverage`, epic child F8 of [#136](https://github.com/drmoisan/TaskMaster/issues/136))
+- Severity: Low-Medium (silent data-quality defect in a metrics CSV; no user-visible crash)
+
+- Issue: #451
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/451
+- Last Updated: 2026-08-08
+## Summary
+
+Six latent defects were verified by direct source inspection in the `EfcHomeController` metrics and
+move-execution paths. None was fixed in #437 because the parent epic's NFR forbids behavior change
+in a coverage-only child. They are recorded here so they survive as tracked work rather than as
+prose inside a feature folder.
+
+## Defect 1 — the QuickFile duration metric is permanently zero (primary)
+
+`EfcHomeController._stopWatch` is constructed but **never started**:
+
+- `QuickFiler/Controllers/EfcHomeController.cs` L76 — `_stopWatch = new Stopwatch();`
+- `QuickFiler/Controllers/EfcHomeController.cs` L225 — `_stopWatch = new Stopwatch();`
+- No `_stopWatch.Start()` call exists anywhere in the `EfcHomeController` family.
+
+Contrast the sibling controller, which does start its stopwatch:
+
+- `QuickFiler/Controllers/QfcHomeController.cs` L267-268 — `_stopWatch = new Stopwatch(); _stopWatch.Start();`
+
+Consequently `QuickFiler/Controllers/EfcHomeController.Metrics.cs` L23 always evaluates
+`_stopWatch.Elapsed.Seconds` as `0`, so every EFC-path metrics row records a duration of zero. The
+metric is inert and any analysis built on it is measuring nothing.
+
+**Verification:** `grep -rn "_stopWatch" QuickFiler/Controllers/` returns construction and read
+sites for `EfcHomeController` but no `Start()`; the `QfcHomeController` sites show the intended
+pattern.
+
+## Defect 2 — `.Seconds` instead of `.TotalSeconds` truncates durations past one minute
+
+`EfcHomeController.Metrics.cs` L23 passes `_stopWatch.Elapsed.Seconds`, which is the 0-59 second
+*component* of the interval, not its total length. Any elapsed time of 1m05s is reported as 5
+seconds. This is latent behind Defect 1 today but becomes active the moment the stopwatch is
+started, so the two must be fixed together.
+
+## Defect 3 — non-atomic check-then-set in `TryBeginExecuteMoves`
+
+`QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs` guards re-entrancy with a `volatile`
+field, but `volatile` only constrains memory ordering; it does not make the read-then-write atomic.
+Two callers can both observe the "not executing" state and both proceed. `Interlocked.CompareExchange`
+is the correct primitive.
+
+## Defect 4 — missing CSV field separator between two columns
+
+The metrics line interpolation omits a separator between `ToRecipientsName` and `SenderName`, so the
+two values are emitted concatenated. This defect is currently **pinned by an existing assertion**
+expecting the concatenated form `"RecipientSender"` at
+`QuickFiler.Test/Controllers/EfcHomeControllerMetricsTests.cs` L59. Any fix must update that
+assertion deliberately; #437 preserves it verbatim precisely because changing it would be a behavior
+change.
+
+## Defect 5 — incomplete CSV sanitization
+
+`QfcCollectionController.xComma(...)` is applied only to `Subject` in
+`EfcHomeController.Metrics.cs`, while three other interpolated fields
+(`ToRecipientsName`, `SenderName`, and the folder value) are written unsanitized. A comma in any of
+them corrupts the CSV row shape.
+
+## Defect 6 — `QuickFileMetrics_WRITE(string filename)` throws `NotImplementedException`
+
+`EfcHomeController.Metrics.cs` L26-29 declares a public single-argument overload whose entire body is
+`throw new NotImplementedException();`. It is public API surface that cannot be called successfully.
+Either implement it or remove it.
+
+## Proposed Fix (outline)
+
+1. Start the stopwatch where the EFC session begins, mirroring `QfcHomeController` L267-268.
+2. Switch the duration read to `.TotalSeconds` and widen the parameter type accordingly.
+3. Replace the `volatile` check-then-set with `Interlocked.CompareExchange`.
+4. Add the missing CSV separator and update the pinning assertion in the same commit.
+5. Apply `xComma` to every interpolated CSV field.
+6. Implement or remove the `NotImplementedException` overload.
+
+Items 1, 2 and 4 change the content of an emitted metrics file, so they need a deliberate decision
+about backward compatibility with any existing downstream consumer of that CSV.
+
+## Acceptance Criteria (early draft)
+
+- [ ] The EFC QuickFile duration metric records a real non-zero elapsed time.
+- [ ] Durations beyond one minute are reported in full, not truncated to the seconds component.
+- [ ] Re-entrancy protection in `TryBeginExecuteMoves` is atomic.
+- [ ] Every interpolated CSV field is comma-sanitized and correctly separated.
+- [ ] No public method body remains a bare `NotImplementedException`.
+- [ ] Regression tests cover each fix; the metrics-format change is asserted explicitly rather than
+      pinned to the defective output.
+
+## Constraints & Risks
+
+- Changing emitted CSV content is a behavior change with potential downstream consumers.
+- `EfcHomeControllerMetricsTests.cs` L59 currently asserts the defective concatenation and must be
+  updated in the same change.
+- Coverage work for these files is tracked separately under #437; this issue is behavior-only.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug template)
+- [ ] Create the active feature folder from the template

--- a/docs/features/potential/promoted/2026-08-07-efc-item-controller-cleanup-nre-and-timer-leak.md
+++ b/docs/features/potential/promoted/2026-08-07-efc-item-controller-cleanup-nre-and-timer-leak.md
@@ -1,0 +1,102 @@
+# efc-item-controller-cleanup-nre-and-timer-leak (Issue #460)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/efc-item-controller-cleanup-nre-and-timer-leak/ (Issue #460)
+- Work Mode: full-bug
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #460
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/460
+- Last Updated: 2026-08-08
+## Summary
+
+`EfcItemController.Cleanup()` throws `NullReferenceException` for controllers built through one of the
+public constructors, leaks an armed `System.Threading.Timer`, and leaves the `Subject` property in an
+inconsistent post-cleanup state relative to its sibling properties.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Runtime: .NET Framework 4.8.1 WinForms VSTO add-in
+- UI path: `QuickFiler/Controllers/EfcItemController.cs` item teardown path
+- Data source or fixture: n/a
+
+## Steps to Reproduce
+
+1. Construct an `EfcItemController` through the `(globals, homeController, parent, itemViewer, token)`
+   constructor.
+2. Call `Cleanup()` without first calling `InitializeWithoutData()` or `InitializeDataFields()`.
+3. Observe `NullReferenceException`.
+
+For the timer leak:
+
+1. Expand an unread item so the mark-as-read timer is armed.
+2. Clean up the item while it is still expanded and unread.
+3. Observe that the `System.Threading.Timer` is dropped without being disposed.
+
+## Expected Behavior
+
+- `Cleanup()` is safe to call on any constructed controller regardless of which initializer ran.
+- Disposable resources owned by the controller are disposed, not merely dereferenced.
+- Property accessors behave consistently with each other after cleanup.
+
+## Actual Behavior
+
+**A — unconditional dereference (`EfcItemController.cs:257`).** `Cleanup()` dereferences `Buttons`
+(backing field `_buttons`). `_buttons` is only assigned in `ResolveControlGroups` (`:341`), which the
+`(globals, homeController, parent, itemViewer, token)` constructor never runs. `Cleanup` also never
+nulls `_buttons` while nulling 15 sibling fields, and `_itemViewer = null` is written twice (`:264`
+and `:276`).
+
+**B — timer leaked (`EfcItemController.cs:277`).** `_timer = null` is assigned **without disposing**
+the timer, leaking an armed `System.Threading.Timer` whenever the item is cleaned up while expanded
+and unread.
+
+**C — inconsistent post-cleanup property behavior (`EfcItemController.cs:610-613` vs `:595-598`).**
+`Subject` reads `_itemViewer.LblSubject.Text` while `Sender` and `To` read `_itemInfo`. After
+`Cleanup()` nulls `_itemViewer` (`:264`), `Subject` throws while `Sender` still works. Before
+`PopulateControls` runs, `Subject` returns the Designer placeholder rather than the mail subject.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Code-read evidence recorded above (verified 2026-08-07 against the working tree).
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+Defect A is an unhandled exception on a teardown path. Defect B leaks a live OS timer per affected
+item, which accumulates across a filing session.
+
+## Suspected Cause / Notes
+
+`Cleanup()` appears to have been written against the fully-initialized object graph produced by one
+constructor path and never revisited when the lighter constructor overloads were added. The duplicated
+`_itemViewer = null` assignment suggests the method has been edited incrementally without review of the
+whole body.
+
+Reading `Subject` from the viewer rather than the model (defect C) is the underlying inconsistency; the
+model-backed read used by `Sender`/`To` is the more robust shape.
+
+Discovered during preparation of issue #452 (epic #136) per-file coverage research. Out of scope there
+under that feature's no-behavior-change constraint.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Guard or null-condition the `Buttons` dereference and null `_buttons` alongside its siblings
+- [ ] Dispose `_timer` before nulling it
+- [ ] Read `Subject` from `_itemInfo` for consistency with `Sender`/`To`, or document why it differs
+- [ ] Remove the duplicated `_itemViewer = null` assignment
+- [ ] Unit coverage: cleanup after each constructor overload; double cleanup; cleanup while timer armed
+- [ ] Manual verification: filing session with many expanded unread items shows no timer growth
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-efc-item-controller-dead-conversation-expanded-handler.md
+++ b/docs/features/potential/promoted/2026-08-07-efc-item-controller-dead-conversation-expanded-handler.md
@@ -1,0 +1,96 @@
+# efc-item-controller-dead-conversation-expanded-handler (Issue #461)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/efc-item-controller-dead-conversation-expanded-handler/ (Issue #461)
+- Work Mode: full-bug
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #461
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/461
+- Last Updated: 2026-08-08
+## Summary
+
+`EfcItemController.ConversationResolverPropertyChanged` filters on a property name that
+`ConversationResolver` never raises, so the handler body is dead. Background-loaded conversation rows
+never reach the topic thread through this path.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Runtime: .NET Framework 4.8.1 WinForms VSTO add-in
+- UI path: `QuickFiler/Controllers/EfcItemController.cs` conversation-loading notification path
+- Data source or fixture: a mail item whose conversation is resolved asynchronously
+
+## Steps to Reproduce
+
+1. Open the Email Filer on a mail item that participates in a conversation.
+2. Allow the `ConversationResolver` to complete its background load, which raises
+   `PropertyChanged` notifications.
+3. Observe that the `EfcItemController` handler body never executes.
+
+## Expected Behavior
+
+When the conversation resolver signals that its conversation information has changed, the item
+controller reacts and the background-loaded conversation rows reach the topic thread.
+
+## Actual Behavior
+
+`EfcItemController.cs:746` guards on:
+
+```csharp
+e.PropertyName == nameof(_dataModel.ConversationResolver.ConversationInfo.Expanded)
+```
+
+`nameof(...)` resolves at compile time to the literal `"Expanded"`. `ConversationResolver` only ever
+raises:
+
+- `"ConversationInfo"` — `ConversationResolver.Loading.cs:26`
+- `"ConversationItems"` — `ConversationResolver.Loading.cs:167`
+- `"Df"` — `ConversationResolver.Loading.cs:205`, `:227`
+- `"UpdateUI"` — `ConversationResolver.cs:277`
+
+It never raises `"Expanded"`. The subscription at `:667` fires, but the body at `:749-753` never
+executes.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Code-read evidence recorded above (verified 2026-08-07 against the working tree).
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+A documented notification path is silently inert. The failure mode is missing behavior rather than an
+exception, which is why it has not been noticed.
+
+## Suspected Cause / Notes
+
+`nameof` applied to a nested property path (`...ConversationInfo.Expanded`) yields only the final
+segment, so the expression compiles cleanly and reads plausibly while selecting a name the publisher
+never emits. This is the classic `nameof`-on-a-path trap: the compiler cannot warn, because
+`"Expanded"` is a genuine member name — just not one this publisher raises.
+
+Determining the correct replacement requires deciding which of the four published names carries the
+intent; `"ConversationInfo"` is the most likely, but that should be confirmed against the intended
+behavior rather than assumed.
+
+Discovered during preparation of issue #452 (epic #136) per-file coverage research. Out of scope there
+under that feature's no-behavior-change constraint.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Confirm which published property name expresses the intended trigger
+- [ ] Replace the guard with that name and consider a defensive test asserting publisher/subscriber agreement
+- [ ] Unit coverage: handler fires for the intended name; ignores unrelated names
+- [ ] Manual verification: conversation rows appear in the topic thread after a background load
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-efc-item-controller-keyboard-registration-defects.md
+++ b/docs/features/potential/promoted/2026-08-07-efc-item-controller-keyboard-registration-defects.md
@@ -1,0 +1,102 @@
+# efc-item-controller-keyboard-registration-defects (Issue #459)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/efc-item-controller-keyboard-registration-defects/ (Issue #459)
+- Work Mode: full-bug
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #459
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/459
+- Last Updated: 2026-08-08
+## Summary
+
+Three related defects in `EfcItemController` keyboard-action registration: the `KbdActions<>` indexer
+setter silently drops unregistered keys, the async expansion path never registers or removes the
+`'B'`/`'D'` jump keys that the sync path does, and the resulting asymmetry can make a later sync
+expansion throw `ArgumentException`.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Runtime: .NET Framework 4.8.1 WinForms VSTO add-in
+- UI path: `QuickFiler/Controllers/EfcItemController.cs` expansion and keyboard-registration paths
+- Data source or fixture: n/a
+
+## Steps to Reproduce
+
+Defect B is the user-visible one:
+
+1. Open the Email Filer and expand an item through the **async** expansion path (`ToggleExpansionAsync`).
+2. Press `B` or `D` to jump to the message body / detail.
+3. Observe that the jump keys are not registered.
+4. Now expand through the **sync** path (`ToggleExpansion(ToggleState.On)`), collapse through the async
+   path, then expand through the sync path again.
+5. Observe an `ArgumentException` from `KbdActions<>.Add`.
+
+## Expected Behavior
+
+- `RegisterActions` registers the actions it is given.
+- The async and sync expansion paths produce the same keyboard-action state.
+- Repeated expand/collapse cycles in any order do not throw.
+
+## Actual Behavior
+
+**A — `RegisterActions` registers nothing (`EfcItemController.cs:691`).**
+`_keyboardHandler.CharActions[action.Key] = action.Value` uses the `KbdActions<>` indexer setter
+(`KbdActions.cs:38-47`), which performs a `Find(key)` and only assigns when the element is **non-null**.
+A missing key is a silent no-op, not an insert. Combined with the `!overwriteDuplicates` filter at
+`:687-690` — which removes exactly the keys that *are* present — the `overwriteDuplicates: false` path
+is guaranteed to register nothing. `RegisterActions` currently has zero call sites, so this is latent.
+
+**B — async and sync expansion paths are not equivalent (`EfcItemController.cs:931-956` vs `:862-905`).**
+`ToggleExpansion(ToggleState.On)` registers `'B'`/`'D'` in `CharActions` (`:879-888`) and
+`ToggleExpansion(Off)` removes them (`:902-903`). `ToggleExpansionOn()` (`:944-956`) and
+`ToggleExpansionOff()` (`:931-942`) — the bodies dispatched by `ToggleExpansionAsync` (`:913`, `:922`) —
+do neither.
+
+**C — duplicate registration throws (`EfcItemController.cs:879-888`).**
+`KbdActions<>.Add` throws `ArgumentException` when the `(sourceId, key)` pair already exists
+(`KbdActions.cs:92-98`). Because of B, a sync-On -> async-Off -> sync-On sequence leaves the
+`"Item"`/`'B'` and `"Item"`/`'D'` entries in place and the second sync-On throws on a UI-thread call path.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Code-read evidence recorded above (verified 2026-08-07 against the working tree).
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+Defect C is an unhandled exception on a UI-thread call path. Defect B silently removes documented
+keyboard navigation. Defect A is latent today but will surface the moment `RegisterActions` is wired up.
+
+## Suspected Cause / Notes
+
+The indexer-setter semantics in `KbdActions<>` (assign-only-if-present) differ from the usual
+`IDictionary` indexer contract (upsert), which is the likely origin of defect A. Defects B and C stem
+from the async expansion path being added later without mirroring the sync path's registration
+bookkeeping.
+
+Related open issue: #444 `Bug: kbdactions-enumerable-ctor-bypasses-duplicate-guard` covers a separate
+`KbdActions<>` guard gap.
+
+Discovered during preparation of issue #452 (epic #136) per-file coverage research. Out of scope there
+under that feature's no-behavior-change constraint.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Decide and document the intended `KbdActions<>` indexer-setter contract, then align `RegisterActions`
+- [ ] Make `ToggleExpansionOn`/`ToggleExpansionOff` mirror the sync path's `'B'`/`'D'` registration
+- [ ] Unit coverage: register-into-empty; async expand then key press; sync/async interleaved expand cycles
+- [ ] Manual verification: `B` and `D` jump keys work after expanding through either path
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-efc-viewer-processcmdkey-swallows-alt-mnemonics.md
+++ b/docs/features/potential/promoted/2026-08-07-efc-viewer-processcmdkey-swallows-alt-mnemonics.md
@@ -1,0 +1,93 @@
+# efc-viewer-processcmdkey-swallows-alt-mnemonics (Issue #467)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/efc-viewer-processcmdkey-swallows-alt-mnemonics/ (Issue #467)
+- Work Mode: full-bug
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #467
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/467
+- Last Updated: 2026-08-08
+## Summary
+
+`EfcViewer.ProcessCmdKey` returns `true` for **every** Alt-modified key whenever a keyboard handler is
+attached, so `base.ProcessCmdKey` never runs for any Alt combination. This disables the standard
+WinForms mnemonic path for both of the form's menu strips.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Runtime: .NET Framework 4.8.1 WinForms VSTO add-in
+- UI path: `QuickFiler/Viewers/EfcViewer.cs` (Email Filer viewer form)
+- Data source or fixture: n/a — pure input-routing path
+
+## Steps to Reproduce
+
+1. Open the Email Filer viewer (`EfcViewer`) so that `_keyboardHandler` is attached.
+2. Press any Alt-modified accelerator that maps to a menu mnemonic on either menu strip.
+3. Observe that the menu does not open and the keyboard-dialog toggle is invoked instead.
+
+## Expected Behavior
+
+Alt combinations that the QuickFiler keyboard handler does not claim should fall through to
+`base.ProcessCmdKey` so WinForms can resolve menu mnemonics and standard accelerators normally.
+
+## Actual Behavior
+
+`EfcViewer.cs:94-105`:
+
+```csharp
+protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+{
+    if ((_keyboardHandler is not null) && (keyData.HasFlag(Keys.Alt)))
+    {
+        object sender = FromHandle(msg.HWnd);
+        var e = new KeyEventArgs(keyData);
+        _keyboardHandler.ToggleKeyboardDialogAsync(sender, e);
+        return true;
+    }
+
+    return base.ProcessCmdKey(ref msg, keyData);
+}
+```
+
+The guard tests only `keyData.HasFlag(Keys.Alt)` — it does not ask the handler whether it actually
+claims this key. Returning `true` reports the key as fully handled, so no further processing occurs.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Code-read evidence recorded above (verified 2026-08-07 against the working tree).
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+Keyboard-only users lose the menu mnemonic path on this form. The severity is bounded because the
+menus remain reachable by mouse.
+
+## Suspected Cause / Notes
+
+The guard conflates "this is an Alt chord" with "the keyboard handler owns this Alt chord".
+`ToggleKeyboardDialogAsync` is also invoked without awaiting and its result is discarded, so a fault
+inside it is unobserved.
+
+Related: `EfcViewer.ProcessCmdKey` is the only branch in the file, and both of its false outcomes flow
+into `base.ProcessCmdKey`. This is relevant to coverage work under issue #452 (epic #136), which must
+pin the **current** behavior with characterization tests rather than correct it.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Narrow the guard so it consults the handler for a claim on `keyData` before returning `true`
+- [ ] Unit coverage: Alt chord claimed by handler; Alt chord not claimed; non-Alt chord; null handler
+- [ ] Manual verification: menu mnemonics open both menu strips with the viewer focused
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-excludefromcodecoverage-does-not-suppress-nested-lambdas.md
+++ b/docs/features/potential/promoted/2026-08-07-excludefromcodecoverage-does-not-suppress-nested-lambdas.md
@@ -1,0 +1,117 @@
+# excludefromcodecoverage-does-not-suppress-nested-lambdas (Issue #457)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/excludefromcodecoverage-does-not-suppress-nested-lambdas/ (Issue #457)
+- Work Mode: full-bug
+- Discovered during: preparation research for issue #455 (epic #136, child F13)
+
+- Issue: #457
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/457
+- Last Updated: 2026-08-08
+## Summary
+
+A method-level `[ExcludeFromCodeCoverage]` attribute does not suppress instrumentation of lambdas
+declared inside the attributed member. The C# compiler hoists those lambdas into a separate
+compiler-generated closure type whose members do not inherit the attribute, so the lambda bodies
+remain in the coverage denominator. When the attributed member is exempt precisely because it
+cannot execute in a unit-test host, its nested lambda bodies are therefore **permanently
+uncovered** and permanently counted against the file.
+
+This is a silent measurement defect: it does not crash, it quietly and irreducibly depresses the
+line-coverage figure of any file that uses the "thin exempt production forwarder" seam pattern.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Runtime: .NET Framework 4.8.1
+- Coverage pipeline: `scripts/vscode/Invoke-MSTestWithCoverage.ps1` producing Cobertura output
+
+## Steps to Reproduce
+
+1. Take a method carrying `[ExcludeFromCodeCoverage]` that declares one or more lambdas in its body.
+2. Run the coverage pipeline.
+3. Inspect the Cobertura report for the file's `<line>` entries.
+4. Observe that the source line numbers of the lambda bodies are present with `hits="0"`, while the
+   attributed member's own lines are correctly absent.
+
+## Evidence (verified 2026-08-07)
+
+Report: `docs/features/active/2026-08-06-quickfiler-high-confidence-queue-init-stall-424/evidence/qa-gates/coverage-final.cobertura.xml`
+
+`QuickFiler/Viewers/BreadcrumbPopupUiOperations.cs` reports 258 instrumented lines with 24
+uncovered. The uncovered line numbers are:
+
+```
+58, 325, 406, 409, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480,
+481, 482, 483, 484, 485, 486, 487, 488, 489, 490
+```
+
+Mapping those against the source:
+
+- Lines **406** and **409** are lambda bodies inside `BeginProductionNavigation`, which carries
+  `[ExcludeFromCodeCoverage]` at `BreadcrumbPopupUiOperations.cs:394`.
+- Lines **471-490** are the lambda body passed to
+  `BreadcrumbPopupLifecycleOperations.NavigateWithSubscription` inside `BindProductionNavigation`,
+  which carries `[ExcludeFromCodeCoverage]` at `BreadcrumbPopupUiOperations.cs:457`.
+
+That is **22 of the file's 24 uncovered lines** attributable solely to this defect. Only lines 58
+and 325 are ordinary coverage gaps.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+The seam pattern this repository prefers — move decision logic into a testable host-neutral member
+and leave a thin, exempt production forwarder — is precisely the pattern that triggers the defect,
+because those forwarders commonly wire SDK event handlers using lambdas. The consequence is a hard,
+invisible ceiling on the achievable line coverage of every file that adopts the pattern.
+
+Concretely, `BreadcrumbPopupUiOperations.cs` cannot exceed roughly **91.5%** line coverage
+((258 - 22) / 258) no matter how many tests are written. It currently measures 90.7%. Any gate,
+audit, or acceptance criterion that assumes the remaining 9.3% is closable by testing is working
+from a false premise.
+
+This matters at epic scale: epic #136 requires every testable file to reach >= 80% line coverage,
+and several children plan to adopt exactly this seam pattern to remove `[ExcludeFromCodeCoverage]`
+attributes. Each will inherit an unannounced ceiling.
+
+## Suspected Cause
+
+The C# compiler lowers lambdas into members of a generated closure class (commonly `<>c` or
+`<>c__DisplayClass*`). `[ExcludeFromCodeCoverage]` is applied to the original method's metadata and
+is not propagated to the generated closure type or its members, so the coverage collector continues
+to instrument them.
+
+## Suggested Remediation
+
+Options, in rough order of preference:
+
+1. Apply `[ExcludeFromCodeCoverage]` at the **type** level on the generated closure where the
+   tooling permits, or configure the coverage collector to exclude compiler-generated types
+   (`<>c*`) that originate from an exempt member.
+2. Add a `coverage.config` / runsettings exclusion rule for compiler-generated closure types whose
+   declaring member carries the attribute.
+3. Restructure the affected production forwarders to avoid lambdas — use named private methods
+   (which can each carry their own attribute) instead of inline lambdas.
+4. At minimum, document the ceiling so per-file coverage gates and audits do not treat a
+   structurally uncoverable remainder as a test gap.
+
+Option 3 is available to individual children today and requires no tooling change; options 1 and 2
+are the durable repo-wide fix.
+
+## Related
+
+- Issue #441 — Cobertura post-processing double-counts `<line>` nodes. Distinct defect, same
+  pipeline; both distort reported coverage.
+- Issue #432 — QuickFiler per-file coverage ledger and harness (epic #136, child F1). The ledger
+  should record this ceiling so children do not chase unreachable lines.
+- Issue #136 — parent epic requiring >= 80% per-file line coverage.
+
+## Next Step
+
+- [ ] Promote to GitHub issue
+- [ ] Decide between tooling-level exclusion and the no-lambda forwarder convention

--- a/docs/features/potential/promoted/2026-08-07-itemviewer-breadcrumb-pipeline-lifecycle.md
+++ b/docs/features/potential/promoted/2026-08-07-itemviewer-breadcrumb-pipeline-lifecycle.md
@@ -1,0 +1,101 @@
+# itemviewer-breadcrumb-pipeline-lifecycle (Issue #488)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/itemviewer-breadcrumb-pipeline-lifecycle/ (Issue #488)
+- Discovered during: preparation research for issue #456 (epic #136, child F14)
+
+- Issue: #488
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/488
+- Last Updated: 2026-08-08
+## Summary
+
+Five lifecycle defects in `QuickFiler/Viewers/ItemViewer.Breadcrumb.cs`. All are out of scope to fix
+under epic #136's no-behavior-change NFR. Two of them (Defects 1 and 3) are reachable through the
+existing pooled-viewer reuse path in production.
+
+## Defect 1 — `ConfigureBreadcrumbDropDown` leaks the previous host on WebView2 environment change
+
+`ItemViewer.Breadcrumb.cs:147-176`. The idempotence guard at `:147-153` returns early only when the
+existing host is a concrete `BreadcrumbDropDownHost` **and**
+`ReferenceEquals(existing.Environment, environment)`. When the environment reference differs, control
+falls through to `:158-168` and constructs a second `BreadcrumbDropDownHost` over the same
+`_l0vhBreadcrumb_WebView2`. The first host is never disposed by this file:
+`BreadcrumbItemViewerLifecycleCoordinator.cs:127-142` calls `ReleaseHostCore()`, which unsubscribes
+`PopupMessengerReady` and calls `coordinator.Release()` (`:300-303`), but does not call
+`IBreadcrumbDropDownHost.Dispose()` — even though `IBreadcrumbDropDownHost` is `IDisposable`
+(`Viewers/IBreadcrumbDropDownHost.cs:19`). `BreadcrumbDropDownIntegrationTests.cs:308` asserts
+`host.Dispose()` is called exactly once on **viewer** disposal, proving disposal is viewer-lifetime
+scoped rather than host-replacement scoped.
+
+Reachable in production: `QfcItemController.ViewerSetup.cs:166` passes `_webViewEnvironment`, which is
+recreated per controller initialization while `ItemViewer` instances are pooled and reused
+(`ViewerSetup.cs:396` calls `ResetBreadcrumb()` on reuse, which does not reset host identity). Every
+environment change leaks one WebView2-backed popup host for the lifetime of the viewer.
+
+## Defect 2 — `SetBreadcrumbTheme` can be lost when issued off the UI thread
+
+`ItemViewer.Breadcrumb.cs:197-198` forwards synchronously to
+`BreadcrumbItemViewerLifecycleCoordinator.SetTheme` (`:155-160`), which reads
+`DropDownHost` → `_openCoordinator?.Host`. `_openCoordinator` is assigned inside an asynchronous post
+(`ConfigureHost`, `:120-152`). On the UI thread the post runs inline
+(`BreadcrumbUiDispatcher.cs:78-95`), so ordering holds and production is currently safe
+(`QfcItemController.ViewerSetup.cs:166-167`). Off the UI thread — or after any `ConfigureAwait(false)`
+resumption, which `BreadcrumbUiDispatcher.cs:263-268` documents as a real scenario — the post is
+genuinely deferred, `DropDownHost` is still null when `SetTheme` reads it, and the popup surface keeps
+the previous theme with no error surfaced. Same class of defect as the dark-mode stale-label family
+(issues #254 / #269).
+
+## Defect 3 — `InitializeBreadcrumbPipeline` silently discards a second, different provider
+
+`ItemViewer.Breadcrumb.cs:45-48`. The guard returns without comparing providers, so a caller supplying
+a different `IFolderHierarchyProvider` to an already-initialized viewer gets no error and no effect.
+Pooled viewer reuse reaches this path: `QfcItemController.ViewerSetup.cs:140-146` guards
+`EnsureBreadcrumbPipeline` on `viewer.BreadcrumbCoordinator == null`, so a viewer reused across two
+controllers with different `_globals.Ol.FolderTreeService` instances keeps the first controller's
+provider. `BreadcrumbItemViewerLifecycleCoordinator.SetBridgeCoordinator` (`:66-69`) does compare by
+reference before short-circuiting — the coordinator is stricter than its own wrapper.
+
+## Defect 4 — `BreadcrumbCoordinator` initialization is a non-atomic read-then-write
+
+`ItemViewer.Breadcrumb.cs:45` reads and `:59` writes with no synchronization and no memory barrier.
+Two threads entering `InitializeBreadcrumbPipeline` concurrently both construct a
+`BreadcrumbItemViewerLifecycleCoordinator` and a `BreadcrumbBridgeCoordinator`; one pair is silently
+discarded without being disposed, leaking its `BreadcrumbMessengerHub` and its bridge subscriptions
+(`BreadcrumbItemViewerLifecycleCoordinator.cs:73-76`). The same shape recurs at `:147`/`:159` (host)
+and `:281`/`:287` (resource owner). Production currently calls only from the UI thread, so the window
+is not known to be hit, but nothing in the type declares or enforces UI-thread affinity and
+`AttachBreadcrumbWebViewAsync` is async-facing, which invites off-thread callers.
+
+## Defect 5 — `EnsureBreadcrumbResourceOwnership` can create a `Container` that `Dispose` never disposes
+
+`ItemViewer.Breadcrumb.cs:286-288` executes `components ??= new Container();` then
+`components.Add(_breadcrumbResourceOwner)`. `ItemViewer.Designer.cs:16-23` disposes `components` only
+if it is non-null at the moment `Dispose(bool)` runs. If breadcrumb configuration first occurs after
+disposal has begun — reachable via the deferred `ConfigureHost` post
+(`BreadcrumbItemViewerLifecycleCoordinator.cs:120`) racing `Control.Dispose` — the newly created
+`Container` and the `BreadcrumbResourceOwner` inside it are never disposed, so
+`DisposeBreadcrumbResources` (`:291-296`) never runs and the hub and messengers leak. The generation
+guard at `BreadcrumbItemViewerLifecycleCoordinator.cs:122-125` protects the coordinator's own state
+but not this file's container creation.
+
+## Acceptance Criteria (early draft)
+
+- [ ] Host replacement on environment change disposes the previous host.
+- [ ] `SetBreadcrumbTheme` either orders after host configuration or reports a deferred application.
+- [ ] A second, different `IFolderHierarchyProvider` either fails fast or re-initializes explicitly.
+- [ ] Pipeline initialization is atomic, or UI-thread affinity is declared and enforced.
+- [ ] A `Container` created during teardown is disposed, or creation during teardown is refused.
+- [ ] Regression tests cover each fixed behavior deterministically.
+
+## Constraints & Risks
+
+- `ItemViewer.Breadcrumb.cs` is assigned to epic child F14; `BreadcrumbItemViewerLifecycleCoordinator.cs`
+  and `BreadcrumbBridgeCoordinator.cs` to F12; `BreadcrumbUiDispatcher.cs` and
+  `BreadcrumbDropDownHost.cs` to F13. A fix spans three children's file sets, so reconcile against all
+  three plans before scheduling.
+- Issue #400's live remediation plan also authorizes edits to `ItemViewer.Breadcrumb.cs`.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug template)

--- a/docs/features/potential/promoted/2026-08-07-itemviewer-display-and-folder-contract-defects.md
+++ b/docs/features/potential/promoted/2026-08-07-itemviewer-display-and-folder-contract-defects.md
@@ -1,0 +1,76 @@
+# itemviewer-display-and-folder-contract-defects (Issue #490)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/itemviewer-display-and-folder-contract-defects/ (Issue #490)
+- Discovered during: preparation research for issue #456 (epic #136, child F14)
+
+- Issue: #490
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/490
+- Last Updated: 2026-08-08
+## Summary
+
+Five contract and state-handling defects across `ItemViewer.FolderSearch.cs`,
+`ItemViewer.DisplayState.cs`, and `ItemViewer.Commands.cs`. All are out of scope to fix under epic
+#136's no-behavior-change NFR.
+
+## Defect 1 — `SetFolderItems` appends rather than sets
+
+`SetFolderItems` calls `AddItems` rather than replacing the collection, contradicting both its own
+name and its `IItemViewer` contract. The defect is masked in production only because the caller
+issues a preceding `ClearFolderItems()`. Any caller that omits the clear gets silently duplicated
+folder entries.
+
+## Defect 2 — `FocusSearch` and `FocusSubject` use incompatible threading discipline on one type
+
+`FocusSearch` marshals through `Control.Invoke` while `FocusSubject` calls `.Focus()` bare. Two
+different threading contracts on the same control creates a blocking-marshal deadlock risk if
+`FocusSearch` is reached beneath a modal dialog, and makes the type's thread-affinity contract
+unstateable. Related to the broader marshalling divergence tracked separately for
+`ItemViewer.WebViewThread.cs`.
+
+## Defect 3 — `FocusSubject()` targets a non-selectable control and discards its result
+
+`FocusSubject()` calls `Focus()` on a `Label`. `Label` is not selectable, so the call is a no-op, and
+the returned `bool` — the only signal that the focus request failed — is discarded. The intended
+focus target is never reached and nothing reports it.
+
+## Defect 4 — `FlagTaskDialogResult` uses a WinForms control property as cross-call scratch state
+
+`FlagTaskDialogResult` stores intermediate state in `Button.DialogResult` between calls, using a
+presentation property as mutable application state. This couples the result protocol to control
+lifetime and to any designer regeneration of the button, and it is not discoverable from the member's
+signature.
+
+## Defect 5 — ten mutable display projections with no transactional grouping
+
+`ItemViewer` exposes ten independently settable display projections with no consistency guarantee. A
+caller that applies a subset — or that is interrupted partway during pooled viewer reuse — renders a
+viewer showing fields from two different mail items simultaneously. There is no grouping construct
+and no assertion that a render is complete.
+
+## Related nullability observation
+
+`GetSelectedFolder()` erases a `string?` annotation to `string` at the `ItemViewer` boundary. The
+downstream impact was not traced during research; it is recorded here so a fix can evaluate it.
+
+## Acceptance Criteria (early draft)
+
+- [ ] `SetFolderItems` replaces rather than appends, or is renamed to match its behavior.
+- [ ] `FocusSearch` and `FocusSubject` share one documented threading contract.
+- [ ] `FocusSubject` targets a selectable control and its failure is observable.
+- [ ] `FlagTaskDialogResult` holds its state in a field rather than a control property.
+- [ ] Display projections are applied as one grouped operation, or the partial-render risk is
+      documented and guarded.
+- [ ] Regression tests cover each fixed behavior deterministically.
+
+## Constraints & Risks
+
+- All three files are assigned to epic child F14 (issue #456). Scheduling this fix while F14 is in
+  flight will produce a semantic conflict; reconcile against F14's plan first.
+- Defect 2 overlaps the separately tracked `ItemViewer` UI-thread marshalling divergence; fix them
+  together or sequence them deliberately.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug template)

--- a/docs/features/potential/promoted/2026-08-07-itemviewer-move-option-menu-defects.md
+++ b/docs/features/potential/promoted/2026-08-07-itemviewer-move-option-menu-defects.md
@@ -1,0 +1,70 @@
+# itemviewer-move-option-menu-defects (Issue #486)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/itemviewer-move-option-menu-defects/ (Issue #486)
+- Discovered during: preparation research for issue #456 (epic #136, child F14)
+
+- Issue: #486
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/486
+- Last Updated: 2026-08-08
+## Summary
+
+The QuickFiler item-viewer move-option menu is defective in three independent ways. All three were
+found while researching coverage for the `ItemViewer` family and are out of scope to fix under the
+epic's no-behavior-change NFR.
+
+## Defect 1 — the menu check image is cleared immediately after being set
+
+`QuickFiler/Viewers/ToolStripMenuItemCb.cs:32-58` shadows `Checked` and `CheckedChanged` with `new`
+and never assigns `base.Checked`. The consuming handlers at
+`QuickFiler/Viewers/ItemViewerExpanded.cs:169-179` and `QuickFiler/Viewers/ItemViewer.cs:177-187`
+receive the parameter as the base `ToolStripMenuItem`, so the write lands on the base property and
+the shadowed value is never reflected. The user-visible result is that the four move-option menu
+items never display a check mark.
+
+Candidate fix: assign `base.Checked = value;` at `ToolStripMenuItemCb.cs:37`.
+
+## Defect 2 — `ItemViewer` and `ItemViewerExpanded` have silently divergent menu behavior
+
+`ItemViewer.cs:171-175`, `:177-187`, and `:205` have no caller and no designer wiring anywhere in the
+solution. `ItemViewer.Designer.cs` wires exactly one handler, at `:256`, and it is not one of these.
+The same three members in `ItemViewerExpanded.cs:163-179` **are** wired four times
+(`ItemViewerExpanded.Designer.cs:171,180,189,198`) and called four times from its constructor
+(`ItemViewerExpanded.cs:24-27`).
+
+Combined with Defect 1, the wired path is the defective one: it clears the check image the setter
+just applied. The two twins therefore behave differently and the divergence appears accidental
+rather than designed.
+
+Candidate disposition: delete the three dead members from `ItemViewer.cs` (behavior-neutral) and fix
+or document the `ItemViewerExpanded` path.
+
+## Defect 3 — `PicturesChanged` has no production subscriber
+
+Toggling "Save Pictures" in QuickFiler is silently discarded. `QfcItemController.EventWiring.cs:66-94`
+wires the other three move-option events but not `PicturesChanged`. `EfcFormController.cs:389` does
+wire it, so the omission is specific to the QuickFiler path rather than a design decision.
+
+## Impact
+
+Defects 1 and 3 are user-visible: the move-option menu gives no check-mark feedback, and one of the
+four options has no effect at all in QuickFiler. Defect 2 is a latent correctness and maintenance
+hazard rather than a live failure.
+
+## Acceptance Criteria (early draft)
+
+- [ ] `ToolStripMenuItemCb.Checked` round-trips through the base property and the check image renders.
+- [ ] The `ItemViewer` / `ItemViewerExpanded` menu-handler divergence is resolved or documented.
+- [ ] `PicturesChanged` is wired in the QuickFiler path, or its absence is documented as intended.
+- [ ] Regression tests cover each fixed behavior.
+
+## Constraints & Risks
+
+- `ToolStripMenuItemCb.cs` is assigned to epic child F15; `ItemViewer*.cs` to F14; the wiring file
+  `QfcItemController.EventWiring.cs` to F10. Scheduling this fix against an in-flight child will
+  produce a semantic conflict, so reconcile against those children's plans first.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug template)

--- a/docs/features/potential/promoted/2026-08-07-itemviewer-parentchanged-console-and-cast.md
+++ b/docs/features/potential/promoted/2026-08-07-itemviewer-parentchanged-console-and-cast.md
@@ -1,0 +1,53 @@
+# itemviewer-parentchanged-console-and-cast (Issue #487)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/itemviewer-parentchanged-console-and-cast/ (Issue #487)
+- Discovered during: preparation research for issue #456 (epic #136, child F14)
+
+- Issue: #487
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/487
+- Last Updated: 2026-08-08
+## Summary
+
+Two small policy violations in the `ItemViewer` / `ItemViewerExpanded` twins, both out of scope to fix
+under epic #136's no-behavior-change NFR because the least-bad disposition for each is a deletion
+rather than a rewrite.
+
+## Defect 1 — production `Console.WriteLine` in a designer-wired WinForms event handler
+
+`QuickFiler/Viewers/ItemViewer.cs:168` is `Console.WriteLine("Parent Changed");` — the entire body of
+`L0v2h2_WebView2_ParentChanged`, wired at `ItemViewer.Designer.cs:256`.
+`QuickFiler/Viewers/ItemViewerExpanded.cs:160` is identical, wired at
+`ItemViewerExpanded.Designer.cs:274`.
+
+This violates the General Code Change Policy § 3, which requires the project's logging pattern rather
+than ad-hoc console output. Because the handler is otherwise a no-op, an alternative disposition is
+deleting both the handler and its designer wiring — a behavior change, hence promotion rather than an
+in-scope fix.
+
+## Defect 2 — unguarded downcast in an event handler
+
+`QuickFiler/Viewers/ItemViewer.cs:173` and `QuickFiler/Viewers/ItemViewerExpanded.cs:165` are
+`var menuItem = (ToolStripMenuItem)sender;` with no `is` / `as` guard. A non-`ToolStripMenuItem`
+sender raises `InvalidCastException` on the UI thread with no diagnostic context.
+
+Severity is low today — all four current wirings pass a `ToolStripMenuItemCb`, and in `ItemViewer` the
+member is dead code — but it is a fail-fast-without-context path that becomes live the moment anyone
+wires it.
+
+## Acceptance Criteria (early draft)
+
+- [ ] No production `Console.WriteLine` remains in either handler.
+- [ ] The downcast is guarded, or the handler is removed together with its designer wiring.
+- [ ] Designer wiring and handler bodies stay consistent between the two twins.
+
+## Constraints & Risks
+
+- Editing `*.Designer.cs` files means touching generated code; confirm the designer round-trips.
+- `ItemViewer*.cs` is assigned to epic child F14 and `ToolStripMenuItemCb.cs` to F15; reconcile
+  against those children before scheduling.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug template)

--- a/docs/features/potential/promoted/2026-08-07-itemviewer-ui-thread-marshalling-divergence.md
+++ b/docs/features/potential/promoted/2026-08-07-itemviewer-ui-thread-marshalling-divergence.md
@@ -1,0 +1,85 @@
+# itemviewer-ui-thread-marshalling-divergence (Issue #489)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/itemviewer-ui-thread-marshalling-divergence/ (Issue #489)
+- Discovered during: preparation research for issue #456 (epic #136, child F14)
+
+- Issue: #489
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/489
+- Last Updated: 2026-08-08
+## Summary
+
+The `ItemViewer` type exposes three different UI-thread seams and the codebase uses all three, with
+one operation marshalled onto a WPF `Dispatcher` that may never be pumped and another marshalled not
+at all. Out of scope under epic #136's no-behavior-change NFR.
+
+## Defect 1 — `ShowMoveOptionsMenu` is marshalled onto a WPF `Dispatcher`
+
+`QuickFiler/Controllers/QfcItemController.Navigation.cs:83` marshals with
+`await _uiDispatcher.InvokeAsync(() => _itemViewer.ShowMoveOptionsMenu())`, where `_uiDispatcher`
+originates from `System.Windows.Threading.Dispatcher.CurrentDispatcher` captured in the `ItemViewer`
+constructor (`QuickFiler/Viewers/ItemViewer.cs:13,28,71-75`). Every other forwarder in
+`ItemViewer.WebViewThread.cs` is marshalled — where it is marshalled at all — with WinForms
+`Control.InvokeRequired` / `Control.Invoke` (`QfcItemController.EventWiring.cs:139-146`,
+`QfcItemController.Conversation.cs:224-228`).
+
+A WPF `Dispatcher` and a `WindowsFormsSynchronizationContext` are different queues.
+`Dispatcher.CurrentDispatcher` on the Outlook UI thread creates a WPF dispatcher whose message loop is
+pumped only if a WPF component pumps it. In a VSTO add-in with no WPF root, work queued to that
+dispatcher can be delayed until a nested WPF pump runs, or never run at all. The move-options menu
+therefore has a different and weaker delivery guarantee than every other UI operation on the same
+control.
+
+## Defect 2 — `NavigateToString` is called unguarded from the theme path
+
+`QuickFiler/Controllers/QfcItemController.FocusAndTheme.cs:293` calls
+`_itemViewer.NavigateToString(ItemHelper.ToggleDark(desiredState))` with no `InvokeRequired` guard.
+The same operation at `QfcItemController.EventWiring.cs:139-146` is explicitly guarded, and the
+comparable topic-thread pair at `QfcItemController.Conversation.cs:224-228` is guarded.
+`ItemViewer.WebViewThread.cs:15` performs no marshalling of its own, so the unguarded site is
+protected only by the assumption that theme toggling always originates on the UI thread. Theme
+toggling is precisely the family that produced issues #254 and #269, so the assumption is not
+obviously safe.
+
+Failure mode: `InvalidOperationException: Cross-thread operation not valid: Control 'L0v2h2_WebView2'
+accessed from a thread other than the thread it was created on` — the exact shape recorded for the
+sibling control in issue #400's runtime evidence
+(`docs/features/active/2026-07-21-quickfiler-folder-selector-dropdown-400/evidence/regression-testing/runtime-selector-toggle-thread-affinity.2026-07-22T01-29.md:25`).
+
+## Defect 3 — `SetConversationItems` and `SortConversationByDate` must be an atomic pair, unenforced
+
+`ItemViewer.WebViewThread.cs:23` and `:25` are independent `IItemViewer` members
+(`QuickFiler/Viewers/IItemViewer.cs:109-110`). The only production caller,
+`QfcItemController.Conversation.cs:231-232`, issues them back to back inside a single `Invoke`d
+`SetTopicThread` call, so the pair is atomic in that path. Nothing in the interface, the
+implementation, or the XML documentation records that atomicity as a requirement. Any future caller
+that marshals the two separately, or that calls `SetConversationItems` without a following sort,
+leaves the conversation list in source order rather than descending sent-date order, with no error.
+
+## Defect 4 — three concurrent marshalling contracts on one control
+
+`QuickFiler/Viewers/ItemViewer.cs` exposes `UiSyncContext` (`:59-63`), `UiScheduler` (`:65-69`), and
+`UiDispatcher` (`:71-75`), all captured in the constructor (`:26-28`). Consumers have diverged onto
+three strategies: `Control.Invoke` (`EventWiring.cs:141`, `Conversation.cs:226`), WPF
+`Dispatcher.InvokeAsync` (`Navigation.cs:83`), and unguarded (`EventHandlers.cs:196,200`,
+`FocusAndTheme.cs:293`). This makes every thread-affinity review of the area expensive and makes
+Defects 1 and 2 easy to reintroduce.
+
+## Acceptance Criteria (early draft)
+
+- [ ] `ShowMoveOptionsMenu` uses the same UI-thread queue as the other forwarders.
+- [ ] The theme-path `NavigateToString` call is guarded consistently with its siblings.
+- [ ] The conversation set-then-sort pair is atomic by construction, or the contract is documented.
+- [ ] `ItemViewer` consolidates onto a single documented UI-thread seam.
+- [ ] Regression tests are deterministic and use no real wall-clock waits.
+
+## Constraints & Risks
+
+- `ItemViewer.cs` and `ItemViewer.WebViewThread.cs` are assigned to epic child F14;
+  `QfcItemController.*` to F10. Consolidating the seam is a cross-child contract change; reconcile
+  against both plans before scheduling.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug template)

--- a/docs/features/potential/promoted/2026-08-07-iteratequeueasync-deadline-closes-queue-early.md
+++ b/docs/features/potential/promoted/2026-08-07-iteratequeueasync-deadline-closes-queue-early.md
@@ -1,0 +1,73 @@
+# iteratequeueasync-deadline-closes-queue-early (Issue #446)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/iteratequeueasync-deadline-closes-queue-early/ (Issue #446)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #446
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/446
+- Last Updated: 2026-08-08
+## Summary
+
+`QfcHomeController.IterateQueueAsync` treats an empty dequeue result as proof that the mail source is exhausted and irreversibly closes the QuickFiler UI queue. Since issue #424 introduced a first-batch deadline on the underlying dequeue, an empty result can now mean "the deadline expired" rather than "no items remain", so a slow high-confidence scan can close the queue for the rest of the session while items are still available.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Python version: n/a (C# / .NET Framework 4.8 VSTO add-in)
+- Command/flags used: QuickFiler launched from the TaskMaster ribbon with `QfSettings.HighConfidenceModeEnabled = true`
+- Data source or fixture: Live Outlook mailbox with a low proportion of items above the confidence threshold, so scoring is slow relative to the deadline
+
+## Steps to Reproduce
+
+1. Enable High Confidence mode with a threshold that few messages clear.
+2. Launch QuickFiler against a folder large enough that scoring a batch exceeds the first-batch deadline.
+3. File the first batch so `IterateQueueAsync` runs for the next batch.
+4. Observe whether further batches are ever presented.
+
+## Expected Behavior
+
+An empty batch caused by a scan deadline should leave the queue open so later iterations can continue supplying items. The queue should be closed only when the mail source is genuinely exhausted.
+
+## Actual Behavior
+
+The empty result routes to `QfcQueue.CompleteAddingAsync`, which calls `BlockingCollection.CompleteAdding()`. That operation is irreversible, so no further items can be enqueued for the remainder of the session even though unscanned items remain.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Snippet: none captured; the failure presents as QuickFiler ending the session early rather than as an error.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+High: in High Confidence mode with a low-yield folder the user can be denied the remainder of their queue for the session, with no error shown and no way to recover short of relaunching QuickFiler.
+
+## Suspected Cause / Notes
+
+Found during read-only research for epic child F7 (`quickfiler-qfc-home-controller-coverage`, issue #433) under parent epic #136. Report-only; deliberately not fixed inside a coverage child. Evidence is recorded in
+`docs/features/active/2026-08-07-quickfiler-qfc-home-controller-coverage-433/research/QfcHomeController.Iteration.cs.research.2026-08-07T20-50.md` (finding LD3).
+
+- `QfcHomeController.Iteration.cs:21` calls the two-argument `_datamodel.DequeueNextItemGroupAsync(_formController.ItemsPerIteration, 2000)`.
+- Issue #424 changed what that overload does. `QfcDatamodel.QueueProcessing.cs:66-76` now makes the two-argument overload delegate to the deadline-bearing path using `QfcStreamingDequeueConfidenceGate.DefaultFirstBatchDeadline` (12 s, `QfcStreamingDequeueConfidenceGate.cs:22`). The post-UI iteration call site therefore inherited a deadline it was not written for.
+- `QfcHomeController.Iteration.cs:32` infers from `listObjects.Count == 0` that the source is exhausted and calls `QfcQueue.CompleteAddingAsync(Token, 10000)`, which reaches `_queue.CompleteAdding()` at `QfcQueue.cs:59`. `BlockingCollection.CompleteAdding()` cannot be undone.
+- #424's `spec.md` states the post-UI iteration call site was "left unchanged". That is true of the file text and false of the resulting behavior, which is why the interaction was not caught during that change.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Unit coverage areas: `IterateQueueAsync`'s empty-batch branch, distinguishing a deadline-expired empty result from a genuine end-of-source result. This likely needs the dequeue contract to report which of the two occurred.
+- [ ] Integration scenario to retest: High Confidence launch against a low-yield folder large enough to exceed the deadline; confirm later batches still arrive.
+- [ ] Manual verification notes: confirm the queue is closed exactly once, and only on genuine exhaustion.
+
+Note that a fix likely requires a contract change on `IQfcDatamodel` (owned by epic child F5) so the caller can distinguish the two empty-result causes. Coordinate accordingly.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-iwebviewcoreinitializer-contract-defects.md
+++ b/docs/features/potential/promoted/2026-08-07-iwebviewcoreinitializer-contract-defects.md
@@ -1,0 +1,121 @@
+# iwebviewcoreinitializer-contract-defects (Issue #477)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/iwebviewcoreinitializer-contract-defects/ (Issue #477)
+- Work Mode: full-bug
+- Discovered during: preparation research for issue #455 (epic #136, child F13)
+
+- Issue: #477
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/477
+- Last Updated: 2026-08-08
+## Summary
+
+`IWebViewCoreInitializer` documents itself as a 1:1 forward to the WebView2 SDK, and its
+implementation `WebView2CoreInitializer` is coverage-exempt on that basis. Neither claim survives
+reading the code: the implementation silently hard-codes an SDK parameter, and it validates none of
+its four arguments. Because the type is `[ExcludeFromCodeCoverage]`, no test exercises either
+problem.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Runtime: .NET Framework 4.8.1 WinForms VSTO add-in
+- Package: `Microsoft.Web.WebView2` 1.0.4129.50 (`QuickFiler/packages.config:29`)
+
+## Defect 1 — the "1:1" contract is false; a parameter is silently hard-coded
+
+`QuickFiler/Viewers/WebView2CoreInitializer.cs:19-22`:
+
+```csharp
+public Task<CoreWebView2Environment> CreateEnvironmentAsync(
+    string cacheFolder,
+    CoreWebView2EnvironmentOptions options
+) => CoreWebView2Environment.CreateAsync(null, cacheFolder, options);
+```
+
+The SDK signature is `CreateAsync(string browserExecutableFolder, string userDataFolder,
+CoreWebView2EnvironmentOptions options)`. The seam drops `browserExecutableFolder` and passes
+`null` unconditionally, pinning every caller to the Evergreen runtime with no way to select a
+fixed-version distribution.
+
+That is a real product constraint expressed as an undocumented literal. The interface doc at
+`QuickFiler/Viewers/IWebViewCoreInitializer.cs:10-11` describes the member as a 1:1 forward, which
+it is not. The same doc claim is what the coverage exemption at `WebView2CoreInitializer.cs:15`
+rests on.
+
+## Defect 2 — no argument validation on any parameter
+
+Neither member validates anything:
+
+```csharp
+public Task<CoreWebView2Environment> CreateEnvironmentAsync(string cacheFolder, CoreWebView2EnvironmentOptions options)
+    => CoreWebView2Environment.CreateAsync(null, cacheFolder, options);          // :22
+
+public Task EnsureCoreWebView2Async(WebView2 control, CoreWebView2Environment environment)
+    => control.EnsureCoreWebView2Async(environment);                             // :28
+```
+
+A null `control` at `:28` produces a bare `NullReferenceException` with no parameter name. A null or
+empty `cacheFolder` at `:22` is forwarded to the SDK, which surfaces a less specific failure than a
+guard would. Every other seam in this area guards its arguments — `WebView2Messenger.cs:38-39`,
+`WebView2BreadcrumbHost.cs:45-46`, `BreadcrumbPopupUiOperations.cs:71-77` — so this file is the
+outlier, not the convention.
+
+`CLAUDE.md` §C#4 requires validating constructor and method preconditions and failing fast with
+explicit exceptions.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+Defect 1's impact is latent but architectural: the repository cannot adopt a fixed-version WebView2
+distribution without editing this file, and nothing documents that. Defect 2's impact is
+diagnostic — failures surface as `NullReferenceException` without a parameter name, which is harder
+to triage from a production log.
+
+Severity is Medium because neither misbehaves in the current happy path.
+
+## Note on the coverage exemption
+
+The exemption on `WebView2CoreInitializer` is otherwise **justified** and should be retained: both
+members require the Evergreen runtime (an external process) and `CreateEnvironmentAsync` creates a
+user-data folder on disk. Executing either in a unit test is prohibited by `CLAUDE.md` §UT4
+("Creation and use of temporary files on the local filesystem is expressly prohibited... approved
+exceptions: none") and by the ban on external dependencies — not merely difficult. That is the
+correct reason to exempt it.
+
+But the exemption's *stated* rationale ("1:1 forwarding") is the part that is false, and the
+exemption is what has kept both defects unexamined. Adding the guards in Defect 2 does not make the
+type testable and does not change the exemption verdict.
+
+## Suggested Remediation
+
+1. Add explicit `ArgumentNullException` / `ArgumentException` guards to both members, matching the
+   convention already used by the sibling seams.
+2. Either surface `browserExecutableFolder` as a parameter on `IWebViewCoreInitializer`, or document
+   the `null` as a deliberate Evergreen-only decision in the interface XML doc.
+3. Correct the "1:1 forward" wording in `IWebViewCoreInitializer.cs:10-11` and in the exemption
+   rationale at `WebView2CoreInitializer.cs:8-14`, restating the exemption on the accurate ground
+   (external runtime plus filesystem side effect).
+
+## Why this is not fixed under epic #136
+
+Epic #136 child F13 (issue #455) carries a hard no-behavior-change NFR, and adding throwing guards
+changes observable behavior on a null argument. Item 3 is doc-only and may be folded into F13's own
+change if the ledger rationale is being rewritten there anyway.
+
+## Related
+
+- Issue #455 — F13, breadcrumb drop-down and WebView2 host coverage (where this was found).
+- Issue #432 — F1 coverage ledger; the ratified rationale for this exemption should use the accurate
+  ground, not the "1:1 forward" claim.
+- Issue #136 — parent epic.
+
+## Next Step
+
+- [ ] Promote to GitHub issue
+- [ ] Confirm whether fixed-version WebView2 distribution is a product requirement

--- a/docs/features/potential/promoted/2026-08-07-kbdactions-enumerable-ctor-bypasses-duplicate-guard.md
+++ b/docs/features/potential/promoted/2026-08-07-kbdactions-enumerable-ctor-bypasses-duplicate-guard.md
@@ -1,0 +1,97 @@
+# kbdactions-enumerable-ctor-bypasses-duplicate-guard (Issue #444)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/kbdactions-enumerable-ctor-bypasses-duplicate-guard/ (Issue #444)
+- Discovered during: research for issue #430 (`quickfiler-keyboard-actions-coverage`, child F3 of epic #136)
+
+- Issue: #444
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/444
+- Last Updated: 2026-08-08
+## Summary
+
+`KbdActions<TKey, UClass, VDelegate>` enforces a duplicate-registration guard in `Add`, but the
+`IEnumerable<UClass>` constructor bypasses it entirely. Production code registers a duplicate through
+that constructor, which makes a subsequent lookup for that key throw `InvalidOperationException`.
+
+## Evidence
+
+The guard exists in `Add`:
+
+```csharp
+// QuickFiler/Controllers/KbdActions.cs:90-92
+public void Add(string sourceId, TKey key, VDelegate @delegate)
+{
+    if (_list.Any(x => x.SourceId == sourceId && StoredKeyEquals(x.Key, key)))
+```
+
+The constructor has no equivalent check:
+
+```csharp
+// QuickFiler/Controllers/KbdActions.cs:25-28
+public KbdActions(IEnumerable<UClass> list)
+{
+    _list = new List<UClass>(list);
+}
+```
+
+Production registers a duplicate pair through that constructor — two entries sharing
+`SourceId = "Collection"` and `Key = Keys.Down`:
+
+```csharp
+// QuickFiler/Controllers/QfcCollectionController.cs:1265-1272
+_kbdHandler.KeyActions = new KbdActions<Keys, KaKey, Action<Keys>>(
+    new List<KaKey>
+    {
+        new KaKey("Collection", Keys.Up, (k) => SelectPreviousItem()),
+        new KaKey("Collection", Keys.Down, (k) => SelectNextItem()),
+        new KaKey("Collection", Keys.Down, (k) => _parent.ActionOkAsync()),
+    }
+);
+```
+
+Had these been registered via `Add`, the third entry would have been rejected. Because they were not,
+`Find(Keys.Down)` resolves against a two-element match set and throws `InvalidOperationException`
+(`KbdActions.cs:67` / `:86`). The consuming call site is `QuickFiler/Controllers/KeyboardHandler.cs:122`.
+
+Both the constructor bypass and the duplicate registration were verified by direct file read at
+`origin/epic/quickfiler-per-file-coverage-integration` (base commit `56ca1cea`).
+
+## Impact
+
+`Keys.Down` handling in the QuickFiler collection surface resolves to an exception path rather than to
+either registered action. The severity depends on whether `Find(Keys.Down)` is reached in normal
+operation, which has not been confirmed by runtime observation — the analysis is static.
+
+## Why this was not fixed in issue #430
+
+Issue #430 (child F3) carries an explicit acceptance criterion of **no behavior change to observable
+QuickFiler keyboard flows**, and `QfcCollectionController.cs` is assigned to sibling child F11
+(`quickfiler-collection-controller-coverage`), not F3. Adding a guard to the constructor is a breaking
+change for the existing call site. F3 characterizes the current behavior in tests rather than changing
+it.
+
+## Proposed Fix Direction
+
+Two independent decisions are required, and they should be made together:
+
+1. **Which of the two `Keys.Down` actions is correct?** `SelectNextItem()` and `_parent.ActionOkAsync()`
+   are materially different behaviors. This is a product decision, not a mechanical fix.
+2. **Should the `IEnumerable` constructor enforce the same duplicate guard as `Add`?** Making the
+   constructor consistent with `Add` is the design-correct answer, but it converts the existing latent
+   defect into a construction-time throw and therefore must land together with decision 1.
+
+## Acceptance Criteria (early draft)
+
+- [ ] The intended `Keys.Down` behavior for the QuickFiler collection surface is decided and recorded.
+- [ ] The duplicate registration in `QfcCollectionController.cs` is resolved to a single entry.
+- [ ] `KbdActions(IEnumerable<UClass>)` either enforces the same duplicate guard as `Add` or documents
+      in-code why it deliberately does not.
+- [ ] A regression test covers the chosen behavior, including the duplicate-input case.
+- [ ] Full C# toolchain passes: csharpier, analyzer build, nullable build, coverage-enabled vstest.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug template)
+- [ ] Coordinate with epic #136 child F11 (`quickfiler-collection-controller-coverage`), which owns
+      `QfcCollectionController.cs`

--- a/docs/features/potential/promoted/2026-08-07-merge-cobertura-classes-blends-union-with-primary-methods.md
+++ b/docs/features/potential/promoted/2026-08-07-merge-cobertura-classes-blends-union-with-primary-methods.md
@@ -1,0 +1,102 @@
+# merge-cobertura-classes-blends-union-with-primary-methods (Issue #478)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/merge-cobertura-classes-blends-union-with-primary-methods/ (Issue #478)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #478
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/478
+- Last Updated: 2026-08-08
+## Summary
+
+`Merge-CoberturaClassesByFilename` unions the class-level `<lines>` of all `<class>` elements sharing
+a `filename` correctly, but never merges the corresponding `<methods>` subtrees. It then recomputes
+`line-rate` over the descendant axis `.//lines/line`, which sees the correct union **plus** only the
+primary class's method-level lines. The emitted per-file `line-rate` is therefore a blend of two
+different denominators and matches neither. This is distinct from, and additional to, issue #441.
+
+## Environment
+
+- OS/version: n/a (PowerShell post-processing defect, reproducible from committed data)
+- Python version: n/a
+- Command/flags used: `scripts/vscode/Invoke-MSTestWithCoverage.ps1` post-processing path
+- Data source or fixture:
+  `docs/features/active/2026-08-06-quickfiler-high-confidence-queue-init-stall-424/evidence/qa-gates/coverage-final.cobertura.xml`
+
+## Steps to Reproduce
+
+1. Inspect `Merge-CoberturaClassesByFilename` in
+   `scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1`, beginning at `:167`.
+2. Observe the class-level `<lines>` union at `:217-268`. It correctly takes max hits per line number
+   across every `<class>` element sharing a `filename`.
+3. Observe that the `<methods>` subtrees of the non-primary group members are **not** merged into the
+   primary class element.
+4. Observe the rate recomputation, which selects over the descendant axis `.//lines/line`. That axis
+   matches both the merged class-level `<lines>` and the *unmerged, primary-only* `<methods>/<method>/<lines>/<line>`.
+5. Verify arithmetically against `QfcHomeController.Iteration.cs` in the committed report: the true
+   per-file figure computed from the class-level union alone is **45/56 = 80.36%**, while the emitted
+   attribute is `0.8625`, which is exactly **69/80** — the blended numerator and denominator.
+6. Cross-check the recipe independently: `#424`'s own delta evidence
+   (`docs/features/active/2026-08-06-quickfiler-high-confidence-queue-init-stall-424/evidence/qa-gates/coverage-delta.2026-08-07T00-48.md:10,41`)
+   arrived at the class-level-only computation, confirming that the attribute is not the right source.
+
+## Expected Behavior
+
+The emitted per-file `line-rate` should equal the rate computed from the merged class-level `<lines>`
+set alone: distinct line numbers, max hits per number, hit count over total count.
+
+## Actual Behavior
+
+The emitted `line-rate` mixes the merged class-level line set with the primary class's method-level
+line set, producing a figure that corresponds to neither the true per-file rate nor any single
+class's rate.
+
+## Logs / Screenshots
+
+- [x] Attached minimal logs or screenshot
+- Snippet: `QfcHomeController.Iteration.cs` — true per-file `45/56 = 0.8036`; emitted attribute
+  `0.8625 = 69/80`. Confirmed against `scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1:167`
+  (function start) and `:217-268` (the correct union). Discovered during preparation research for
+  issue #454 (epic #136, child F11); full analysis in
+  `docs/features/active/2026-08-07-quickfiler-collection-controller-coverage-454/research/coverage-harness-contract.md`
+  section A.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+Any consumer reading the per-file `line-rate` attribute gets a wrong number, and the error is not in
+a consistent direction because it depends on how much of a file's coverage sits in the primary class
+versus its siblings. Epic #136 gates every one of its fifteen children on a per-file line rate, so an
+uncorrected attribute would produce false passes and false failures across the whole epic.
+
+## Suspected Cause / Notes
+
+The union logic and the rate recomputation were written against different assumptions: the union
+operates on the class-level `<lines>` element specifically, while the recomputation reuses the
+same `.//lines/line` descendant axis that issue #441 identifies as the source of the double-count.
+Fixing #441's axis alone would **not** fix this defect; the `<methods>` merge is separately missing.
+
+Related: this is why epic #136's harness directive tells children to recompute per-file rates from
+deduplicated `<line>` nodes and never to read the `<class>` `line-rate` attribute. That guidance is
+correct and this issue documents the underlying reason.
+
+## Proposed Fix / Validation Ideas
+
+- [x] Unit coverage areas: a Pester case with two `<class>` elements sharing one `filename`, each
+      with its own `<methods>`, asserting the merged `line-rate` equals the class-level union rate.
+- [x] Integration scenario to retest: re-run post-processing over the committed `#424` report and
+      assert `QfcHomeController.Iteration.cs` reports `0.8036`, not `0.8625`.
+- [x] Manual verification notes: fix alongside #441, since both live in the same two functions and a
+      partial fix would leave the attribute wrong in a different way. Re-capture any committed
+      coverage baseline that was derived from the attribute.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-qfc-collection-background-task-and-catch-defects.md
+++ b/docs/features/potential/promoted/2026-08-07-qfc-collection-background-task-and-catch-defects.md
@@ -1,0 +1,103 @@
+# qfc-collection-background-task-and-catch-defects (Issue #473)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/qfc-collection-background-task-and-catch-defects/ (Issue #473)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #473
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/473
+- Last Updated: 2026-08-08
+## Summary
+
+Two concurrency and error-handling defects in `QfcCollectionController`: replacing the
+`BackgroundLoadingTasks` bag reference after awaiting it discards any task added in the interim, and
+`TryMoveEmailByGroupAsync` produces two misleading error logs for one failure while also swallowing
+cancellation.
+
+## Environment
+
+- OS/version: n/a (logic defects, reproducible wherever QuickFiler runs)
+- Python version: n/a
+- Command/flags used: n/a
+- Data source or fixture: `QuickFiler/Controllers/QfcCollectionController.cs`
+
+## Steps to Reproduce
+
+**Defect 1 — `BackgroundLoadingTasks` reset race (`:398-399`, `:492-493`)**
+
+1. `internal ConcurrentBag<Task> BackgroundLoadingTasks = [];` is declared at `:80`.
+2. Both `:398-399` and `:492-493` perform the sequence
+   `await Task.WhenAll(BackgroundLoadingTasks); BackgroundLoadingTasks = [];`
+3. That assignment replaces the bag **reference**, it does not clear the existing bag.
+4. Any `Add` performed by a concurrently running load between the `WhenAll` completing and the
+   assignment executing lands in the old bag.
+5. The old bag is then dropped, so that task is never awaited and its completion is never observed.
+   An exception it raises becomes an unobserved task exception.
+
+**Defect 2 — `TryMoveEmailByGroupAsync` double-log and swallowed cancellation (`:2236-2258`)**
+
+1. `TryGetItemGroupByIndex` at `:2260-2270` can return `null`.
+2. That null reaches `TryMoveEmailByGroupAsync`, where line 2240 dereferences it and throws a
+   `NullReferenceException`.
+3. The broad `catch (System.Exception)` at `:2242` catches it and logs an error.
+4. Execution continues to line 2247, which dereferences the same null and throws again.
+5. The second broad catch at `:2249` logs a second error.
+6. One root cause therefore produces two misleading log entries and no clear failure signal.
+7. Both broad catches also swallow `OperationCanceledException`, so a cancelled move is reported as
+   an error rather than as a cancellation.
+
+## Expected Behavior
+
+1. Tasks added to the background-loading set should always be awaited; the set should be cleared in a
+   way that cannot drop a concurrently added task, or the add/await boundary should be synchronized.
+2. A single root failure should produce a single, accurate log entry, and cancellation should
+   propagate as cancellation rather than being caught as a generic error.
+
+## Actual Behavior
+
+1. A task added during the reset window is silently discarded and never awaited; any exception it
+   raises is unobserved.
+2. A null group produces two `NullReferenceException` log entries; a cancelled move is logged as an
+   error.
+
+## Logs / Screenshots
+
+- [x] Attached minimal logs or screenshot
+- Snippet: Confirmed directly against source at `QfcCollectionController.cs:80` (field declaration),
+  `:398-399` and `:492-493` (the reset sequence), and `:2236-2258` (the two catch blocks).
+  Discovered during preparation research for issue #454 (epic #136, child F11); full analysis in
+  `docs/features/active/2026-08-07-quickfiler-collection-controller-coverage-454/research/qfc-collection-controller.md`
+  sections E16 and E17.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [ ] Medium
+- [x] Low
+
+Defect 1's window is narrow and `BackgroundLoadingTasks` has no consumer outside this file, so a fix
+is locally contained. Defect 2 is a diagnosability problem rather than a functional one, but it makes
+genuine move failures harder to attribute and hides cancellation.
+
+## Suspected Cause / Notes
+
+Defect 1 is the common "reassign instead of clear" mistake with concurrent collections. Defect 2 is a
+consequence of catching broadly and then continuing rather than returning; note that the repository
+code-change policy explicitly discourages broad catches that do not re-raise or add context.
+
+## Proposed Fix / Validation Ideas
+
+- [x] Unit coverage areas: assert a task added during the reset window is still awaited; assert a
+      null group yields exactly one log entry; assert `OperationCanceledException` propagates.
+- [x] Integration scenario to retest: cancel a move mid-flight and confirm it is reported as
+      cancelled, not as an error.
+- [x] Manual verification notes: prefer an early return after the first catch over allowing execution
+      to fall through to the second dereference.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-qfc-collection-controller-coupling-and-modal-getter.md
+++ b/docs/features/potential/promoted/2026-08-07-qfc-collection-controller-coupling-and-modal-getter.md
@@ -1,0 +1,112 @@
+# qfc-collection-controller-coupling-and-modal-getter (Issue #474)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/qfc-collection-controller-coupling-and-modal-getter/ (Issue #474)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #474
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/474
+- Last Updated: 2026-08-08
+## Summary
+
+Two design defects in `QfcCollectionController` that are structural rather than incidental: a
+downcast from an interface-typed field to a concrete sibling controller that will throw for any other
+implementation, and a property getter that shows a modal dialog as a side effect.
+
+## Environment
+
+- OS/version: n/a (design defects, reproducible wherever QuickFiler runs)
+- Python version: n/a
+- Command/flags used: n/a
+- Data source or fixture: `QuickFiler/Controllers/QfcCollectionController.cs`
+
+## Steps to Reproduce
+
+**Defect 1 — concrete-type downcast to a sibling controller (`:1232`)**
+
+1. `_parent` is declared as `IFilerFormController` at
+   `QuickFiler/Controllers/QfcCollectionController.cs:64`.
+2. Line 1232 executes `await ((QfcFormController)_parent).SkipGroupAsync();` — a downcast to the
+   concrete type.
+3. `SkipGroupAsync` is declared on `QuickFiler.Controllers.IQfcFormController`
+   (`QuickFiler/Controllers/IQfcFormController.cs:38`).
+4. That is a **different** interface from `QuickFiler.Interfaces.IFilerFormController`
+   (`QuickFiler/Interfaces/IFilerFormController.cs:9-24`), which does not declare `SkipGroupAsync`.
+5. Any `IFilerFormController` implementation other than `QfcFormController` therefore throws
+   `InvalidCastException` at line 1232.
+6. The root cause is that two interfaces model the same role and neither is a superset of the other.
+
+**Defect 2 — modal dialog inside a property getter (`:152-194`)**
+
+1. `ReadyForMove`'s getter iterates the item groups.
+2. When any group lacks a destination folder, lines 186-191 show a modal `MessageBox`.
+3. Reading a property therefore blocks on user interaction and cannot be evaluated on a background
+   thread, in a test, or twice without side effects.
+
+## Expected Behavior
+
+1. Either `IFilerFormController` declares the member that `QfcCollectionController` needs, or the
+   controller depends on the interface that does. No downcast to a concrete sibling should be
+   required.
+2. A readiness check should return a result the caller can inspect and act on. Presenting UI is the
+   caller's decision, not the property's.
+
+## Actual Behavior
+
+1. `InvalidCastException` for any non-`QfcFormController` parent; the interface-typed field provides
+   no real substitutability.
+2. Reading `ReadyForMove` displays a modal dialog, which blocks the calling thread and makes the
+   property untestable under the repository unit-test policy, which prohibits popups in tests.
+
+## Logs / Screenshots
+
+- [x] Attached minimal logs or screenshot
+- Snippet: Confirmed directly against source at `QfcCollectionController.cs:64` (field type), `:1232`
+  (downcast), `IQfcFormController.cs:38` and `IFilerFormController.cs:9-24` (the two-interface split),
+  and `QfcCollectionController.cs:152-194` (the getter, with the `MessageBox` at `:186-191`).
+  Discovered during preparation research for issue #454 (epic #136, child F11); full analysis in
+  `docs/features/active/2026-08-07-quickfiler-collection-controller-coverage-454/research/qfc-collection-controller.md`
+  sections E8 and E10.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+Neither defect misbehaves in the current single-implementation production configuration, so this is
+latent rather than active. Both are load-bearing for testability and for any future alternative
+implementation, and the modal getter is a standing violation of the separation between domain logic
+and UI.
+
+## Suspected Cause / Notes
+
+The two-interface split (`QuickFiler.Controllers.IQfcFormController` versus
+`QuickFiler.Interfaces.IFilerFormController`) looks like an incomplete consolidation. Resolving it is
+the real fix for defect 1; the downcast is a symptom.
+
+Note for scheduling: `QuickFiler/Controllers/IQfcFormController.cs` and
+`QuickFiler/Interfaces/IFilerFormController.cs` are owned by child F6 (issue #435) of epic #136.
+Whoever schedules this work should reconcile with F6 rather than editing those files independently.
+
+Issue #454 (child F11) introduces injectable delegate seams around both call sites so the current
+behavior is preserved bit-for-bit while becoming testable. That work does **not** fix either defect;
+it only makes them reachable from tests. The structural fixes are deferred here because they are
+behavior changes, which epic #136's no-behavior-change NFR excludes.
+
+## Proposed Fix / Validation Ideas
+
+- [x] Unit coverage areas: assert the parent interaction works against a substitute
+      `IFilerFormController`; assert a readiness check returns a result without presenting UI.
+- [x] Integration scenario to retest: attempt a move with a group that has no destination folder and
+      confirm the user-facing prompt still appears, driven by the caller.
+- [x] Manual verification notes: consolidate the two form-controller interfaces first; the downcast
+      removal follows from it.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-qfc-collection-controller-unreachable-load-paths.md
+++ b/docs/features/potential/promoted/2026-08-07-qfc-collection-controller-unreachable-load-paths.md
@@ -1,0 +1,100 @@
+# qfc-collection-controller-unreachable-load-paths (Issue #468)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/qfc-collection-controller-unreachable-load-paths/ (Issue #468)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #468
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/468
+- Last Updated: 2026-08-08
+## Summary
+
+Twelve members of `QfcCollectionController`, totalling roughly 227 lines, have no caller anywhere in
+the solution. They are dead code that inflates the coverage denominator and, in one case, hides a
+real defect behind an unreachable entry point.
+
+## Environment
+
+- OS/version: n/a (dead-code finding, established by static reference search)
+- Python version: n/a
+- Command/flags used: repository-wide reference search across `QuickFiler`, `QuickFiler.Test`, and
+  all other projects in `TaskMaster.sln`
+- Data source or fixture: `QuickFiler/Controllers/QfcCollectionController.cs`
+
+## Steps to Reproduce
+
+1. Search the whole solution for callers of each of the following members of
+   `QuickFiler/Controllers/QfcCollectionController.cs`:
+   - `WireUpKeyboardHandler` (`:1254`)
+   - `AnyOpenDropDownsAsync` (`:1324`)
+   - `LoadGroups_02cAsync` (`:587`)
+   - `LoadGroups_02bAsync` (`:635`)
+   - `LoadGroup_03bAsync` (`:654`)
+   - `LoadConversationsAndFoldersAsync` (`:761`)
+   - `LoadItemGroup` (`:776`)
+   - `LoadSequentialAsync` (`:827`)
+   - `LoadGroupSequential` (`:842`)
+   - `CacheTlpForMove` (`:865`)
+   - `SwapTlp` (`:870`)
+   - `CaptureTlpTemplate` (`:1991`)
+2. Confirm no production or test caller exists for any of them.
+3. Note `LoadGroups_02bAsync` is referenced only from a commented-out line at `:402`.
+4. Note the field `_templateTlp` (`:70`) is written only by the dead `CaptureTlpTemplate`, so it is
+   dead state as well.
+
+## Expected Behavior
+
+Production code should not retain unreachable members. Every member should either have a caller or be
+removed, so that the coverage denominator reflects code that can actually run.
+
+## Actual Behavior
+
+Roughly 227 lines of unreachable code sit in the largest file in the repository. Under epic #136's
+per-file 80% line-coverage target these lines must either be covered by tests that exercise code no
+production path reaches, or be removed.
+
+## Logs / Screenshots
+
+- [x] Attached minimal logs or screenshot
+- Snippet: Confirmed by solution-wide reference search during preparation research for issue #454
+  (epic #136, child F11); full analysis in
+  `docs/features/active/2026-08-07-quickfiler-collection-controller-coverage-454/research/qfc-collection-controller.md`
+  section E1.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [ ] Medium
+- [x] Low
+
+Low functional risk, since none of it executes. The cost is real but indirect: a substantial share of
+the file's coverage denominator is code that cannot be exercised through any production path, and one
+of these members hides an active defect.
+
+## Suspected Cause / Notes
+
+The `Load*` cluster appears to be a superseded loading strategy left in place after the current async
+load path was introduced. The commented-out reference at `:402` supports that reading.
+
+Related finding: `WireUpKeyboardHandler` (`:1254`) is the entry point for the duplicate `KaKey`
+registration recorded in issue #444. Because it has no caller, that defect is **dormant, not live** —
+production wires keys through `WireUpAsyncKeyboardHandler` (`:1275-1280`) and `RegisterAsyncKeyActions`
+(`:1282-1291`), which register `Keys.Up` and `Keys.Down` exactly once each. Removing this dead member
+would resolve #444 as a side effect; the two should be scheduled together.
+
+## Proposed Fix / Validation Ideas
+
+- [x] Unit coverage areas: none — the correct resolution is removal, not new tests.
+- [x] Integration scenario to retest: exercise the full QuickFiler load, conversation-expansion, and
+      move flows after removal to confirm no reflective or late-bound caller was missed.
+- [x] Manual verification notes: several of these members are `public`, so removal is a public-API
+      change. That is why it is deferred out of issue #454, whose epic carries a no-behavior-change
+      constraint. Schedule alongside issue #444.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-qfc-collection-conversation-index-defects.md
+++ b/docs/features/potential/promoted/2026-08-07-qfc-collection-conversation-index-defects.md
@@ -1,0 +1,109 @@
+# qfc-collection-conversation-index-defects (Issue #470)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/qfc-collection-conversation-index-defects/ (Issue #470)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #470
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/470
+- Last Updated: 2026-08-08
+## Summary
+
+Three related index and null-guard defects in `QfcCollectionController`'s conversation-expansion
+path: a `-1` index used to subscript `_itemGroups`, a slot-reservation count that can disagree with
+the number of members actually inserted, and an unguarded dereference that precedes its own null
+check.
+
+## Environment
+
+- OS/version: n/a (logic defects, reproducible wherever QuickFiler runs)
+- Python version: n/a
+- Command/flags used: n/a
+- Data source or fixture: `QuickFiler/Controllers/QfcCollectionController.cs`
+
+## Steps to Reproduce
+
+**Defect 1 — `ToggleGroupConv(string)` can index `_itemGroups[-1]` (`:1733-1766`)**
+
+1. At `:1743`, `indexOriginal` is `-1` when the original message has already been removed.
+2. That routes to `PromoteFirstChild(originalId, ref childCount)` at `:1970`.
+3. `PromoteFirstChild` calls `FindIndex` at `:1972`. If no group carries
+   `ConvOriginID == originalId`, that also returns `-1`.
+4. Line 1975 then evaluates `_itemGroups[-1].ItemViewer`, throwing `ArgumentOutOfRangeException`.
+5. `ChangeConversationSilently(indexOriginal, true)` at `:1749` fails the same way for the same
+   reason.
+
+**Defect 2 — `EnumerateConversationMembers` count mismatch (`:1875-1922`)**
+
+1. `ToggleUnGroupConv` reserves `insertCount = conversationCount - 1` slots at `:1823` and
+   `:1827-1829`.
+2. `EnumerateConversationMembers` iterates `insertions.Count` at `:1888-1889`, a count derived
+   independently from `resolver.ConversationItems.SameFolder` at `:1883-1886`.
+3. If the resolver returns **more** members than `conversationCount - 1`, then
+   `_itemGroups[i + insertionIndex]` at `:1893` walks past the reserved slots and re-initializes
+   groups that already hold other messages.
+4. If it returns **fewer**, the empty placeholder `QfcItemGroup`s created at `:2008` are left with a
+   `null` `ItemController`, which the next `RenumberGroups` at `:2068` dereferences.
+
+**Defect 3 — `SetVisualDigits` inconsistent null handling (`:130-146`)**
+
+1. Line 140 dereferences `grp.ItemController.ItemNumberDigits` with no guard.
+2. Lines 141-142 guard the same object: `grp.ItemController?.ItemNumber... ?? 0.ToString(format)`.
+3. Since `ItemController` genuinely can be `null` (see Defect 2), line 140 throws before the guard on
+   line 141 is ever evaluated.
+
+## Expected Behavior
+
+1. A `-1` index should be handled explicitly rather than used to subscript `_itemGroups`.
+2. The number of slots reserved and the number of members inserted should be derived from a single
+   source, or reconciled before insertion.
+3. `SetVisualDigits` should guard `ItemController` consistently across all three reads.
+
+## Actual Behavior
+
+1. `ArgumentOutOfRangeException` when a conversation's original message is gone and no child carries
+   the matching `ConvOriginID`.
+2. Either existing groups are silently overwritten, or placeholder groups with a `null`
+   `ItemController` cause a `NullReferenceException` in `RenumberGroups`.
+3. `NullReferenceException` at line 140 whenever `ItemController` is null.
+
+## Logs / Screenshots
+
+- [x] Attached minimal logs or screenshot
+- Snippet: Confirmed directly against source at the line numbers above. Discovered during preparation
+  research for issue #454 (epic #136, child F11); full analysis in
+  `docs/features/active/2026-08-07-quickfiler-collection-controller-coverage-454/research/qfc-collection-controller.md`
+  sections E11, E12, and E13.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+All three throw rather than corrupt, so the failure is visible. Defect 2's overwrite branch is the
+most serious because it can silently re-initialize a group holding a different message.
+
+## Suspected Cause / Notes
+
+Defects 1 and 3 are both "guard placed after the dereference it protects", the same shape as the
+`GetMoveDiagnostics` defect filed separately. Defect 2 is a genuine two-sources-of-truth problem
+between the reservation count and the resolver result.
+
+## Proposed Fix / Validation Ideas
+
+- [x] Unit coverage areas: `ToggleGroupConv` with a removed original and no matching child;
+      `EnumerateConversationMembers` with resolver counts above, equal to, and below
+      `conversationCount - 1`; `SetVisualDigits` with a null `ItemController`.
+- [x] Integration scenario to retest: expand and collapse a conversation whose original message was
+      filed in a previous step.
+- [x] Manual verification notes: Defect 2 should be fixed by reconciling the counts before insertion,
+      not by clamping the loop, so that a resolver disagreement is surfaced rather than hidden.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-qfc-collection-eliminate-space-sign-error.md
+++ b/docs/features/potential/promoted/2026-08-07-qfc-collection-eliminate-space-sign-error.md
@@ -1,0 +1,87 @@
+# qfc-collection-eliminate-space-sign-error (Issue #471)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/qfc-collection-eliminate-space-sign-error/ (Issue #471)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #471
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/471
+- Last Updated: 2026-08-08
+## Summary
+
+`QfcCollectionController.EliminateSpaceForItems` computes a negative `heightChange` and then
+subtracts it, so the item panel **grows** when rows are removed instead of shrinking.
+
+## Environment
+
+- OS/version: n/a (logic defect, reproducible wherever QuickFiler runs)
+- Python version: n/a
+- Command/flags used: n/a
+- Data source or fixture: `QuickFiler/Controllers/QfcCollectionController.cs`
+
+## Steps to Reproduce
+
+1. Inspect `QuickFiler/Controllers/QfcCollectionController.cs:2013-2027`
+   (`EliminateSpaceForItems(int removalInex, int removalCount)`).
+2. Note line 2017 assigns a negative magnitude:
+   `var heightChange = -(int)Math.Round(_template.Height * removalCount, 0);`
+3. Note lines 2020 and 2025 then **subtract** that value:
+   `... MinimumSize.Height - heightChange` and `... Size.Height - heightChange`.
+4. Subtracting a negative number adds. Removing `removalCount` rows therefore increases the panel
+   height by `_template.Height * removalCount`.
+5. Compare with the sibling `MakeSpaceForItems` at `:2029-2042`, which computes a **positive**
+   magnitude and uses `+`. The two methods are not symmetric.
+6. The reachable production path is `ToggleGroupConv` at `:1779`, i.e. collapsing a conversation.
+
+## Expected Behavior
+
+Removing `removalCount` rows should reduce the panel's `MinimumSize.Height` and `Size.Height` by
+`_template.Height * removalCount`, mirroring `MakeSpaceForItems` in the opposite direction.
+
+## Actual Behavior
+
+The panel height increases by `_template.Height * removalCount` on every removal, so the item table
+grows each time a conversation is collapsed.
+
+## Logs / Screenshots
+
+- [x] Attached minimal logs or screenshot
+- Snippet: Confirmed directly against source at `QuickFiler/Controllers/QfcCollectionController.cs:2017`
+  (negative assignment), `:2020` and `:2025` (subtraction), and `:2029-2042` (the asymmetric sibling
+  `MakeSpaceForItems`). Discovered during preparation research for issue #454 (epic #136, child F11);
+  full analysis in
+  `docs/features/active/2026-08-07-quickfiler-collection-controller-coverage-454/research/qfc-collection-controller.md`
+  section E3.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+A visual layout defect on the conversation-collapse path. It does not corrupt data or lose mail, but
+it degrades the QuickFiler item panel cumulatively over a session.
+
+## Suspected Cause / Notes
+
+A sign error introduced when `EliminateSpaceForItems` was written as the inverse of
+`MakeSpaceForItems`: the author negated the magnitude **and** kept the subtraction, applying the
+inversion twice.
+
+## Proposed Fix / Validation Ideas
+
+- [x] Unit coverage areas: assert `EliminateSpaceForItems` reduces both `MinimumSize.Height` and
+      `Size.Height` by exactly `_template.Height * removalCount`, and that
+      `MakeSpaceForItems` followed by `EliminateSpaceForItems` with the same count is height-neutral.
+- [x] Integration scenario to retest: collapse and re-expand a conversation repeatedly and confirm
+      the panel height returns to its original value.
+- [x] Manual verification notes: the fix is either negating line 2017 or changing lines 2020/2025 to
+      `+`, not both.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-qfc-collection-move-diagnostics-defects.md
+++ b/docs/features/potential/promoted/2026-08-07-qfc-collection-move-diagnostics-defects.md
@@ -1,0 +1,118 @@
+# qfc-collection-move-diagnostics-defects (Issue #469)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/qfc-collection-move-diagnostics-defects/ (Issue #469)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #469
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/469
+- Last Updated: 2026-08-08
+## Summary
+
+Four related defects in `QfcCollectionController`'s move and move-diagnostics path: a null guard
+placed after the dereference it protects, a trailing null element in the returned array, positional
+indexing into an unordered `ConcurrentDictionary`, and a declared parameter that the method body
+never reads.
+
+## Environment
+
+- OS/version: n/a (logic defects, reproducible wherever QuickFiler runs)
+- Python version: n/a
+- Command/flags used: n/a
+- Data source or fixture: `QuickFiler/Controllers/QfcCollectionController.cs`
+
+## Steps to Reproduce
+
+**Defect 1 — unreachable null guard in `GetMoveDiagnostics` (`:2288-2322`)**
+
+1. Line 2288: `var qf = TryGetItemGroupByIndex(k)?.ItemController;` — `qf` may be `null` by
+   construction of the null-conditional.
+2. Line 2289 dereferences it immediately: `qf.ItemHelper`.
+3. Line 2312 dereferences it again: `xComma(qf.ItemHelper.Subject)`.
+4. Only at line 2313 does `if (qf is not null)` appear, so the `else` branch at `:2318-2322` is dead
+   code and a null `qf` throws a `NullReferenceException` at 2289 before reaching the guard.
+5. Note the issue-#97 guard documented at `QuickFiler.Test/Controllers/QfcCollectionControllerTests.cs:77-80`
+   protects the `olAppointment` parameter, not this path.
+
+**Defect 2 — trailing null element (`:2284-2286`)**
+
+1. Line 2284 allocates `new string[_itemGroupsToMove.Count + 1]`.
+2. The loop at 2286 fills indices `0 .. Count-1`.
+3. `strOutput[Count]` is therefore always `null`.
+4. Consumers are `QuickFiler/Controllers/QfcHomeController.Metrics.cs:75` and `:144`.
+
+**Defect 3 — positional access into a `ConcurrentDictionary` (`:2260-2270`)**
+
+1. `_itemGroupsToMove` is declared `ConcurrentDictionary<QfcItemGroup, int>` at `:71`.
+2. `TryGetItemGroupByIndex` does `_itemGroupsToMove.ElementAt(index).Key` at `:2264`.
+3. `ConcurrentDictionary` enumeration order is unspecified and not stable across mutations.
+4. `MoveEmailsAsync` (`:2220-2223`) and `GetMoveDiagnostics` (`:2286-2288`) each walk `0..Count-1`
+   independently, so the two walks can observe different orders.
+
+**Defect 4 — `MoveEmailsAsync` ignores its parameter (`:2206-2228`)**
+
+1. `stackMovedItems` (`SloStack<IMovedMailInfo>`) is declared on the interface at
+   `QuickFiler/Interfaces/IQfcCollectionController.cs:50`.
+2. It is supplied by `QuickFiler/Controllers/QfcFormController.EventHandlers.cs:225` as `_movedItems`.
+3. The method body at `:2206-2228` never reads the parameter.
+
+## Expected Behavior
+
+1. The null guard should precede every dereference of `qf`, so a missing item controller produces the
+   intended diagnostic line rather than an exception.
+2. `GetMoveDiagnostics` should return exactly `_itemGroupsToMove.Count` elements.
+3. Index-to-group resolution should use a stable, explicitly ordered collection so that a diagnostic
+   line is attributed to the message it describes.
+4. Either `MoveEmailsAsync` populates the undo stack it is handed, or the parameter is removed from
+   the contract.
+
+## Actual Behavior
+
+1. A null `ItemController` throws `NullReferenceException` at `:2289`; the `else` branch is dead.
+2. Callers receive an array whose last element is always `null`.
+3. A diagnostic line can be attributed to the wrong message when the dictionary is mutated between
+   the two independent walks.
+4. The undo record supplied by the caller is silently dropped, unless it is populated elsewhere.
+
+## Logs / Screenshots
+
+- [x] Attached minimal logs or screenshot
+- Snippet: Confirmed directly against source at the line numbers above. Discovered during preparation
+  research for issue #454 (epic #136, child F11); full analysis in
+  `docs/features/active/2026-08-07-quickfiler-collection-controller-coverage-454/research/qfc-collection-controller.md`
+  sections E4, E5, E6, and E15.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+Defects 1 and 3 can produce wrong or failed move diagnostics. Defect 4 needs triage before a final
+severity can be assigned: if the undo record is genuinely dropped, undo-after-move is broken, which
+would be High.
+
+## Suspected Cause / Notes
+
+Defects 1 and 2 share a shape with `SetVisualDigits` (`:138-143`), suggesting a systematic
+guard-placement habit rather than isolated slips. Defect 3 is a consequence of using a
+`ConcurrentDictionary` where an ordered list is required. Defect 4 should be triaged first, since its
+resolution may be "remove the parameter" rather than "populate it".
+
+## Proposed Fix / Validation Ideas
+
+- [x] Unit coverage areas: `GetMoveDiagnostics` with a null `ItemController`; array length equals
+      `Count`; `TryGetItemGroupByIndex` stability across a mutation; `MoveEmailsAsync` populates or
+      does not require `stackMovedItems`.
+- [x] Integration scenario to retest: move a multi-message selection and confirm each diagnostic line
+      matches its message, then exercise undo.
+- [x] Manual verification notes: triage defect 4 before fixing; the correct resolution may be a
+      contract change coordinated with the `IQfcCollectionController` owner.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-qfc-collection-navigation-digits-desync.md
+++ b/docs/features/potential/promoted/2026-08-07-qfc-collection-navigation-digits-desync.md
@@ -1,0 +1,99 @@
+# qfc-collection-navigation-digits-desync (Issue #472)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/qfc-collection-navigation-digits-desync/ (Issue #472)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #472
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/472
+- Last Updated: 2026-08-08
+## Summary
+
+`QfcCollectionController.RegisterNavigation` captures the side-effecting `Digits` property once,
+while `UnregisterNavigation` re-evaluates it inside its loop. If the item count crosses the 10-item
+boundary between the two calls, keys are unregistered under different names than they were
+registered, leaving orphaned key registrations that later collide. This is the same failure family as
+issue #232.
+
+## Environment
+
+- OS/version: n/a (logic defect, reproducible wherever QuickFiler runs)
+- Python version: n/a
+- Command/flags used: n/a
+- Data source or fixture: `QuickFiler/Controllers/QfcCollectionController.cs`
+
+## Steps to Reproduce
+
+1. Inspect `RegisterNavigation` at `QuickFiler/Controllers/QfcCollectionController.cs:1330-1341`.
+   Line 1332 captures the value once: `var digits = Digits;`, then passes that captured value to
+   every `RegisterNavigationAsyncAction` call.
+2. Inspect `UnregisterNavigation` at `:1343-1356`. Line 1347 re-evaluates `Digits` **inside** the
+   loop, once per iteration.
+3. Inspect the `Digits` property at `:114-128`. It reads `_itemGroups?.Count` live and returns 1 for
+   counts below 10 and 2 at or above 10. It is side-effecting: it also drives
+   `SetVisualDigits` via `_digitRefreshNeeded`.
+4. Register navigation while the collection holds 10 or more items, so keys are registered as
+   `"01".."09"`.
+5. Allow the item count to drop below 10 (for example by filing messages) before
+   `UnregisterNavigation` runs.
+6. `UnregisterNavigation` now computes `digits == 1` and attempts to remove `"1".."9"`.
+7. `KbdActions.Remove` (`QuickFiler/Controllers/KbdActions.cs:123-135`) returns `false` **silently**
+   when the key is absent; nothing surfaces the mismatch.
+8. The original `"01".."09"` registrations remain. A later `Add` of the same key collides in
+   `KbdActions.Add` (`KbdActions.cs:90-98`) and throws `ArgumentException`.
+
+## Expected Behavior
+
+The digit width used to unregister a navigation key must be the same width used to register it, so
+that every registered key is removed exactly once and no orphan remains.
+
+## Actual Behavior
+
+When the count crosses the 10-item boundary between register and unregister, the removal silently
+no-ops and the stale registrations persist until a later `Add` throws `ArgumentException`.
+
+## Logs / Screenshots
+
+- [x] Attached minimal logs or screenshot
+- Snippet: Confirmed directly against source at `QfcCollectionController.cs:1332` (single capture),
+  `:1347` (per-iteration re-evaluation), `:114-128` (the live, side-effecting `Digits` property), and
+  `KbdActions.cs:123-135` (the silent `false` return). Discovered during preparation research for
+  issue #454 (epic #136, child F11); full analysis in
+  `docs/features/active/2026-08-07-quickfiler-collection-controller-coverage-454/research/qfc-collection-controller.md`
+  section E14.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+Produces a delayed, hard-to-attribute `ArgumentException` in keyboard registration rather than an
+immediate failure at the point of the mismatch. Directly analogous to issue #232, which was a
+navigation-key collision on page swap.
+
+## Suspected Cause / Notes
+
+The asymmetry looks unintentional: the two methods are otherwise mirror images, and only the
+placement of the `Digits` read differs. A secondary concern is that `Digits` is a property with side
+effects, which makes reading it inside a loop hazardous in general.
+
+`KbdActions.Remove` returning `false` silently is what converts this from a loud failure into a
+latent one; consider whether that return value should be checked at the call site.
+
+## Proposed Fix / Validation Ideas
+
+- [x] Unit coverage areas: register with count >= 10, drop the count below 10, unregister, and assert
+      no orphaned registrations remain; assert `UnregisterNavigation` uses a single captured digit
+      width.
+- [x] Integration scenario to retest: fill a page with 10 or more messages, file several, then swap
+      pages and confirm no `ArgumentException` in keyboard registration.
+- [x] Manual verification notes: reconcile with issue #232's fix so the two do not diverge again.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-qfc-home-controller-dead-iterate-paths.md
+++ b/docs/features/potential/promoted/2026-08-07-qfc-home-controller-dead-iterate-paths.md
@@ -1,0 +1,51 @@
+# qfc-home-controller-dead-iterate-paths (Issue #447)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/qfc-home-controller-dead-iterate-paths/ (Issue #447)
+
+- Issue: #447
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/447
+- Last Updated: 2026-08-08
+## Problem / Why
+
+`QfcHomeController.Iterate()` and `QfcHomeController.Iterate2()` are unreachable in production but are still compiled, so they sit in the coverage denominator and must be tested by epic child F7 (`quickfiler-qfc-home-controller-coverage`, issue #433) despite delivering no behavior.
+
+Evidence is recorded in
+`docs/features/active/2026-08-07-quickfiler-qfc-home-controller-coverage-433/research/QfcHomeController.Iteration.cs.research.2026-08-07T20-50.md` (finding LD1):
+
+- The two methods account for 23 of the 86 lines of `QuickFiler/Controllers/QfcHomeController.Iteration.cs`.
+- `Iterate` is bound into `QfcFormController`'s private `IterateDelegate Iterate` field (`QfcFormController.cs:48`, declared at `:85`, nulled at `QfcFormController.SetupDisposal.cs:225`). That field is never invoked.
+- `Iterate2` has no caller anywhere in the repository.
+- Both are declared on `IQfcHomeController` (`QuickFiler/Controllers/IQfcHomeController.cs`), so removal is an interface change.
+
+## Proposed Behavior
+
+Remove `Iterate()` and `Iterate2()` and their `IQfcHomeController` declarations, together with the unused `IterateDelegate` binding in `QfcFormController`, after confirming no reflection-based or late-bound caller exists. The observable behavior of QuickFiler should be unchanged because neither method executes today.
+
+## Acceptance Criteria (early draft)
+
+- [ ] A repository-wide search confirms no caller of either method, including reflection and delegate indirection.
+- [ ] Both methods and their interface declarations are removed.
+- [ ] The now-unused `IterateDelegate` field and its assignment and disposal in `QfcFormController` are removed.
+- [ ] Full C# toolchain passes and no observable QuickFiler behavior changes.
+
+## Constraints & Risks
+
+- This spans files owned by two concurrent epic children: `QfcHomeController.Iteration.cs` and `IQfcHomeController.cs` (F7) and `QfcFormController*` (F6). It must not be executed unilaterally inside either child.
+- Sequencing: doing this before F7 executes would shrink F7's target surface by 23 lines and remove test work; doing it after means F7 writes tests that are then deleted. Deferring to the epic capstone (F16) or scheduling it after the epic completes both avoid mid-epic churn.
+
+## Decision recorded for F7
+
+F7 will COVER these methods rather than remove them. Rationale: removing production code inside a coverage child would breach the epic NFR of no behavior change through a testability refactor, and the removal necessarily touches F6-owned files, which the epic's disjoint-file-set design prohibits. The removal is recorded here instead so it is not lost.
+
+## Test Conditions to Consider
+
+- [ ] Unit coverage areas: confirm no remaining references after removal.
+- [ ] Integration scenarios: a full QuickFiler session in both normal and High Confidence mode.
+- [ ] CLI/API examples: n/a
+
+## Next Step
+
+- [ ] Promote to GitHub issue (feature request template)
+- [ ] Schedule after the `quickfiler-per-file-coverage` epic completes, or fold into its capstone

--- a/docs/features/potential/promoted/2026-08-07-qfc-home-controller-metrics-duration-misread.md
+++ b/docs/features/potential/promoted/2026-08-07-qfc-home-controller-metrics-duration-misread.md
@@ -1,0 +1,72 @@
+# qfc-home-controller-metrics-duration-misread (Issue #443)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/qfc-home-controller-metrics-duration-misread/ (Issue #443)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #443
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/443
+- Last Updated: 2026-08-08
+## Summary
+
+QuickFiler session-duration metrics are recorded incorrectly: `WriteMetricsAsync` reads the freshly restarted stopwatch instead of the swapped-out one, and both metrics writers use `TimeSpan.Seconds` (the 0-59 component) instead of `TotalSeconds`.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Python version: n/a (C# / .NET Framework 4.8 VSTO add-in)
+- Command/flags used: QuickFiler launched from the TaskMaster ribbon; any session that records metrics
+- Data source or fixture: Live Outlook mailbox
+
+## Steps to Reproduce
+
+1. Launch QuickFiler and file messages for a measurable interval longer than 60 seconds.
+2. Complete the session so the metrics write path runs.
+3. Inspect the recorded duration value.
+
+## Expected Behavior
+
+The recorded duration equals the elapsed time of the completed filing interval.
+
+## Actual Behavior
+
+Two independent errors corrupt the value:
+
+- On the end-of-database path the recorded duration is approximately 0 seconds regardless of the real interval.
+- Where a duration is recorded at all, an interval of 90 seconds is written as 30 because only the seconds component is taken.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Snippet: none; the values are written to the session metrics CSV.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+Medium: no user-visible functional regression in filing, but recorded performance metrics are wrong, so any tuning decision based on them is unsound. Note this defect is currently masked by the separate defect in which metrics are never flushed to disk at all.
+
+## Suspected Cause / Notes
+
+Found during read-only research for epic child F7 (`quickfiler-qfc-home-controller-coverage`, issue #433) under parent epic #136. Report-only; deliberately not fixed inside a coverage child. Evidence is recorded in
+`docs/features/active/2026-08-07-quickfiler-qfc-home-controller-coverage-433/research/QfcHomeController.Metrics.cs.research.2026-08-07T20-50.md` (findings D1, D2, D8, D9).
+
+- **Wrong stopwatch.** `QfcHomeController.Metrics.cs:121` reads `StopWatch.Elapsed` (`_stopWatch`); the commented-out line 120 shows it previously read `_stopWatchMoved`. Production calls `SwapStopWatch()` *before* the metrics write on the end-of-database path (`QfcFormController.EventHandlers.cs:191-192` -> `BackGroundMoveAsync` -> `WriteMetrics`), so `_stopWatch` at that moment is the freshly restarted stopwatch and the true interval sits unread in `_stopWatchMoved`. The sibling method `QuickFileMetrics_WRITE` (`Metrics.cs:42`) reads `_stopWatchMoved` — the two writers disagree. On the `MoveAndIterate` path (`EventHandlers.cs:157-161`) the swap in `LoadUiFromQueue` races `BackGroundMoveAsync`, making the value non-deterministic as well.
+- **Seconds truncation.** `Metrics.cs:42` and `Metrics.cs:121` use `TimeSpan.Seconds` rather than `TotalSeconds`. `Metrics.cs:44` compounds it by deriving `startTime` from the full `Elapsed` while `duration` uses the truncated value, so the calendar appointment span and the CSV duration disagree.
+- **Related formatting defects, same code path (fix together or split as judged).** `Metrics.cs` lines 31, 53, 56, 108, 110, 132, 135 format with `CultureInfo.CurrentCulture`, so on a non-invariant culture the `##0.00` numbers gain a comma decimal separator and corrupt the comma-delimited CSV. The `"hh:mm"` format renders 14:30 as `02:30` with no AM/PM designator.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Unit coverage areas: the duration-text construction in `QfcHomeController.Metrics.cs`, extracted as a pure function so the value can be asserted without a live stopwatch.
+- [ ] Integration scenario to retest: run a filing session longer than 60 seconds on both the end-of-database and `MoveAndIterate` paths and confirm the recorded duration matches.
+- [ ] Manual verification notes: confirm CSV output is culture-invariant and that recorded times are unambiguous.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-qfc-home-controller-metrics-never-flushed.md
+++ b/docs/features/potential/promoted/2026-08-07-qfc-home-controller-metrics-never-flushed.md
@@ -1,0 +1,71 @@
+# qfc-home-controller-metrics-never-flushed (Issue #442)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/qfc-home-controller-metrics-never-flushed/ (Issue #442)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #442
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/442
+- Last Updated: 2026-08-08
+## Summary
+
+`QfcHomeController.WriteMetricsAsync` enqueues QuickFiler session metrics into a `BlockingCollection<string>` that no consumer ever drains, so the metrics are never written to disk. The consumer guard can never pass and the consumer timer is never started.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Python version: n/a (C# / .NET Framework 4.8 VSTO add-in)
+- Command/flags used: QuickFiler launched from the TaskMaster ribbon; any session that completes and writes metrics
+- Data source or fixture: Live Outlook mailbox
+
+## Steps to Reproduce
+
+1. Launch QuickFiler and file at least one batch of messages so a metrics line is produced.
+2. Complete the session so `WriteMetricsAsync` runs.
+3. Inspect the configured session metrics file (`Globals.FS.Filenames.EmailSession`).
+
+## Expected Behavior
+
+The session metrics line is appended to the configured metrics file.
+
+## Actual Behavior
+
+No metrics line is written. The line is added to the in-memory `_metrics` collection and remains there until the process exits.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Snippet: none; the failure is silent.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+Medium: no user-visible functional regression in filing, but the QuickFiler performance-metrics feature produces no output at all, so the data intended to drive tuning does not exist.
+
+## Suspected Cause / Notes
+
+Found during read-only research for epic child F7 (`quickfiler-qfc-home-controller-coverage`, issue #433) under parent epic #136. Report-only; deliberately not fixed inside a coverage child. Evidence is recorded in
+`docs/features/active/2026-08-07-quickfiler-qfc-home-controller-coverage-433/research/QfcHomeController.Metrics.cs.research.2026-08-07T20-50.md` (findings D3, D4, D5) and
+`.../research/QfcHomeController.cs.research.2026-08-07T20-50.md`.
+
+- `_metricsConsumers` (`QuickFiler/Controllers/QfcHomeController.cs:356`) is initialized to `0` and is only ever **decremented** (`QfcHomeController.Metrics.cs:228`, `QfcHomeController.cs:366`). No code path in the repository increments it. The guard `Interlocked.CompareExchange(ref _metricsConsumers, 0, 2) == 2` (`QfcHomeController.Metrics.cs:226`) can therefore never be true, so `TimedConsumerAsync` is never subscribed.
+- Even if the guard passed, `QfcHomeController.Metrics.cs:229-230` constructs `new System.Timers.Timer(2000)` into a **local**, subscribes `TimedConsumerAsync` to `Elapsed`, and never calls `Start()` or sets `Enabled`. The local is immediately eligible for collection and is never disposed.
+- `_metrics` never receives `CompleteAdding()`, so `QfcHomeController.cs:367` (`foreach` over `GetConsumingEnumerable`) would block indefinitely if the consumer ever did run.
+- `_fileName` (`QfcHomeController.cs:358`) is assigned at `Metrics.cs:153` and never read; `TimedConsumerAsync` uses `Globals.FS.Filenames.EmailSession` instead. It is also `static` on an instance-scoped concern.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Unit coverage areas: the consumer-scheduling path in `QfcHomeController.Metrics.cs` and `TimedConsumerAsync` in `QfcHomeController.cs`, behind an injectable writer seam so no test touches disk.
+- [ ] Integration scenario to retest: complete a QuickFiler session and confirm the metrics file receives the expected line.
+- [ ] Manual verification notes: confirm the timer is started and disposed, and that `CompleteAdding()` is called on shutdown so the consumer terminates.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-qfc-item-controller-cleanup-timer-and-stale-field-defects.md
+++ b/docs/features/potential/promoted/2026-08-07-qfc-item-controller-cleanup-timer-and-stale-field-defects.md
@@ -1,0 +1,88 @@
+# qfc-item-controller-cleanup-timer-and-stale-field-defects (Issue #484)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/qfc-item-controller-cleanup-timer-and-stale-field-defects/ (Issue #484)
+- Discovered during: preparation research for epic #136 child F10 (issue #453)
+
+- Issue: #484
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/484
+- Last Updated: 2026-08-08
+## Summary
+
+`QfcItemController.Cleanup()` nulls the armed `_emailIsReadTimer` field without disposing it,
+orphaning a live 4-second `System.Threading.Timer` that will still fire against a torn-down
+controller. The same method leaves other collaborator fields in an inconsistent state.
+
+## Affected Code
+
+### 1. Armed timer nulled without disposal
+
+`_emailIsReadTimer` is declared at `QuickFiler/Controllers/QfcItemController.cs:53` as a
+`System.Threading.Timer`.
+
+It is created and armed at `QuickFiler/Controllers/QfcItemController.Navigation.cs:223-224`:
+
+```csharp
+_emailIsReadTimer = new System.Threading.Timer(ApplyReadEmailFormat);
+_emailIsReadTimer.Change(4000, System.Threading.Timeout.Infinite);
+```
+
+`Navigation.cs:211-213` demonstrates the correct pattern on the re-arm path:
+
+```csharp
+if (_emailIsReadTimer is not null)
+{
+    _emailIsReadTimer.Dispose();
+```
+
+But `QuickFiler/Controllers/QfcItemController.ViewerSetup.cs:420`, inside `Cleanup()`, does only:
+
+```csharp
+_emailIsReadTimer = null;
+```
+
+The timer is armed for 4000 ms and is not disposed. After `Cleanup()` the callback
+`ApplyReadEmailFormat` still executes on a thread-pool thread against a controller whose fields have
+just been nulled. The disposal path elsewhere in the same type shows this is an oversight rather
+than an intentional handoff.
+
+### 2. Stale collaborator fields across `Cleanup()` / `SaveParameters`
+
+`Cleanup()` nulls 17 collaborator fields, but `_mailActions` is retained across the
+`Cleanup()`/`SaveParameters` boundary, so a reused controller can act through a collaborator bound
+to the previous mail item. This is latent rather than currently reachable, and is recorded here so
+it is not rediscovered.
+
+## Why This Is a Defect
+
+QuickFiler pools and reuses item viewers and their controllers. A 4-second timer surviving cleanup
+means the callback lands during or after the next item's setup, where it either throws a
+`NullReferenceException` against nulled fields or applies read-formatting to the wrong item. Both
+are silent: the callback runs on a thread-pool thread with no logging on the fault path.
+
+## Reproduction Sketch
+
+Arm the read timer by selecting an item, then tear the controller down within four seconds by
+navigating away or closing the pane. Observe `ApplyReadEmailFormat` executing after `Cleanup()`.
+
+## Suspected Fix
+
+In `Cleanup()`, dispose the timer before nulling the field, mirroring the existing pattern at
+`Navigation.cs:211-213`. Audit `_mailActions` lifetime against the pooled-reuse path and null it
+with the other collaborators if no caller depends on its retention.
+
+## Severity
+
+Medium. Reachable `NullReferenceException` on a thread-pool thread, or misapplied UI formatting on a
+recycled viewer.
+
+## Related
+
+- #481 — `QfcItemController` has no event unwiring path (same teardown-incompleteness class).
+
+## Scope
+
+Out of scope for epic #136 child F10, whose NFR prohibits behavior change to observable QuickFiler
+flows. Disposing the timer changes teardown semantics and must be scheduled with its own regression
+test.

--- a/docs/features/potential/promoted/2026-08-07-qfc-item-controller-expansion-registry-divergence.md
+++ b/docs/features/potential/promoted/2026-08-07-qfc-item-controller-expansion-registry-divergence.md
@@ -1,0 +1,83 @@
+# qfc-item-controller-expansion-registry-divergence (Issue #482)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/qfc-item-controller-expansion-registry-divergence/ (Issue #482)
+- Discovered during: preparation research for epic #136 child F10 (issue #453)
+
+- Issue: #482
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/482
+- Last Updated: 2026-08-08
+## Summary
+
+`QfcItemController`'s synchronous and asynchronous expansion paths maintain disjoint keyboard-action
+registries for the `'B'` and `'D'` keys while sharing a single `_expanded` state flag. Interleaving
+the two paths drives the flag and the registries out of agreement, and the next registration throws
+`ArgumentException` because `KbdActions.Add` is not idempotent.
+
+## Affected Code
+
+- `QuickFiler/Controllers/QfcItemController.Navigation.cs` — synchronous `ToggleExpansion()` and
+  asynchronous `ToggleExpansionAsync()` register and unregister against separate registries but
+  share `_expanded`.
+- `QuickFiler/Controllers/KbdActions.cs:90-104` — `Add` throws rather than no-ops on a duplicate
+  `(sourceId, key)` pair:
+
+```csharp
+public void Add(string sourceId, TKey key, VDelegate @delegate)
+{
+    if (_list.Any(x => x.SourceId == sourceId && StoredKeyEquals(x.Key, key)))
+    {
+        string message =
+            $"Cannot add key because it already exists. Key {key} SourceId {sourceId}";
+        logger.Error(message);
+        throw new ArgumentException(message);
+    }
+    ...
+}
+```
+
+- `QuickFiler/Controllers/QfcCollectionController.cs:1439` —
+  `ActivateBySelectionAsync` calls the *synchronous* `ToggleExpansion()` from an asynchronous
+  activation path, which is what makes the interleaving reachable in production rather than
+  theoretical.
+
+## Reproduction Sequence
+
+1. Expand via the synchronous path (registers `'B'`/`'D'` in the sync registry, sets `_expanded`).
+2. Collapse via the asynchronous path (unregisters from the async registry, which does not hold
+   those entries, and clears `_expanded`).
+3. Expand again via the synchronous path.
+
+The third step re-registers `'B'`/`'D'` while the sync registry still holds them from step 1, and
+`KbdActions.Add` throws `ArgumentException`.
+
+## Compounding Factor
+
+`KbdActions.Remove` returns `bool` to signal whether anything was removed, and all 30 call sites in
+the codebase discard the return value. A failed unregistration is therefore silent, which is why the
+registries can diverge without any diagnostic until the exception surfaces.
+
+## Suspected Fix
+
+Unify the two registries behind a single registration owner keyed on the actual current state rather
+than on which code path performed the toggle, and either make `Add` idempotent or make the callers
+check `Remove`'s result. Note that making `Add` idempotent is a contract change affecting all
+consumers and interacts with #444.
+
+## Severity
+
+Medium-High. Reachable unhandled `ArgumentException` from ordinary user interaction with expansion.
+
+## Related
+
+- #444 — `KbdActions` enumerable constructor bypasses the duplicate guard (same class, different
+  entry point).
+- #445 — QuickFiler keyboard-action contract defects.
+
+## Scope
+
+Out of scope for epic #136 child F10, whose NFR prohibits behavior change to observable QuickFiler
+flows, and whose file assignment excludes `KbdActions.cs` (F3 / #430) and
+`QfcCollectionController.cs` (F11 / #454). Filed for independent scheduling with an explicit note
+that a fix spans three children's file assignments.

--- a/docs/features/potential/promoted/2026-08-07-qfc-item-controller-mailactions-error-handling-defects.md
+++ b/docs/features/potential/promoted/2026-08-07-qfc-item-controller-mailactions-error-handling-defects.md
@@ -1,0 +1,75 @@
+# qfc-item-controller-mailactions-error-handling-defects (Issue #483)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/qfc-item-controller-mailactions-error-handling-defects/ (Issue #483)
+- Discovered during: preparation research for epic #136 child F10 (issue #453)
+
+- Issue: #483
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/483
+- Last Updated: 2026-08-08
+## Summary
+
+`MoveMailAsync` swallows every exception behind a broad `catch (System.Exception)`, reports it
+through a blocking `MessageBox.Show` from a possibly non-UI thread, and does not rethrow. Sibling
+mail actions omit cancellation checks that `MarkItemForDeletionAsync` performs.
+
+## Affected Code
+
+### 1. Broad catch that swallows move failures
+
+`QuickFiler/Controllers/QfcItemController.MailActions.cs:115-122`
+
+```csharp
+catch (System.Exception e)
+{
+    //logger.Debug($"Error moving mail {Subject} from {Sender} on {SentDate}. Skipping");
+    logger.Error($"{e}");
+    MessageBox.Show(
+        $"Error moving mail {ItemHelper.Subject} from {ItemHelper.Sender} on {ItemHelper.SentDate}. Skipping"
+    );
+}
+```
+
+Three problems:
+
+- **Broad catch without propagation.** `.claude/rules/general-code-change.md` requires failing fast
+  and explicitly, and prohibits broad catch-all handlers "unless you immediately re-raise or
+  propagate with added context." This handler does neither. The caller cannot distinguish a
+  successful move from a failed one, so the queue proceeds as though the mail was filed.
+- **Modal dialog from a non-UI thread.** `MoveMailAsync` is async and the catch is not marshalled to
+  the UI thread. `MessageBox.Show` from a thread-pool thread produces a dialog with no owner, which
+  can appear behind the Outlook window and block a background thread indefinitely with no user
+  affordance to discover it.
+- **Message loses the cause.** The user-facing text reports which mail failed but not why; the
+  exception detail goes only to the log.
+
+### 2. Missing cancellation checks
+
+`MarkItemForDeletionAsync` checks the cancellation token, but `MoveMailAsync`, `FlagAsTaskAsync`,
+and `EnumerateConversationAsync` do not perform the equivalent check on the same paths. During a
+bulk operation that the user cancels, these continue to completion.
+
+## Why This Is a Defect
+
+The swallowed exception is the more serious of the two. A move that throws is reported to the user
+as a transient message and then forgotten; the item remains in place while the surrounding flow
+treats the operation as complete. There is no retry and no durable record beyond the log line.
+
+## Suspected Fix
+
+Narrow the catch to the exception types actually anticipated on the filer path, add context and
+rethrow (or return a failure result the caller can act on), and marshal any user-facing notification
+through the existing UI dispatcher seam rather than calling `MessageBox.Show` directly. Add
+cancellation checks to the three actions that lack them, matching `MarkItemForDeletionAsync`.
+
+## Severity
+
+Medium-High. Silent failure to file mail, with a user-visible message that does not prevent the
+surrounding flow from treating the operation as successful.
+
+## Scope
+
+Out of scope for epic #136 child F10, whose NFR prohibits behavior change to observable QuickFiler
+flows. Both changes alter observable error behavior and must be scheduled with their own regression
+tests.

--- a/docs/features/potential/promoted/2026-08-07-qfc-item-controller-no-event-unwiring-path.md
+++ b/docs/features/potential/promoted/2026-08-07-qfc-item-controller-no-event-unwiring-path.md
@@ -1,0 +1,66 @@
+# qfc-item-controller-no-event-unwiring-path (Issue #481)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/qfc-item-controller-no-event-unwiring-path/ (Issue #481)
+- Discovered during: preparation research for epic #136 child F10 (issue #453)
+
+- Issue: #481
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/481
+- Last Updated: 2026-08-08
+## Summary
+
+`QfcItemController` subscribes to roughly 22 events across its wiring partials and never detaches
+any of them. `Cleanup()` nulls collaborator fields but performs no unsubscription, so handlers
+remain reachable from live event sources after the controller is logically torn down.
+
+## Affected Code
+
+- `QuickFiler/Controllers/QfcItemController.EventWiring.cs` — 25 `+=` subscription operators.
+  `WireIntentEvents()` alone makes 16 subscriptions; `WireControlTreeEvents()` adds further
+  per-control, per-button, and per-menu-item subscriptions.
+- `QuickFiler/Controllers/QfcItemController.ViewerSetup.cs:392-421` — `Cleanup()` nulls 17
+  collaborator fields and detaches nothing.
+
+Across all ten `QfcItemController.*.cs` partials there are exactly three `-=` operators
+(`ViewerSetup.cs:152`, `:155`, `:399`), all for the single unrelated `BreadcrumbUnhandledArrow`
+event. Every other subscription is permanent for the lifetime of the event source.
+
+## Why This Is a Defect
+
+QuickFiler pools and reuses item viewers. A subscription that outlives its controller keeps the
+controller object graph reachable from the viewer's event source, which prevents collection and — more
+importantly — allows a stale controller to receive and act on events after `Cleanup()`. At least one
+observed consequence is a swallowed `NullReferenceException` when a post-cleanup
+`WebViewInitializationCompleted` handler dereferences a field that `Cleanup()` has already nulled.
+
+This is the same defect class recorded for `EmailMoveMonitor` in issue #426 (a leaked
+`BeforeItemMove` subscription), here at substantially larger scale.
+
+## Reproduction Sketch
+
+Wire a controller against a viewer, call `Cleanup()`, then raise any wired event on the viewer.
+The handler still executes against a controller with nulled fields.
+
+## Suspected Fix
+
+Introduce a symmetric unwiring path — an `UnwireIntentEvents()` / `UnwireControlTreeEvents()` pair
+mirroring the wiring methods — and invoke it from `Cleanup()` before the fields are nulled.
+Detachment must use the same delegate identity used at subscription time, which for lambda-based
+subscriptions requires capturing the delegate in a field first.
+
+## Severity
+
+Medium. No data loss. Causes handler execution against torn-down state, swallowed exceptions, and
+retention of the controller graph across pooled-viewer reuse.
+
+## Related
+
+- #426 — `EmailMoveMonitor` rejected-item hook retention (same defect class, different owner).
+- #458 — `WebView2BreadcrumbHost` handler retention with pooled viewer.
+
+## Scope
+
+Out of scope for epic #136 child F10, whose NFR prohibits behavior change to observable QuickFiler
+flows. Adding an unwiring path changes teardown semantics and must be scheduled and tested on its
+own.

--- a/docs/features/potential/promoted/2026-08-07-qfc-item-controller-togglenavigation-double-toggle.md
+++ b/docs/features/potential/promoted/2026-08-07-qfc-item-controller-togglenavigation-double-toggle.md
@@ -1,0 +1,88 @@
+# qfc-item-controller-togglenavigation-double-toggle (Issue #480)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/qfc-item-controller-togglenavigation-double-toggle/ (Issue #480)
+- Discovered during: preparation research for epic #136 child F10 (issue #453)
+
+- Issue: #480
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/480
+- Last Updated: 2026-08-08
+## Summary
+
+`QfcItemController.ToggleNavigation(bool async)` invokes the state-flipping
+`QfcTipsDetails.Toggle(bool)` exactly twice on every call, so the navigation position tips return to
+their original visibility. The feature is inert.
+
+## Affected Code
+
+`QuickFiler/Controllers/QfcItemController.FocusAndTheme.cs:168-179`
+
+```csharp
+public void ToggleNavigation(bool async)
+{
+    _itemViewer.BeginInvoke(new System.Action(() => _itemPositionTips.Toggle(false)));
+    if (async)
+    {
+        _itemViewer.BeginInvoke(new System.Action(() => _itemPositionTips.Toggle(false)));
+    }
+    else
+    {
+        _itemViewer.Invoke(new System.Action(() => _itemPositionTips.Toggle(false)));
+    }
+}
+```
+
+Line 170 toggles unconditionally. Then exactly one of line 173 or line 177 toggles again. Both
+branches lead to a second toggle, so there is no path through this method that toggles only once.
+
+## Why This Is a Defect
+
+`UtilitiesCS/HelperClasses/ToolTips/QfcTipsDetails.cs:193-203` shows `Toggle(bool sharedColumn)` is a
+flip, not an idempotent set:
+
+```csharp
+public void Toggle(bool sharedColumn)
+{
+    if (_state.HasFlag(Enums.ToggleState.On))
+    {
+        Toggle(Enums.ToggleState.Off, sharedColumn);
+    }
+    else
+    ...
+}
+```
+
+Two flips return the control to its starting state. The user-visible effect is that invoking
+navigation-tip toggling through this overload does nothing.
+
+Contrast the sibling overload `ToggleNavigation(bool async, Enums.ToggleState desiredState)` at
+`FocusAndTheme.cs:181`, which correctly calls the idempotent `Toggle(desiredState, false)` exactly
+once per branch. The single-argument overload appears to have been written by analogy without
+accounting for the flip semantics of the one-argument `Toggle`.
+
+## Reproduction
+
+Call `ToggleNavigation(async: false)` or `ToggleNavigation(async: true)` on a controller whose
+`_itemPositionTips` is initialized, then observe `_labelControl.Visible`. It is unchanged.
+
+## Suspected Fix
+
+Remove the unconditional toggle at line 170, leaving exactly one toggle per branch. Confirm against
+the intended behavior of the caller before changing, since some caller may have been written to
+compensate for the no-op.
+
+## Severity
+
+Medium. No crash or data loss; a UI affordance silently does nothing.
+
+## Detection Note
+
+This was masked in the existing test suite by an assertion using `Times.AtLeastOnce()`, which is
+satisfied by two invocations just as well as by one. A regression test must assert the exact
+invocation count.
+
+## Scope
+
+Out of scope for epic #136 child F10, whose NFR prohibits behavior change to observable QuickFiler
+flows. Filed for independent scheduling.

--- a/docs/features/potential/promoted/2026-08-07-qfc-item-controller-webview-handler-unguarded-inputs.md
+++ b/docs/features/potential/promoted/2026-08-07-qfc-item-controller-webview-handler-unguarded-inputs.md
@@ -1,0 +1,75 @@
+# qfc-item-controller-webview-handler-unguarded-inputs (Issue #485)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/qfc-item-controller-webview-handler-unguarded-inputs/ (Issue #485)
+- Discovered during: preparation research for epic #136 child F10 (issue #453)
+
+- Issue: #485
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/485
+- Last Updated: 2026-08-08
+## Summary
+
+The `WebResourceRequested` handler installed by `InitializeWebViewAsync` dereferences two
+externally-supplied values without guarding them. Both throw inside a WebView2 event handler, where
+the exception has no useful propagation path.
+
+## Affected Code
+
+`QuickFiler/Controllers/QfcItemController.ViewerSetup.cs:81-102`
+
+### 1. Unguarded `new Uri(...)` — line 83
+
+```csharp
+var requestedId = new Uri(e.Request.Uri).Segments.LastOrDefault()?.Trim('/');
+```
+
+`e.Request.Uri` is supplied by the WebView2 runtime from whatever the rendered mail body requested.
+A malformed or non-absolute value throws `UriFormatException`. The result is only tested for
+emptiness on the following line, so the guard is applied one step too late — the constructor has
+already run. `Uri.TryCreate` is the appropriate form here.
+
+### 2. Unguarded `new MemoryStream(match.AttachmentData)` — line 97
+
+```csharp
+e.Response = _webViewEnvironment.CreateWebResourceResponse(
+    new MemoryStream(match.AttachmentData),
+    ...
+);
+```
+
+`match.AttachmentData` is not null-checked. `new MemoryStream(null)` throws
+`ArgumentNullException`. `match` comes from `CidImageResolver.BuildContentIdMap(...)`, which is
+built from `ItemHelper.AttachmentsInfo`; an attachment entry whose data failed to load yields a null
+payload while still contributing a map entry, so the `TryGetValue` success at line 90 does not imply
+a non-null `AttachmentData`.
+
+## Why This Is a Defect
+
+Both faults occur on the WebView2 message-handler path. An exception there does not surface to the
+user as a handled error; it either terminates the handler silently (leaving the inline image
+unrendered with no diagnostic) or escapes as an unhandled exception on a runtime callback thread,
+depending on the host's dispatch behavior. Neither outcome is diagnosable from the logs, because
+neither path logs.
+
+## Suspected Fix
+
+Replace line 83 with `Uri.TryCreate(e.Request.Uri, UriKind.Absolute, out var uri)` and return early
+on failure. Add a null check on `match.AttachmentData` before constructing the stream, returning
+early and logging at debug level so a missing attachment payload is visible.
+
+## Severity
+
+Low-Medium. No data loss. Causes silent failure to render inline images and produces an
+undiagnosable exception on a callback thread.
+
+## Related
+
+- #463 — WebView2 `-–incognito` argument uses an en dash (same initialization method, already filed;
+  this report does not duplicate it).
+
+## Scope
+
+Out of scope for epic #136 child F10, whose NFR prohibits behavior change to observable QuickFiler
+flows. Adding guards changes observable behavior on the failure path and must be scheduled with its
+own regression tests.

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-breadcrumb-dropdown-webview-coverage.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-breadcrumb-dropdown-webview-coverage.md
@@ -1,0 +1,50 @@
+# quickfiler-breadcrumb-dropdown-webview-coverage (Promoted)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> Issue #455 -> `docs/features/active/2026-08-07-quickfiler-breadcrumb-dropdown-webview-coverage-455/`
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/455
+- Work Mode: full-feature
+- Parent epic: #136 (QuickFiler per-file 80% coverage)
+- Epic child: F13 of `quickfiler-per-file-coverage`
+- Integration branch: `epic/quickfiler-per-file-coverage-integration`
+- Upstream dependency: F1 `quickfiler-coverage-ledger` (issue #432)
+
+> Audit-trail note: the MCP promotion tool reported this destination path in its receipt but the
+> file was not present on disk afterwards. It is reconstructed here so the promotion lifecycle
+> remains auditable. The authoritative record is issue #455 and the active feature folder.
+
+## Problem / Why
+
+Child F13 of epic #136 owns the QuickFiler breadcrumb drop-down surface and the WebView2 host
+(15 compiled files, ~3,111 lines under `QuickFiler/Viewers/`). Eight coordinator files are already
+well covered; three WebView2 files carry class-level `[ExcludeFromCodeCoverage]` and are absent
+from instrumentation entirely; one file carries seven method-level exemptions; four are
+interface-only declarations.
+
+## Proposed Behavior
+
+Raise every `testable` file in the F13 assignment to at least 80% line and 75% branch coverage,
+verified with F1's per-file harness, and either remove the `[ExcludeFromCodeCoverage]` attributes
+with the code genuinely covered or retain only a file-specific irreducible remainder argued against
+the exemption grounds in the epic's Shared Design section 1. No observable behavior change to
+QuickFiler flows.
+
+## Outcome of Preparation (2026-08-08)
+
+Promotion, twelve per-file research artifacts, `spec.md` (AC-1..AC-25), `user-story.md`
+(US-1..US-11), and a 14-phase / 220-task atomic plan were produced. The plan passed the MCP plan
+validator and cleared `atomic-executor` preflight on the third round.
+
+Research materially corrected several premises carried in the epic manifest and the original
+delegation brief; those corrections are recorded as D1-D13 in the active folder's `issue.md` and in
+`spec.md` section 11.
+
+Six latent defects were promoted to their own issues rather than left as feature-folder prose, per
+the epic's Latent Defect Promotion rule: **#457, #458, #462, #475, #476, #477**.
+
+## Next Step
+
+- [x] Promote to GitHub issue (#455)
+- [x] Create the active feature folder
+- [ ] Atomic execution — deferred to `epic-orchestrator` after F1 (#432) merges

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-collection-controller-coverage.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-collection-controller-coverage.md
@@ -1,0 +1,110 @@
+# quickfiler-collection-controller-coverage
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/2026-08-07-quickfiler-collection-controller-coverage-454/ (Issue #454)
+- Parent epic issue: #136 (https://github.com/drmoisan/TaskMaster/issues/136)
+- Parent epic manifest: docs/features/epics/quickfiler-per-file-coverage/epic.md (child F11, wave 1)
+- Integration branch: `epic/quickfiler-per-file-coverage-integration`
+- Upstream dependency: F1 `quickfiler-coverage-ledger` (issue #432, wave 0)
+
+> Recreated by the orchestrator after promotion. The MCP promotion tool created issue #454 and
+> populated the active feature folder's `issue.md`, but did not leave the potential markdown on
+> disk. This file restores the audit trail.
+
+## Problem / Why
+
+`QuickFiler/Controllers/QfcCollectionController.cs` is the single largest production file in the
+repository at 2,349 lines. It carries a real `[ExcludeFromCodeCoverage]` attribute, so it is absent
+from every Cobertura report the repository produces: it is **unmeasured, not covered**. Its
+interface, `QuickFiler/Interfaces/IQfcCollectionController.cs` (118 lines), completes the pair.
+
+Three repository policies are violated or unenforced against this file today:
+
+1. `.claude/rules/general-code-change.md` sets a 500-line ceiling for production files. At 2,349
+   lines the file breaches it by a factor of nearly five.
+2. `.claude/rules/general-unit-test.md` § Coverage Exclusion Policy states that no production file
+   may be excluded from coverage measurement, and that the correct response to untestable lines is
+   refactoring, not exclusion.
+3. Issue #136 AC1 requires every compiled QuickFiler file to reach >= 80% line coverage or sit on a
+   ratified exemption ledger with a file-specific rationale.
+
+The epic manifest makes this file its own child precisely because closing the gap requires three
+substantial pieces of work in strict sequence: a partial split into at least five files to satisfy
+the 500-line rule, seam extraction so the logic is reachable without live COM or WinForms, and only
+then the coverage itself.
+
+## Proposed Behavior
+
+No observable behavior change to QuickFiler flows. The work is a testability refactor plus test
+authorship:
+
+1. Split `QfcCollectionController.cs` into coherent partial-class files along logical responsibility
+   seams (not mechanical 500-line chops), each under 500 lines.
+2. Extract seams — interface seam first, injectable delegate second, adapter third — so the
+   controller's logic is reachable from MSTest without constructing live forms, showing popups,
+   touching the UI thread, or instantiating Outlook COM objects.
+3. Remove `[ExcludeFromCodeCoverage]` and author MSTest/Moq/FluentAssertions tests bringing each
+   resulting partial to >= 80% line and >= 75% branch coverage, with newly created files reaching
+   >= 90% line coverage per the `CLAUDE.md` new-module rule.
+
+## Acceptance Criteria (early draft)
+
+- [ ] `QfcCollectionController` and every partial it is split into reaches >= 80% line and >= 75%
+      branch coverage, verified with F1's per-file harness and recorded under
+      `<FEATURE>/evidence/qa-gates/`.
+- [ ] `[ExcludeFromCodeCoverage]` is removed from `QfcCollectionController.cs` and the code is
+      genuinely covered. A blanket re-exemption of the whole file is not acceptable; an irreducible
+      remainder is acceptable only where F1's ledger ratifies it with a file-specific rationale.
+- [ ] No production file in scope exceeds 500 lines.
+- [ ] Every file newly created by this work reaches >= 90% line coverage.
+- [ ] Tests use MSTest, Moq, and FluentAssertions; are deterministic and isolated; create no
+      temporary files; contact no external services; construct no live forms; raise no popups.
+- [ ] The full C# toolchain (csharpier, analyzers, nullable, MSTest with coverage) is green in the
+      final form, and repository-wide coverage is retained or improved.
+- [ ] No behavior change to observable QuickFiler flows.
+
+## Constraints & Risks
+
+- **`QuickFiler.csproj` edits are guaranteed.** The project is a legacy non-SDK project with no
+  globbing; every new partial needs an explicit `<Compile Include=...>` entry. Per epic.md
+  "Cross-Child Constraints" section 1: only this child's own entries, minimal adjacent hunks, and
+  CRLF must be preserved. An additive fan-in conflict with siblings is anticipated, not a defect.
+- **Upstream dependency on F1** (issue #432) for the per-file coverage harness and the ledger at
+  `docs/features/epics/quickfiler-per-file-coverage/coverage-ledger.md`. A ledger row must be
+  appended for every new file per epic.md "Mid-Wave File Creation".
+- **Sibling boundaries.** This controller is consumed by `QfcHomeController` (F7, #433) and consumes
+  `IQfcDatamodel` (F5, #436) and `IQfcQueue` (F2, #431). No sibling files may be edited. Seams
+  should stay `internal` where possible so F7's conclusion that it needs no contract additions
+  remains true.
+- **Moq cannot proxy internal QuickFiler types.** `QuickFiler/Properties/AssemblyInfo.cs:5` grants
+  `InternalsVisibleTo("QuickFiler.Test")` and nothing else; `DynamicProxyGenAssembly2` is not
+  granted. Internal seams are visible to tests but must be injectable delegates or hand-written
+  fakes rather than Moq-mocked internal interfaces.
+- **No `InternalsVisibleTo` grant** from `UtilitiesCS` to `QuickFiler.Test`
+  (`UtilitiesCS/Properties/AssemblyInfo.cs:18-20`). A local seam must be built rather than editing
+  that file.
+- **Known defects out of scope for fixing.** Issue #444 (`KbdActions` enumerable constructor
+  bypasses the duplicate guard, reached via this controller's keyboard registration) and issue #286
+  (`RemoveSpecificControlGroupAsync` static reentrancy counter leaks on exception because the
+  decrement is not in a `finally`). Both are characterized, not fixed, under the epic's
+  no-behavior-change NFR.
+- **Starting coverage is unknown and likely near zero.** The exemption removes the file from
+  instrumentation entirely, so no historical number exists. Two test files
+  (`QfcCollectionControllerTests.cs` at 500 lines, `QfcCollectionControllerDarkModeTests.cs` at 155)
+  already exist; what they actually reach given the exemption is established during research.
+
+## Test Conditions to Consider
+
+- [ ] Per-partial unit coverage for every responsibility group produced by the split.
+- [ ] Seam-level tests exercising injected delegates and adapters without live COM or forms.
+- [ ] Characterization of the #444 duplicate-`KaKey` registration and the #286 counter leak without
+      changing behavior.
+- [ ] STA last-resort tests, if unavoidable, isolated in dedicated `*.StaTests.cs` files.
+- [ ] Branch-coverage-sensitive scenarios (the 75% branch gate is independent of the 80% line gate).
+
+## Next Step
+
+- [x] Promote to GitHub issue (feature request template) -> #454
+- [x] Create `docs/features/active/2026-08-07-quickfiler-collection-controller-coverage-454/` folder
+      from the template

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-coverage-ledger.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-coverage-ledger.md
@@ -1,0 +1,57 @@
+# quickfiler-coverage-ledger (Potential — Promoted)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> Issue [#432](https://github.com/drmoisan/TaskMaster/issues/432) -> `docs/features/active/2026-08-07-quickfiler-coverage-ledger-432/`
+- Parent epic issue: [#136](https://github.com/drmoisan/TaskMaster/issues/136)
+- Epic: `quickfiler-per-file-coverage` (child F1, wave 0)
+- Integration branch: `epic/quickfiler-per-file-coverage-integration`
+- Promotion type: feature
+- Work mode: full-feature
+
+> Recreated for the lifecycle audit trail. The `potential_to_issue` MCP operation created issue #432
+> and populated the active feature folder, but did not leave this file on disk. The authoritative
+> current content lives in
+> `docs/features/active/2026-08-07-quickfiler-coverage-ledger-432/issue.md`, `spec.md`, and
+> `user-story.md`.
+
+## Problem / Why
+
+Epic #136 requires that every production `.cs` file compiled by `QuickFiler/QuickFiler.csproj`
+reach at least 80% line coverage or sit on an explicitly ratified exemption ledger. Fifteen sibling
+child features and the capstone are blocked on three shared prerequisites that must be settled
+exactly once:
+
+1. **The denominator is undefined.** No authoritative per-file classification exists stating which
+   compiled files are `testable` and which are `ratified-exempt`. Without it a child cannot state
+   its own acceptance criteria.
+2. **The existing `[ExcludeFromCodeCoverage]` attributes are unratified.** Until each has a recorded
+   disposition, children would independently and inconsistently decide whether to remove or keep
+   them. An attribute on a testable seam is a Blocking finding per the epic manifest.
+3. **There is no per-file coverage measurement.** `scripts/vscode/Invoke-MSTestWithCoverage.ps1`
+   emits a Cobertura report, but nothing derives per-file line-coverage percentages from it.
+
+Aggregate assembly coverage does not satisfy issue #136, which measures success per production file.
+
+## Proposed Behavior
+
+The wave-0 enabler for epic #136. No QuickFiler production behavior changes; no file under
+`QuickFiler/` is modified. Three deliverables:
+
+1. A per-file classification ledger at
+   `docs/features/epics/quickfiler-per-file-coverage/coverage-ledger.md`, with a machine-readable
+   sidecar at `coverage-ledger.json`, covering every file listed as `<Compile Include=...>` in
+   `QuickFiler/QuickFiler.csproj`.
+2. A recorded disposition for every existing `[ExcludeFromCodeCoverage]` attribute usage in the
+   compiled surface — either `ratified` with rationale, or `remove` naming the owning child.
+3. A repeatable per-file coverage report harness in PowerShell that consumes the existing Cobertura
+   output and exits non-zero when a `testable` file is below 80%.
+
+## Outcome of Promotion
+
+- GitHub issue: [#432](https://github.com/drmoisan/TaskMaster/issues/432)
+- Active feature folder: `docs/features/active/2026-08-07-quickfiler-coverage-ledger-432/`
+- Child branch: `feature/quickfiler-coverage-ledger`
+- Spawned tracking issue: [#441](https://github.com/drmoisan/TaskMaster/issues/441), a latent
+  repo-wide Cobertura `lines-valid` double-count defect surfaced during research and deliberately
+  scoped out of #432.

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-datamodel-coverage.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-datamodel-coverage.md
@@ -1,0 +1,52 @@
+# quickfiler-datamodel-coverage (Promoted)
+
+- Date captured: 2026-08-07
+- Date promoted: 2026-08-08
+- Author: Dan Moisan
+- Status: Promoted -> `docs/features/active/2026-08-07-quickfiler-datamodel-coverage-436/`
+- Issue: [#436](https://github.com/drmoisan/TaskMaster/issues/436)
+- Work Mode: full-feature
+- Parent epic issue: [#136](https://github.com/drmoisan/TaskMaster/issues/136)
+- Epic: `quickfiler-per-file-coverage` (child F5, wave 1)
+- Integration branch: `epic/quickfiler-per-file-coverage-integration`
+- Upstream dependency: F1 `quickfiler-coverage-denominator-and-exemption-ledger`
+
+> **Provenance note.** This document was recreated by the orchestrator after promotion. The
+> `mcp__drm-copilot__potential_to_issue` receipt reported this `destination_path`, but neither the
+> original potential entry nor the promoted copy persisted on disk. GitHub issue #436 was created
+> successfully and the active feature folder was populated, so promotion itself succeeded; only the
+> local markdown artifact was missing. It is restored here to keep the lifecycle audit trail intact.
+
+## Problem / Why
+
+Parent epic issue #136 requires every production `.cs` file compiled by `QuickFiler/QuickFiler.csproj`
+to reach at least 80% line coverage or to sit on an explicitly ratified exemption ledger. This child
+covers the QuickFiler data-model cluster: the `QfcDatamodel` partial-class family, the `EfcDataModel`
+class, and the `IQfcDatamodel` contract.
+
+## Scope (5 files, 1,283 lines)
+
+| File | Lines | `[ExcludeFromCodeCoverage]` |
+| --- | --- | --- |
+| `QuickFiler/Controllers/QfcDatamodel.cs` | 496 | yes (type-scoped) |
+| `QuickFiler/Controllers/QfcDatamodel.QueueProcessing.cs` | 177 | no |
+| `QuickFiler/Controllers/QfcDatamodel.FrameBuilding.cs` | 154 | no |
+| `QuickFiler/Controllers/EfcDataModel.cs` | 397 | no |
+| `QuickFiler/Interfaces/IQfcDatamodel.cs` | 59 | no |
+
+## Outcome of Preparation
+
+Preparation completed on 2026-08-08. Deliverables live in the active feature folder:
+
+- `issue.md`, `spec.md`, `user-story.md` (8 acceptance criteria, mirrored across both AC sources)
+- Five per-file research artifacts under `research/`, satisfying the issue #136 per-file mandate
+- `plan.2026-08-07T20-42.md` — 13 phases, 329 atomic tasks, 157 individual test-case tasks
+- Executor preflight: `PREFLIGHT: ALL CLEAR` after three iterations
+
+Atomic execution is deferred to `epic-orchestrator`.
+
+## Next Step
+
+- [x] Promote to GitHub issue (feature request template)
+- [x] Create the active feature folder from the template
+- [ ] Execute the atomic plan (deferred to `epic-orchestrator`)

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-efc-form-item-controller-coverage.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-efc-form-item-controller-coverage.md
@@ -1,0 +1,61 @@
+# quickfiler-efc-form-item-controller-coverage (Potential Feature)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> https://github.com/drmoisan/TaskMaster/issues/452
+- Work Mode: full-feature
+
+> Audit-trail note: this file was recreated after promotion. The MCP `potential_to_issue` operation
+> reported `destination_path` here and populated the active feature folder's `issue.md`, but the
+> potential document itself did not persist on disk. Recreated so the promotion chain is auditable.
+
+## Problem / Why
+
+Three of the four production files in the EFC form/item controller cluster carry a real
+`[ExcludeFromCodeCoverage]` attribute, which removes them from instrumentation entirely. They do not
+appear in any coverage report, so they are **unmeasured, not covered**:
+
+| File | Lines | Attribute |
+| --- | --- | --- |
+| `QuickFiler/Controllers/EfcItemController.cs` | 1,170 | Yes (`:25`) |
+| `QuickFiler/Controllers/EfcFormController.cs` | 1,086 | Yes (`:27`) |
+| `QuickFiler/Viewers/EfcViewer.cs` | 162 | Yes (`:20`) |
+| `QuickFiler/Viewers/EfcViewer.Designer.cs` | 4,277 | No (generated; suppressed via the partial type) |
+
+Both controllers also breach the repository 500-line file-size limit.
+
+## Proposed Behavior
+
+Extract injectable seams so the controllers' and viewer's logic is reachable by deterministic unit
+tests, split both oversized controllers into cohesive partials under 500 lines, remove the three
+exemption attributes, and bring every testable file to the epic's per-file coverage floors with
+numeric evidence. No observable QuickFiler behavior changes.
+
+## Acceptance Criteria (early draft)
+
+Superseded by AC1-AC11 in the active feature folder's `spec.md` and `user-story.md`.
+
+- [x] Per-file line coverage >= 80% and branch coverage >= 75%, verified with F1's harness
+- [x] `[ExcludeFromCodeCoverage]` removed from all three files, or an irreducible remainder ratified by F1's ledger
+- [x] No production file over 500 lines; new files reach >= 90% line coverage
+- [x] MSTest + Moq + FluentAssertions; deterministic, isolated, no temp files, no live forms, no popups
+- [x] Full C# toolchain green; repository-wide coverage retained or improved
+- [x] No behavior change to observable QuickFiler flows
+
+## Constraints & Risks
+
+- Epic child F9 (wave 1) of `quickfiler-per-file-coverage`; parent epic issue #136.
+- Depends on F1 `quickfiler-coverage-ledger` (issue #432) for the per-file harness and exemption ledger.
+- Sibling-owned files are off-limits: F8's `EfcHomeControllerDependencies.cs` and
+  `EfcHomeControllerDependencyFactories.cs`, F4's `EfcThemeHelper.cs` and `EfcViewerQueue.cs`,
+  F12's `BreadcrumbBridgeRouter.cs`, F5's `EfcDataModel.cs`.
+- `QuickFiler.csproj` and `QuickFiler.Test.csproj` are legacy non-SDK projects with explicit
+  `<Compile Include>` entries and CRLF line endings; new files require additive edits that will
+  conflict at fan-in.
+- Open issue #439 is a live behavior defect in these files that this feature must **not** fix.
+- Open issue #441 corrupts Cobertura per-file rate attributes and threatens the numeric evidence.
+
+## Next Step
+
+- [x] Promote to GitHub issue (feature request template) — issue #452
+- [x] Create `docs/features/active/2026-08-07-quickfiler-efc-form-item-controller-coverage-452/`

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-efc-home-controller-coverage.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-efc-home-controller-coverage.md
@@ -1,0 +1,66 @@
+# quickfiler-efc-home-controller-coverage (Potential — Promoted)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> [Issue #437](https://github.com/drmoisan/TaskMaster/issues/437)
+- Active folder: `docs/features/active/2026-08-07-quickfiler-efc-home-controller-coverage-437/`
+- Parent epic issue: [#136](https://github.com/drmoisan/TaskMaster/issues/136) — QuickFiler per-file 80% coverage
+- Epic manifest: `docs/features/epics/quickfiler-per-file-coverage/epic.md` (child F8, wave 1, band C3)
+- Integration branch: `epic/quickfiler-per-file-coverage-integration`
+- Depends on: F1 `quickfiler-coverage-denominator-and-exemption-ledger` (per-file coverage harness and ratified exemption ledger)
+
+> This file is an audit-trail reconstruction. `mcp__drm-copilot__potential_to_issue` reported
+> `destination_path` as `docs/features/potential/promoted/2026-08-07-quickfiler-efc-home-controller-coverage.md`
+> but did not leave the file on disk. The GitHub issue and the active feature folder are the
+> authoritative records; this file preserves the pre-promotion content.
+
+## Problem / Why
+
+Epic #136 requires every testable production file compiled by `QuickFiler/QuickFiler.csproj` to
+reach at least 80% line coverage, measured per file rather than per assembly. Child F8 owns the
+`EfcHomeController` partial-class family and its dependency-injection factories — six files
+totalling approximately 1,411 lines:
+
+| File | Lines |
+| --- | --- |
+| `QuickFiler/Controllers/EfcHomeController.cs` | 441 |
+| `QuickFiler/Controllers/EfcHomeControllerDependencies.cs` | 428 |
+| `QuickFiler/Controllers/EfcHomeControllerDependencyFactories.cs` | 268 |
+| `QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs` | 144 |
+| `QuickFiler/Controllers/EfcHomeController.Metrics.cs` | 87 |
+| `QuickFiler/Controllers/EfcHomeController.Timing.cs` | 43 |
+
+Existing test files cover parts of this surface, but `EfcHomeControllerDependencyFactories.cs` has
+no dedicated test file and the actual per-file line coverage of each of the six files is unmeasured.
+Aggregate assembly coverage does not satisfy issue #136.
+
+## Proposed Behavior
+
+No change to observable QuickFiler behavior. Add deterministic MSTest coverage — and, only where a
+seam is genuinely required to reach otherwise-unreachable logic, add an additive injectable seam —
+so that every file classified `testable` by F1's ledger reaches at least 80% line coverage,
+verified with F1's per-file coverage harness and recorded as numeric evidence.
+
+## Acceptance Criteria (early draft)
+
+The authoritative acceptance criteria live in
+`docs/features/active/2026-08-07-quickfiler-efc-home-controller-coverage-437/spec.md` and
+`user-story.md` (work mode `full-feature`). The early draft is preserved in `issue.md` of the same
+folder.
+
+## Constraints & Risks
+
+- `EfcHomeControllerDependencies` and `EfcHomeControllerDependencyFactories` form the injection-seam
+  contract for the whole EFC controller family, including `EfcFormController` and
+  `EfcItemController`, which belong to sibling child F9. Any change to the dependency contract must
+  be additive so F9 needs no edit.
+- `ExecuteMoves` performs Outlook `MailItem`/`MAPIFolder` moves and must be exercised only through
+  an injected move seam.
+- `EfcHomeController.Timing.cs` requires an injected clock; `Thread.Sleep`, `Task.Delay`, and real
+  wall-clock waits are prohibited in tests.
+- This child must not modify `coverage.config` or any shared build property file.
+
+## Next Step
+
+- [x] Promote to GitHub issue (feature request template) — Issue #437
+- [x] Create the active feature folder from the template

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-explorer-controller-latent-defects.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-explorer-controller-latent-defects.md
@@ -1,0 +1,94 @@
+# quickfiler-explorer-controller-latent-defects (Issue #449)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/quickfiler-explorer-controller-latent-defects/ (Issue #449)
+- Found during: research for issue #435 (child F6 of epic #136, QuickFiler per-file coverage)
+
+- Issue: #449
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/449
+- Last Updated: 2026-08-08
+## Summary
+
+Two independent latent defects in `QuickFiler/Controllers/QfcExplorerController.cs`, plus a block of
+dead duplicated code. All three were found by reading during F6 coverage research and none is fixed by
+F6, whose acceptance criteria forbid behavior changes.
+
+## Defect 1 — `ExplConvView_Cleanup()` throws `NotImplementedException`
+
+`ExplConvView_Cleanup()` is declared on the public interface `IQfcExplorerController`
+(`QuickFiler/Interfaces/IQfcExplorerController.cs:12`) but its implementation throws
+`NotImplementedException`. Any caller reaching it fails at runtime rather than degrading.
+
+The intended semantics appear to be recoverable from the legacy implementation at
+`QuickFiler/Legacy/QuickFileController.cs:851-869` (not compiled), which should be read before
+implementing rather than reinventing the behavior.
+
+Mitigating factor: the member currently has no production callers, so the throw is not reachable in
+normal operation today. That makes it latent rather than active — but it is a live trap for the next
+caller.
+
+## Defect 2 — `OpenQFItem` re-resolves the active explorer
+
+`OpenQFItem` calls `_globals.Ol.App.ActiveExplorer()` a second time at
+`QuickFiler/Controllers/QfcExplorerController.cs:140` instead of reusing the `_activeExplorer` field
+captured in the constructor at line 35.
+
+This is both a redundant COM round-trip and a correctness hazard: if the active explorer changed
+between construction and the call, the method operates on a different `Explorer` than the rest of the
+type, so the object's view of "the" explorer becomes internally inconsistent.
+
+## Defect 3 — dead duplicated code block
+
+`QuickFiler/Controllers/QfcExplorerController.cs:183-321` (the `#region Email Sorting To Rewrite`)
+contains six private/internal statics — `SanitizeArrayLineTSV`, `StripTabsCrLf`,
+`WriteCSV_StartNewFileIfDoesNotExist`, `SanitizeArray`, `SaveMessageAsMSG`,
+`GetCurrentExplorerFolder`. A repo-wide search confirms they are referenced only from inside that same
+region (lines 193, 241, 264). Every external caller binds to separate copies in
+`UtilitiesCS/EmailIntelligence/EmailParsingSorting/SortEmail.cs`,
+`UtilitiesCS/EmailIntelligence/EmailParsingSorting/EmailFiler.cs`, and
+`ToDoModel/Email Utilities/SortItemsToExistingFolder.cs`, which carry their own tests in
+`UtilitiesCS.Test`.
+
+Two latent defects were additionally observed inside this dead block:
+- `WriteCSV_StartNewFileIfDoesNotExist` passes transposed arguments to `Path.Combine`.
+- `SanitizeArray` writes into a `null` `ref string[]`, which would throw if ever reached.
+
+Because the block is unreachable, neither defect can fire today. Deleting the region is
+behavior-neutral for the QuickFiler assembly and removes roughly 139 lines of uncoverable
+filesystem-I/O code from the coverage denominator.
+
+## Why This Is Filed Separately
+
+All three items were found during read-only research for the F6 coverage child (issue #435). F6's
+acceptance criteria require no behavior change to observable QuickFiler flows, and fixing a
+`NotImplementedException` or changing which `Explorer` instance is used are both behavior changes.
+Recording them only as prose inside a feature folder would lose them at merge.
+
+## Impact
+
+- Defect 1: runtime failure for the next caller of a public interface member.
+- Defect 2: redundant COM call plus a potential inconsistency window.
+- Defect 3: no runtime impact; carrying cost is coverage-denominator pollution and duplicated code
+  that can drift from the maintained copies in `UtilitiesCS`.
+
+## Acceptance Criteria (early draft)
+
+- [ ] `ExplConvView_Cleanup()` either implements the legacy semantics from
+      `QuickFiler/Legacy/QuickFileController.cs:851-869` or is removed from `IQfcExplorerController`
+      with all implementers updated; the decision is recorded with rationale.
+- [ ] `OpenQFItem` reuses the constructor-captured `_activeExplorer` field, or the reason a fresh
+      `ActiveExplorer()` call is required is documented in code.
+- [ ] The dead `#region Email Sorting To Rewrite` block is deleted, with a test run confirming no
+      behavior change.
+- [ ] Deterministic regression tests cover each changed path; no temporary files, no live forms.
+- [ ] Full C# toolchain passes: csharpier, analyzer build, nullable build, coverage-enabled vstest.
+
+## Coordination Note
+
+The dead-code deletion overlaps the file F6 is actively covering. Sequence this issue AFTER F6 merges,
+or coordinate through the epic, to avoid a conflict on `QfcExplorerController.cs`.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug template)

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-formcontroller-tests-file-size-split.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-formcontroller-tests-file-size-split.md
@@ -1,0 +1,80 @@
+# quickfiler-formcontroller-tests-file-size-split (Issue #450)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/quickfiler-formcontroller-tests-file-size-split/ (Issue #450)
+- Found during: research for issue #435 (child F6 of epic #136, QuickFiler per-file coverage)
+
+- Issue: #450
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/450
+- Last Updated: 2026-08-08
+## Problem / Why
+
+`QuickFiler.Test/Controllers/QfcFormControllerTests.cs` is **827 lines** across 42 test methods. The
+repository file-size limit is 500 lines and it explicitly covers test code:
+
+> `.claude/rules/general-code-change.md`, "File Size Limit": *No production code, test code, or
+> reusable script file may exceed 500 lines.* The listed exceptions are throwaway agent-session
+> scripts, raw text fixtures for language-processing test data, and Markdown documentation. A
+> long-lived MSTest fixture is none of those.
+
+This is a pre-existing violation, not one introduced by any current work.
+
+## Why It Is Filed Separately Rather Than Fixed In F6
+
+Child F6 of epic #136 adds a substantial number of new test cases for the `QfcFormController` partial
+family. Two options were considered during F6 research:
+
+1. **Split inside F6.** Rejected. F6's plan runs one phase per production file, and the four
+   `QfcFormController.*` partials are covered by four separate phases. Splitting the shared 827-line
+   fixture would require all four phases to edit the same file, serialising work that is otherwise
+   independent and creating a high-conflict hotspot inside a single child.
+2. **Add new files, leave the existing one alone.** Selected. F6 creates new disjoint test files and
+   does not append to `QfcFormControllerTests.cs`, so F6 neither worsens nor repairs the violation.
+
+Filing this separately keeps the known violation visible instead of letting it disappear when the F6
+feature folder merges.
+
+## Proposed Behavior
+
+Split `QfcFormControllerTests.cs` into files under 500 lines each, grouped by the production partial
+they exercise, mirroring the production tree per `.claude/rules/general-unit-test.md` ("Test File
+Location"). Move tests only — do not rewrite assertions, rename tests, or change coverage.
+
+## Constraints & Risks
+
+- **Sequence after epic #136 wave 1.** Children F6 and F7 both touch `QfcFormController` /
+  `QfcHomeController` test territory. Running this split concurrently would conflict.
+- **Behavior-neutral.** The same set of test methods must exist before and after, and the pass count
+  must be identical. This is a pure move.
+- `QuickFiler.Test/QuickFiler.Test.csproj` is a non-SDK project with an explicit `<Compile Include>`
+  list, so every new file needs an entry.
+- Watch for shared private helpers and `[TestInitialize]` setup in the current fixture; they must move
+  to a shared `TestSupport` partial rather than being duplicated per split file.
+
+## Related Prior Art
+
+`QuickFiler.Test/Controllers/` already contains split fixtures following this pattern, for example
+`QfcStreamingDequeueConfidenceGateTests.cs` with `.Part2.cs` and `.Part3.cs`, and the
+`QfcItemController.*Tests.cs` family split by production partial. Prefer the
+`QfcItemController.*Tests.cs` style (split by production partial, descriptive suffix) over the
+`.Part2/.Part3` style (split by arbitrary overflow).
+
+## Acceptance Criteria (early draft)
+
+- [ ] No file under `QuickFiler.Test/Controllers/` matching `QfcFormController*Tests.cs` exceeds 500 lines.
+- [ ] The set of test method names is identical before and after the split.
+- [ ] The test pass count is identical before and after the split.
+- [ ] Shared setup and private helpers live in one shared partial, not duplicated across split files.
+- [ ] `QuickFiler.Test.csproj` has a `<Compile Include>` entry for every new file.
+- [ ] Full C# toolchain passes: csharpier, analyzer build, nullable build, coverage-enabled vstest.
+
+## Test Conditions to Consider
+
+- [ ] Before/after test-name inventory diff is empty.
+- [ ] Before/after pass-count comparison is equal.
+- [ ] No coverage regression on `QfcFormController.*` production files.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (feature request template)

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-item-controller-coverage.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-item-controller-coverage.md
@@ -1,0 +1,73 @@
+# quickfiler-item-controller-coverage (Potential)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> Issue #453, active folder
+  `docs/features/active/2026-08-07-quickfiler-item-controller-coverage-453/`
+- Parent epic: #136 (QuickFiler Per-File 80% Coverage)
+- Epic child: F10 (wave 1, complexity band C3)
+- Integration branch: `epic/quickfiler-per-file-coverage-integration`
+
+> Audit-trail note: this file was recreated by the orchestrator after promotion. The MCP
+> `potential_to_issue` tool reported a `destination_path` under `potential/promoted/` but did not
+> leave the file on disk for this feature entry (the six sibling bug promotions in the same run did
+> persist). Content below is the promoted source text as submitted.
+
+## Problem / Why
+
+Epic #136 requires every production `.cs` file compiled by `QuickFiler/QuickFiler.csproj` to reach
+at least 80% line coverage and 75% branch coverage, or to sit on an explicitly ratified exemption
+ledger. The `QfcItemController` partial-class family is one of the largest single clusters in that
+denominator: 10 production partials plus one interface file, 3,180 lines in total.
+
+The family is already substantially tested — 17 existing test files with 166 test methods exist
+under `QuickFiler.Test/Controllers/` — so this is a **gap-closure and exemption-removal** exercise
+rather than a build-from-zero effort.
+
+## Proposed Behavior
+
+Raise every `testable` file in the `QfcItemController` family to at least 80% line and 75% branch
+coverage, verified with the per-file coverage harness delivered by epic child F1 (#432), and reduce
+the `[ExcludeFromCodeCoverage]` boundary where reduction is legitimately available.
+
+No observable behavior change to QuickFiler flows. Testability refactors follow the epic's seam
+hierarchy: interface seam, then injectable delegate, then adapter.
+
+## Acceptance Criteria (early draft)
+
+Superseded by `spec.md` AC-1..AC-21 and `user-story.md` US-1..US-14 in the active feature folder,
+which are the authoritative acceptance-criteria sources for `full-feature` work mode.
+
+- [ ] Every `testable` file in scope reaches >= 80% line and >= 75% branch coverage.
+- [ ] The `[ExcludeFromCodeCoverage]` boundary is reduced where legitimately available and every
+      retained attribute is justified against a recorded authority.
+- [ ] No production file in scope exceeds 500 lines; any newly created file reaches >= 90% line
+      coverage.
+- [ ] Tests use MSTest, Moq, and FluentAssertions; deterministic, isolated, no temporary files,
+      no external services, no live forms, no popups.
+- [ ] Full C# toolchain green in final form; repository-wide coverage retained or improved.
+- [ ] No behavior change to observable QuickFiler flows.
+
+## Constraints & Risks
+
+- **One partial-class family.** All 10 partials declare the same type, deliberately kept in a single
+  epic child so no two children share a type or a test fixture.
+- **A maintainer-ratified exemption boundary already exists.** Preparation research established that
+  18 of the family's 19 attributes were ratified under issue #227 on 2026-07-02 after five
+  remediation cycles reduced the boundary from 103 members to 19. Nine of those are blocked by an
+  unbuilt WinForms message-pump test seam tracked as open issue #230, explicitly deferred and
+  explicitly not a merge condition. The realistic outcome is 19 -> 15, not 19 -> 0.
+- **Sibling boundaries.** `ConversationResolver` belongs to F4 (#434) and is invoked positionally.
+  `KeyboardHandler.cs` belongs to F3 (#430). `QfcCollectionController.cs` belongs to F11 (#454).
+  Required upstream changes are cross-child contract notes, not sibling edits.
+- **State-transition invariants.** Event wiring, navigation, and initialization carry ordering,
+  re-entrancy, and dispose-before-setup invariants.
+- **Determinism.** Injected clock and fake timers only.
+- **Upstream dependency.** F1 (#432) delivers the per-file coverage harness and the exemption ledger.
+  A Phase 0 execution-time halt gate covers both.
+- **Branch coverage is the binding gate**, not line coverage — it fails on seven of ten files.
+
+## Next Step
+
+- [x] Promote to GitHub issue (feature request template) — Issue #453
+- [x] Create the active feature folder from the template

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-itemviewer-coverage.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-itemviewer-coverage.md
@@ -1,0 +1,63 @@
+# quickfiler-itemviewer-coverage (Potential — Promoted)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> https://github.com/drmoisan/TaskMaster/issues/456
+- Active folder: `docs/features/active/2026-08-07-quickfiler-itemviewer-coverage-456/`
+- Parent epic issue: #136 (QuickFiler Per-File 80% Coverage)
+- Epic child: F14 of `quickfiler-per-file-coverage`
+- Depends on: F1 `quickfiler-coverage-ledger` (issue #432, wave 0)
+
+> Reconstructed for the audit trail. The MCP `potential_to_issue` receipt reported this
+> `destination_path`, but the file was not present on disk afterward. The issue and the active
+> feature folder were both created successfully.
+
+## Problem / Why
+
+The `ItemViewer` form family under `QuickFiler/Viewers/` is entirely invisible to coverage
+measurement. `ItemViewer` is a partial type spread across six hand-written source files plus a
+6,224-line generated designer file, and the single `[ExcludeFromCodeCoverage]` attribute on
+`ItemViewer.cs:20` suppresses instrumentation for the whole type. The only member of the family that
+is measured, `ItemViewerExpanded.cs`, sits at 37.74% line and 8.33% branch coverage — below both the
+80% line and 75% branch gates that issue #136 and `.claude/rules/general-unit-test.md` set.
+
+Under the epic's ratified policy reconciliation, `[ExcludeFromCodeCoverage]` on a testable seam is a
+Blocking finding. The attribute on `ItemViewer.cs` has never been argued against the
+irreducible-remainder standard, so the family is unratified exempt rather than legitimately exempt.
+
+## Proposed Behavior
+
+Bring every `testable` file in the `ItemViewer` family to at least 80% line and 75% branch coverage,
+verified with F1's per-file harness, by extracting host-neutral seams from the `UserControl`-derived
+partials and removing the type-level `[ExcludeFromCodeCoverage]` attribute. Classify `IItemViewer.cs`
+as `interface-only / not-measured`. No observable behavior change to QuickFiler flows.
+
+## Acceptance Criteria (early draft)
+
+Superseded by the twelve acceptance criteria in
+`docs/features/active/2026-08-07-quickfiler-itemviewer-coverage-456/spec.md`.
+
+- [ ] Every `testable` file in the family reaches >= 80% line and >= 75% branch coverage.
+- [ ] The `[ExcludeFromCodeCoverage]` attribute on `ItemViewer.cs` is removed, or an irreducible
+      remainder is ratified in F1's ledger with a file-specific rationale.
+- [ ] `IItemViewer.cs` is reported N/A as `interface-only / not-measured`, with no attribute added.
+- [ ] The two `*.Designer.cs` files are classified per the ledger's generated-code rules.
+- [ ] No production file in scope exceeds 500 lines; created files reach >= 90% line coverage.
+- [ ] Full C# toolchain green; repository-wide coverage retained or improved.
+
+## Constraints & Risks
+
+- `ItemViewer` derives from `UserControl`, not `Form`. Research established that no STA test file is
+  required: ten existing plain `[TestMethod]`s already construct a live headless `ItemViewer`.
+- A partial type may carry `[ExcludeFromCodeCoverage]` on only one part; annotating two parts is
+  CS0579. The designer partial therefore cannot be exempted independently of the hand-written
+  partials once the attribute is removed.
+- Sibling boundaries: drop-down/WebView2 host files belong to F13, breadcrumb bridge and messenger
+  files to F12, `QfcItemController.*` to F10, `ToolStripMenuItemCb.cs` to F15.
+- `UtilitiesCS` grants no `InternalsVisibleTo` to `QuickFiler.Test`; `QuickFiler` does, so seams may
+  be `internal`.
+
+## Next Step
+
+- [x] Promote to GitHub issue (feature request template) — issue #456
+- [x] Create `docs/features/active/2026-08-07-quickfiler-itemviewer-coverage-456/` from the template

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-keyboard-action-contract-defects.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-keyboard-action-contract-defects.md
@@ -1,0 +1,135 @@
+# quickfiler-keyboard-action-contract-defects (Issue #445)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/quickfiler-keyboard-action-contract-defects/ (Issue #445)
+- Discovered during: research for issue #430 (`quickfiler-keyboard-actions-coverage`, child F3 of epic #136)
+
+- Issue: #445
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/445
+- Last Updated: 2026-08-08
+## Summary
+
+Three related contract defects in the QuickFiler keyboard-action types. All three were verified by
+direct file read at `origin/epic/quickfiler-per-file-coverage-integration` (base commit `56ca1cea`).
+None is fixed by issue #430, which carries a no-behavior-change acceptance criterion and characterizes
+current behavior in tests instead.
+
+## Defect 1 — `KaStringAsync.KeyEquals` applies the `Activated` gate inconsistently
+
+`KeyEquals` guards its `Update` invocation with `Activated` in two of three branches but not the third:
+
+```csharp
+// QuickFiler/Controllers/KaStringAsync.cs:57-78
+public bool KeyEquals(string other)
+{
+    if (Key.Contains(other))
+    {
+        if (Activated && Update is not null)          // gated
+            Update(Key.Substring(other.Length - 1, 1));
+        return true;
+    }
+    else if (other.Length == 1)
+    {
+        if (Activated && ToggleControl is not null)   // gated
+            ToggleControl();
+    }
+    else if (other.Length > 1)
+    {
+        if (Update is not null)                       // NOT gated
+            Update(Key.Substring(0, 1));
+        if (Activated && ToggleControl is not null)
+            ToggleControl();
+    }
+    Activated = false;
+    return false;
+}
+```
+
+The `other.Length > 1` branch invokes `Update` regardless of `Activated`. Whether this is intentional
+or an omission is not determinable from the code; there is no comment explaining it. This is the
+highest-value untested behavior in the cluster.
+
+## Defect 2 — `KeyEquals("")` throws `ArgumentOutOfRangeException`
+
+`Key.Contains("")` is `true` for every string, so an empty `other` enters the first branch and
+evaluates `Key.Substring(other.Length - 1, 1)` — that is, `Substring(-1, 1)` — which throws
+`ArgumentOutOfRangeException` (`KaStringAsync.cs:62`).
+
+This is currently double-shielded and is therefore a robustness gap rather than a live crash:
+`KeyboardHandler` only ever probes with length `>= 1`, and production supplies a null `Update`, so the
+guarded call is not reached. Both shields are incidental, not contractual.
+
+## Defect 3 — `KaChar.DelegateType` reports the wrong type
+
+```csharp
+// QuickFiler/Controllers/KaChar.cs:11
+public class KaChar : IKbdAction<char, Action<char>>
+// QuickFiler/Controllers/KaChar.cs:37
+public Action<char> Delegate
+// QuickFiler/Controllers/KaChar.cs:43-46
+public Type DelegateType
+{
+    get => typeof(Action<Keys>);
+}
+```
+
+`KaChar` stores an `Action<char>` but `DelegateType` reports `typeof(Action<Keys>)`. Impact today is
+nil because no consumer reads `DelegateType`.
+
+## Related — `Update` and `DelegateType` are orphaned public API
+
+`Update` and `DelegateType` appear on four implementer types but on no interface. The corresponding
+contract members are commented out:
+
+```csharp
+// QuickFiler/Interfaces/IKbdAction.cs:12-16
+T Key { get; set; }
+U Delegate { get; set; }
+bool KeyEquals(T other);
+//Action<string> Update { get; set; }
+//Type DelegateType { get; }
+```
+
+Restoring `DelegateType` to the interface **will not compile**: `KaCharAsync` (`KaChar.cs:58`) and
+`KaKeyAsync` do not declare it. The viable cleanup direction is therefore removal from the implementers
+rather than restoration to the interface. Defect 3 disappears if `DelegateType` is removed.
+
+## Impact
+
+No confirmed user-visible failure. Defects 2 and 3 are latent. Defect 1 is a genuine behavioral
+ambiguity that will become load-bearing the moment `Update` is non-null on a multi-character probe.
+All three are the kind of contract inconsistency that makes the surrounding code unsafe to refactor.
+
+## Why these were not fixed in issue #430
+
+Issue #430 (child F3) carries an explicit acceptance criterion of **no behavior change to observable
+QuickFiler keyboard flows**. Each of these fixes is a behavior change. F3's new tests characterize the
+current behavior, including the ungated `Update` call and the empty-string throw, so that a later fix
+has a red-before-green baseline to work against.
+
+## Proposed Fix Direction
+
+1. Decide whether the `other.Length > 1` branch should be `Activated`-gated, and make all three
+   branches consistent with the decision.
+2. Add an explicit guard or documented contract for empty `other` in `KeyEquals`.
+3. Remove `DelegateType` from `KaChar`, `KaKey`, and any sibling implementer, or correct it to
+   `typeof(Action<char>)` if a consumer is introduced. Remove the commented-out members from
+   `IKbdAction.cs` or restore them deliberately with all implementers updated.
+
+## Acceptance Criteria (early draft)
+
+- [ ] The `Activated`-gating contract for `KaStringAsync.KeyEquals` is decided, applied consistently
+      across all three branches, and documented in-code.
+- [ ] `KeyEquals` handles an empty `other` without throwing `ArgumentOutOfRangeException`, or rejects it
+      with an explicit, documented argument exception.
+- [ ] `DelegateType` is either removed from all implementers or reports the actual stored delegate type.
+- [ ] The commented-out members in `IKbdAction.cs` are resolved (removed or restored with all
+      implementers updated).
+- [ ] Regression tests cover each changed behavior, replacing the characterization tests added by #430.
+- [ ] Full C# toolchain passes: csharpier, analyzer build, nullable build, coverage-enabled vstest.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug template)
+- [ ] Sequence after epic #136 child F3 (#430) merges, so the characterization tests exist first

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-keyboard-actions-coverage.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-keyboard-actions-coverage.md
@@ -1,0 +1,91 @@
+# quickfiler-keyboard-actions-coverage (Potential — Promoted)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> `docs/features/active/2026-08-07-quickfiler-keyboard-actions-coverage-430/` (Issue #430)
+- Issue: [#430](https://github.com/drmoisan/TaskMaster/issues/430)
+- Work Mode: full-feature
+- Parent epic issue: [#136](https://github.com/drmoisan/TaskMaster/issues/136)
+- Epic: `quickfiler-per-file-coverage` (child F3, wave 1)
+- Epic manifest: `docs/features/epics/quickfiler-per-file-coverage/epic.md`
+- Integration branch: `epic/quickfiler-per-file-coverage-integration`
+- Depends on: F1 `quickfiler-coverage-denominator-and-exemption-ledger` (wave 0)
+
+## Problem / Why
+
+Epic #136 requires every production `.cs` file compiled by `QuickFiler/QuickFiler.csproj` to reach at
+least 80% line coverage or to sit on an explicitly ratified exemption ledger. This child owns the
+QuickFiler keyboard-handling and mail-item-action cluster: 11 compiled files totalling roughly 1,025
+lines.
+
+The cluster's central file, `QuickFiler/Controllers/KeyboardHandler.cs` (414 lines), currently carries
+`[ExcludeFromCodeCoverage]` and has no tests at all. Per the epic's ratified policy reconciliation
+(Shared Design section 1), the CLAUDE.md COM/VSTO exemption qualifier "without an injectable seam" is
+a live obligation rather than a standing permission: an `[ExcludeFromCodeCoverage]` attribute on a
+*testable* seam is a Blocking finding. `KeyboardHandler.cs` must therefore be refactored behind seams
+and covered, unless F1's ledger ratifies a specific irreducible remainder.
+
+Separately, `.claude/rules/csharp.md` and `CLAUDE.md` § UT2 name `KbdActions<>` explicitly as a
+testable seam within an otherwise COM-bound assembly that is **not** exempt and must meet the coverage
+floor.
+
+## Proposed Behavior
+
+- Establish actual current per-file line coverage for all 11 in-scope files using F1's per-file
+  coverage harness, and target the genuine gaps rather than duplicating the existing test files
+  (`KaCharTests.cs`, `KaKeyTests.cs`, `KaStringAsyncTests.cs`, `KbdActionsTests.cs`,
+  `KbdActionsRemainingBranchesTests.cs`, `QfcFormKeyHandlerTests.cs`, `MailItemActionsAdapterTests.cs`).
+- Extract seams from `KeyboardHandler.cs` following the epic seam hierarchy (interface seam, then
+  injectable delegate, then adapter) so its `[ExcludeFromCodeCoverage]` attribute can be removed and
+  the file can reach the floor.
+- Add MSTest/Moq/FluentAssertions unit tests in `QuickFiler.Test/`, mirroring the production tree,
+  covering positive path plus invalid-input, boundary, and error-handling behavior per file.
+- Record numeric per-file coverage evidence under the feature's `evidence/qa-gates/` folder.
+
+## Acceptance Criteria (early draft — superseded by `spec.md` and `user-story.md`)
+
+- [ ] Every `testable` file in the F3 assignment reaches at least 80% line coverage, verified with
+      F1's per-file harness and recorded as numeric evidence under `<FEATURE>/evidence/qa-gates/`.
+- [ ] `KeyboardHandler.cs` has its `[ExcludeFromCodeCoverage]` removed and reaches the floor via seam
+      extraction, unless F1's ledger ratifies a specific irreducible remainder.
+- [ ] No production file in scope exceeds 500 lines.
+- [ ] Tests use MSTest, Moq, and FluentAssertions; they are deterministic, isolated, and use no
+      temporary files, external services, or live forms.
+- [ ] Coverage per file spans the positive path plus invalid-input, boundary, and error-handling
+      behavior.
+- [ ] The full C# toolchain passes in final form: csharpier, analyzer build, nullable build,
+      coverage-enabled vstest.
+- [ ] No behavior change to observable QuickFiler keyboard flows.
+
+## Constraints & Risks
+
+- **Cross-child contract risk.** `KeyboardHandler.cs` seam extraction changes an internal contract
+  consumed by the QuickFiler form and item controllers, which are owned by sibling children F6
+  (`quickfiler-qfc-form-explorer-controller-coverage`) and F10
+  (`quickfiler-item-controller-coverage`). The change must remain additive: introduce seams without
+  altering the public call shape those controllers use. An unavoidable breaking change must be
+  recorded in `spec.md` as a cross-child contract note rather than resolved by editing sibling files.
+- **Event-driven surface.** Keyboard handling is event-driven. Tests must never construct live forms,
+  never show popups, and never depend on the UI thread.
+- **Determinism.** `Thread.Sleep`, `Task.Delay`, and real wall-clock waits are prohibited in tests;
+  `KaStringAsync` requires a fake-timer or injected-clock approach.
+- **Shared-file isolation.** This child must not modify `coverage.config` or any shared build property
+  file; those are owned by F1 and the epic root.
+- **Upstream dependency.** F1's ledger is the sole authority on whether any in-scope file is
+  `ratified-exempt`, and F1's harness is the per-file coverage evidence mechanism. F1 merges to the
+  integration branch before this child executes.
+
+## Test Conditions to Consider
+
+- [ ] Unit coverage areas: `KeyboardHandler` seam behavior, `KbdActions<>` dispatch/registration,
+      `KaChar` / `KaKey` / `KaStringAsync` action implementations, `QfcFormKeyHandler` routing,
+      `MailItemActionsAdapter` delegation.
+- [ ] Invalid-input and boundary scenarios per file (null/empty keys, unregistered actions,
+      out-of-range modifiers).
+- [ ] Error-handling behavior for action invocation failures.
+- [ ] Async ordering behavior for `KaStringAsync` under an injected clock / fake timer.
+
+## Next Step
+
+- [x] Promote to GitHub issue (feature request template) — issue #430
+- [x] Create `docs/features/active/2026-08-07-quickfiler-keyboard-actions-coverage-430/` folder from the template

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-qfc-form-explorer-controller-coverage.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-qfc-form-explorer-controller-coverage.md
@@ -1,0 +1,80 @@
+# quickfiler-qfc-form-explorer-controller-coverage (Potential — Promoted)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted to issue #435 on 2026-08-07
+- Issue: https://github.com/drmoisan/TaskMaster/issues/435
+- Active folder: `docs/features/active/2026-08-07-quickfiler-qfc-form-explorer-controller-coverage-435/`
+- Parent epic issue: #136 (QuickFiler per-file 80% coverage)
+- Epic manifest: `docs/features/epics/quickfiler-per-file-coverage/epic.md` (child F6, wave 1, band C3)
+- Integration branch: `epic/quickfiler-per-file-coverage-integration`
+
+> Recreated for the audit trail. The `potential_to_issue` MCP tool reported this destination path in its
+> receipt and populated the active folder's `issue.md`, but did not leave the promoted markdown on disk.
+> The promotion itself succeeded — issue #435 exists and the active folder was created from it.
+
+## Problem / Why
+
+Child F6 of epic #136 owns the `QfcFormController` partial-class family plus `QfcExplorerController`
+and their interface declarations — 10 compiled files, approximately 1,611 lines in
+`QuickFiler/QuickFiler.csproj`. Today this cluster does not meet the per-file 80% line-coverage floor
+mandated by issue #136:
+
+- `QuickFiler/Controllers/QfcExplorerController.cs` (323 lines) carries `[ExcludeFromCodeCoverage]`
+  and has no tests at all. Per the epic's Shared Design section 1, that attribute is treated as
+  unratified: the CLAUDE.md COM/VSTO exemption qualifier "without an injectable seam" is a live
+  obligation, not standing permission, so the attribute must be removed and the file covered through
+  seam extraction unless F1's ledger ratifies a specific irreducible remainder.
+- The four `QfcFormController.*` partials (196 + 399 + 302 + 232 lines) have partial coverage from
+  `QuickFiler.Test/Controllers/QfcFormControllerTests.cs` and `QfcFormControllerSeamTests.cs`, but
+  the event-handler and setup/disposal paths cross the form/viewer boundary and are the least
+  reachable.
+- Actual current per-file coverage for each of the ten files is unmeasured; the epic mandates
+  numeric per-file evidence rather than aggregate assembly coverage.
+
+Two distinct files are both named `IQfcFormController.cs` — one under `Controllers/`, one under
+`Interfaces/`. The duplication is unexplained and needs a recorded determination.
+
+## Proposed Behavior
+
+Raise every `testable` file in the F6 set to at least 80% line coverage, verified with F1's per-file
+coverage harness and recorded as numeric evidence, without changing observable QuickFiler behavior.
+Where a path is unreachable from a deterministic unit test, introduce a seam (interface seam first,
+then injectable delegate, then adapter) rather than exempting the file.
+
+## Acceptance Criteria (early draft)
+
+Superseded by `AC-1` through `AC-7` in the active folder's `spec.md` and `US-1` through `US-7` in
+`user-story.md`, which are the authoritative sources under Work Mode `full-feature`.
+
+- [ ] Every `testable` file in the F6 set reaches >= 80% line coverage, verified with F1's per-file
+      harness and recorded as numeric evidence under `<FEATURE>/evidence/qa-gates/`.
+- [ ] `QfcExplorerController.cs` has `[ExcludeFromCodeCoverage]` removed and reaches the floor via
+      seam extraction, unless F1's ledger ratifies a specific irreducible remainder.
+- [ ] No production file in scope exceeds 500 lines.
+- [ ] Tests use MSTest, Moq, and FluentAssertions; deterministic, isolated, no temporary files, no
+      external services, no live forms.
+- [ ] Coverage per file spans positive path plus invalid-input, boundary, and error-handling
+      behavior.
+- [ ] The full C# toolchain passes: csharpier, analyzer build, nullable build, coverage-enabled
+      vstest.
+- [ ] No behavior change to observable QuickFiler flows.
+
+## Outcome of Preparation
+
+Research surfaced three latent defects and one pre-existing policy violation, each promoted to its
+own issue rather than left as prose that would disappear when this feature folder merges:
+
+- **#448** — `QfcFormController.UndoConsumer()` never terminates (`Actions.cs:258`).
+- **#449** — `QfcExplorerController` latent defects: `ExplConvView_Cleanup` throws
+  `NotImplementedException` on a public interface member; `OpenQFItem` re-resolves the active
+  explorer; and a dead 139-line region duplicates code maintained in `UtilitiesCS`/`ToDoModel`.
+- **#450** — `QuickFiler.Test/Controllers/QfcFormControllerTests.cs` is 827 lines against the
+  repository's 500-line limit.
+
+## Next Step
+
+- [x] Promote to GitHub issue (feature request template) — issue #435
+- [x] Create `docs/features/active/2026-08-07-quickfiler-qfc-form-explorer-controller-coverage-435/`
+- [x] Research, feature documents, atomic plan, and preflight clearance complete
+- [ ] Atomic execution — deferred to `epic-orchestrator`

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-qfc-home-controller-coverage.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-qfc-home-controller-coverage.md
@@ -1,0 +1,64 @@
+# quickfiler-qfc-home-controller-coverage
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/2026-08-07-quickfiler-qfc-home-controller-coverage-433/ (Issue #433)
+- Parent epic issue: #136 (https://github.com/drmoisan/TaskMaster/issues/136)
+- Parent epic manifest: docs/features/epics/quickfiler-per-file-coverage/epic.md (child F7, wave 1)
+
+## Problem / Why
+
+Epic #136 requires every testable production file compiled by `QuickFiler/QuickFiler.csproj` to reach
+at least 80% line coverage measured **per production file**, or to be placed on the ratified exemption
+ledger delivered by child F1. Child F7 owns the `QfcHomeController` partial family plus its two
+interface declarations:
+
+- `QuickFiler/Controllers/QfcHomeController.cs` (487 lines)
+- `QuickFiler/Controllers/QfcHomeController.Metrics.cs` (234 lines)
+- `QuickFiler/Controllers/QfcHomeController.Iteration.cs` (86 lines)
+- `QuickFiler/Controllers/IQfcHomeController.cs` (20 lines)
+- `QuickFiler/Interfaces/IFilerHomeController.cs` (45 lines)
+
+This type already carries the densest existing test suite in `QuickFiler.Test`. The work is therefore
+expected to be gap-closing against an existing suite rather than a from-scratch coverage effort, and
+duplicating an existing test is a defect.
+
+## Proposed Behavior
+
+No behavior change to observable QuickFiler flows. The deliverable is per-file coverage evidence plus
+the minimum set of new deterministic MSTest tests (and, only where no seam exists, the minimum
+testability seam) required to bring each `testable` file in the list to >= 80% line coverage as
+measured by child F1's per-file coverage harness.
+
+## Acceptance Criteria (early draft)
+
+- [ ] Each file classified `testable` by the F1 ledger reaches >= 80% line coverage under F1's harness.
+- [ ] Numeric per-file coverage evidence is committed under `<FEATURE>/evidence/qa-gates/`.
+- [ ] No production file in scope exceeds 500 lines (`QfcHomeController.cs` is at 487).
+- [ ] Tests use MSTest, Moq, and FluentAssertions; deterministic, isolated, no temporary files.
+- [ ] Full C# toolchain passes in final form.
+- [ ] No behavior change to observable QuickFiler flows.
+
+## Constraints & Risks
+
+- In-flight issue #424 (`docs/features/active/2026-08-06-quickfiler-high-confidence-queue-init-stall-424`)
+  targets a `QfcHomeController` queue-initialization stall; new tests must not contradict its
+  regression tests.
+- Iteration and metrics paths carry ordering and state-transition invariants; `RunAsync` is the async
+  hot path. `Thread.Sleep`, `Task.Delay`, and real wall-clock waits are prohibited in tests.
+- The home controller consumes `IQfcDatamodel` (sibling F5), `IQfcQueue` (sibling F2), and the
+  collection controller (sibling F11). Those files belong to siblings and must not be edited here.
+- Upstream dependency on F1 (`quickfiler-coverage-ledger`), which supplies the exemption ledger and
+  the per-file coverage harness.
+
+## Test Conditions to Consider
+
+- [ ] `RunAsync` cancellation, zero-batch, and re-entrancy scenarios.
+- [ ] Iteration ordering and state transitions (`Iterate`, `Iterate2`, `IterateQueueAsync`, `SwapStopWatch`).
+- [ ] Metrics accumulation, formatting, and write paths with an injected clock.
+- [ ] Invalid-input, boundary, and error-handling behavior for each covered member.
+
+## Next Step
+
+- [x] Promote to GitHub issue (#433)
+- [x] Create active feature folder `docs/features/active/2026-08-07-quickfiler-qfc-home-controller-coverage-433/`

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-test-form1-live-form.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-test-form1-live-form.md
@@ -1,0 +1,66 @@
+# quickfiler-test-form1-live-form (Issue #491)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/quickfiler-test-form1-live-form/ (Issue #491)
+- Discovered during: preparation research for issue #456 (epic #136, child F14)
+
+- Issue: #491
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/491
+- Last Updated: 2026-08-08
+## Summary
+
+A live `System.Windows.Forms.Form` is compiled into the `QuickFiler.Test` assembly, and a second,
+unrelated item of dead production surface exists in `ItemViewer.Breadcrumb.cs`. Both are test-policy
+and design-debt items rather than runtime defects, and both are outside epic #136 child F14's
+production file set.
+
+## Item 1 — live `Form` compiled into the unit-test assembly
+
+`QuickFiler.Test/Form1.cs:5` and `QuickFiler.Test/Form1.Designer.cs:3` declare
+`public partial class Form1 : System.Windows.Forms.Form`, whose `InitializeComponent` constructs three
+`QuickFiler.ItemViewer` instances (`Form1.Designer.cs:32-34`).
+
+No test instantiates it — verified: the only `Form1` references in the test project are its own two
+files — so no policy violation occurs today. But `.claude/rules/general-unit-test.md` and epic #136's
+"never construct live forms" rule are one `new Form1()` away from being breached, and the type is dead
+weight in the test assembly.
+
+Candidate disposition: delete both files, or move them to a manual harness project outside the unit
+test assembly.
+
+## Item 2 — three `internal` members of `ItemViewer.Breadcrumb.cs` have no production caller
+
+`AttachBreadcrumbMessengerWhenReadyAsync` (`ItemViewer.Breadcrumb.cs:100-124`),
+`AttachBreadcrumbMessenger` (`:126-140`), and `BreadcrumbOpenTask` (`:29-30`) are invoked only from
+tests. A repository-wide search for each identifier returns the declaration plus call sites in
+`QuickFiler.Test/Viewers/BreadcrumbCollapsedSurfaceReadinessTests.cs:438`,
+`BreadcrumbSubfolderActivationTests.cs:340`,
+`BreadcrumbSelectorOpenRetryTests.cs:38,41,61,69,265`,
+`BreadcrumbCoordinatorLifecycleTests.cs:123`, and
+`BreadcrumbDropDownIntegrationTests.cs:415-421`. No `QuickFiler/**` production file references them.
+
+This is roughly 40 lines of production surface maintained solely for tests. It is not a bug, and it
+must not simply be deleted — doing so would break seven existing tests. The disposition is either to
+promote these members to the production attach path (the `AttachCollapsedMessenger` route is
+arguably what `CreateCollapsedBreadcrumbCandidate` should use) or to mark them explicitly as test
+seams so their status is legible.
+
+## Acceptance Criteria (early draft)
+
+- [ ] No `Form`-derived type is compiled into `QuickFiler.Test`, or it is isolated in a non-unit-test
+      project.
+- [ ] The three test-only `internal` members are either wired into the production path or explicitly
+      documented as test seams.
+- [ ] Existing tests continue to pass.
+
+## Constraints & Risks
+
+- Item 2 touches `ItemViewer.Breadcrumb.cs`, assigned to epic child F14 (issue #456); reconcile
+  against F14's plan before scheduling.
+- Deleting `Form1` changes the `QuickFiler.Test.csproj` compile set; preserve CRLF and keep the edit
+  to minimal adjacent hunks.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug template)

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-undoconsumer-nonterminating-loop.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-undoconsumer-nonterminating-loop.md
@@ -1,0 +1,92 @@
+# quickfiler-undoconsumer-nonterminating-loop (Issue #448)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/quickfiler-undoconsumer-nonterminating-loop/ (Issue #448)
+- Found during: research for issue #435 (child F6 of epic #136, QuickFiler per-file coverage)
+
+- Issue: #448
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/448
+- Last Updated: 2026-08-08
+## Summary
+
+`QfcFormController.UndoConsumer()` contains a loop that never terminates. Once its 10-second
+threshold is crossed the loop stops awaiting and busy-spins on a background thread for the remaining
+lifetime of the process.
+
+## Location
+
+`QuickFiler/Controllers/QfcFormController.Actions.cs:253-292`
+
+## Observed Behavior
+
+The loop condition at line 258 is:
+
+```csharp
+while (!_undoQueue.IsCompleted || exit)
+```
+
+Two independent problems compound:
+
+1. `_undoQueue` is a `BlockingCollection<IMovedMailInfo>` (declared at `QfcFormController.cs:90`) and
+   no code path anywhere calls `CompleteAdding()` on it. `IsCompleted` is therefore permanently
+   `false`, so `!_undoQueue.IsCompleted` alone holds the condition true regardless of `exit`.
+2. `exit` is set `true` only in the `sw.ElapsedMilliseconds > 10000` branch at line 279. Because the
+   condition is a disjunction (`|| exit`) rather than a conjunction, setting `exit` makes the
+   condition *more* likely to hold, not less. After the threshold the `else if` branch is taken on
+   every iteration, which re-sets `exit` and reaches no `await`, so the thread spins without yielding.
+
+Before the 10-second mark the loop awaits `Task.Delay(200)` on the empty-queue path, so the spin only
+begins after the threshold.
+
+The consequence is that the post-loop cleanup at lines 288-291:
+
+```csharp
+if (exit)
+{
+    _undoConsumerTask = null;
+}
+```
+
+is unreachable in any terminating execution. `_undoConsumerTask` is never reset, so the `??=` guard at
+line 211 (`_undoConsumerTask ??= Task.Run(UndoConsumer);`) never restarts a consumer either.
+
+## Expected Behavior
+
+The loop should terminate when the queue is drained and the idle threshold has elapsed. The condition
+appears to have been intended as a conjunction, for example `while (!_undoQueue.IsCompleted && !exit)`,
+and the empty-queue path should continue to yield rather than spin.
+
+## Impact
+
+A QuickFiler session in which the user opens the undo dialog leaves a CPU-bound background thread
+running until Outlook exits. Severity depends on how often `UndoDialog()` is reached in practice.
+
+## Why This Is Filed Separately
+
+Discovered during read-only research for the F6 coverage child. Correcting the loop condition is a
+behavior change, and F6's acceptance criteria explicitly forbid behavior changes to observable
+QuickFiler flows. F6 works around it by introducing an injectable start-delegate around
+`Task.Run(UndoConsumer)` so that unit tests never start the real loop; that seam does not fix the
+defect.
+
+## Proposed Fix
+
+1. Add a failing regression test that drives `UndoConsumer` past the idle threshold and asserts it
+   completes, using an injected time provider and delay delegate so the test contains no wall-clock
+   wait (`Thread.Sleep`, `Task.Delay`, and real waits are prohibited in tests by
+   `.claude/rules/general-unit-test.md`).
+2. Correct the loop condition and the idle-exit path.
+3. Confirm `_undoConsumerTask` is reset so a later `UndoDialog()` can start a fresh consumer.
+
+## Acceptance Criteria (early draft)
+
+- [ ] A deterministic regression test fails before the fix and passes after, with no wall-clock wait.
+- [ ] `UndoConsumer()` terminates once the queue is drained and the idle threshold elapses.
+- [ ] `_undoConsumerTask` is reset on exit so a subsequent `UndoDialog()` starts a new consumer.
+- [ ] No busy-spin: the empty-queue path always yields.
+- [ ] Full C# toolchain passes: csharpier, analyzer build, nullable build, coverage-enabled vstest.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug template)

--- a/docs/features/potential/promoted/2026-08-07-quickfiler-webview2-incognito-arg-en-dash.md
+++ b/docs/features/potential/promoted/2026-08-07-quickfiler-webview2-incognito-arg-en-dash.md
@@ -1,0 +1,90 @@
+# quickfiler-webview2-incognito-arg-en-dash (Issue #463)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/quickfiler-webview2-incognito-arg-en-dash/ (Issue #463)
+- Work Mode: full-bug
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #463
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/463
+- Last Updated: 2026-08-08
+## Summary
+
+The WebView2 additional-browser-arguments string uses a U+2013 EN DASH instead of the two ASCII
+hyphens a Chromium switch requires, so the intended incognito mode is never applied. The defect is
+present at three call sites across two controllers.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Runtime: .NET Framework 4.8.1 WinForms VSTO add-in with Microsoft WebView2
+- UI path: WebView2 environment construction in the QuickFiler item controllers
+- Data source or fixture: n/a
+
+## Steps to Reproduce
+
+1. Open an item viewer that initializes a WebView2 environment.
+2. Inspect the resulting `CoreWebView2Environment` browser arguments, or observe that browsing data
+   persists across sessions.
+3. Observe that incognito mode is not in effect.
+
+## Expected Behavior
+
+The WebView2 environment is created with a valid Chromium `--incognito` switch and no browsing data
+persists.
+
+## Actual Behavior
+
+The argument string is `"–incognito "`, whose first character is **U+2013 EN DASH**, not two ASCII
+hyphen-minus characters. Chromium does not recognise the token, so the switch is silently ignored.
+
+Affected sites:
+
+- `QuickFiler/Controllers/EfcItemController.cs:184`
+- `QuickFiler/Controllers/EfcItemController.cs:217`
+- `QuickFiler/Controllers/QfcItemController.ViewerSetup.cs:52`
+
+The commented-out alternative directly above two of these sites (`EfcItemController.cs:182`, `:215`)
+correctly uses ASCII in `"--disk-cache-size=1 "`, which is what makes the substitution visible on a
+close read.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Code-read evidence recorded above (verified 2026-08-07 against the working tree).
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+Browsing data that was intended to be discarded is retained. There is no crash and no visible error,
+which is why the defect has persisted.
+
+## Suspected Cause / Notes
+
+Almost certainly an editor or documentation copy-paste that applied "smart dashes" autocorrection,
+converting `--` to a single en dash. WebView2 ignores unrecognised switches silently, so there is no
+runtime signal.
+
+Because the same string appears in both the EFC and QFC item controllers, a single fix should cover
+all three sites, and a guard test asserting the arguments contain only ASCII would prevent recurrence.
+
+Discovered during preparation of issue #452 (epic #136) per-file coverage research. Out of scope there
+under that feature's no-behavior-change constraint.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Replace the en dash with `--` at all three sites
+- [ ] Add a test asserting the additional-browser-arguments string is pure ASCII and starts with `--`
+- [ ] Consider a repository-wide check for non-ASCII dashes inside string literals passed to process/browser arguments
+- [ ] Manual verification: confirm incognito behavior after the fix
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-07-webview2breadcrumbhost-handler-retention-pooled-viewer.md
+++ b/docs/features/potential/promoted/2026-08-07-webview2breadcrumbhost-handler-retention-pooled-viewer.md
@@ -1,0 +1,105 @@
+# webview2breadcrumbhost-handler-retention-pooled-viewer (Issue #458)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/webview2breadcrumbhost-handler-retention-pooled-viewer/ (Issue #458)
+- Work Mode: full-bug
+- Discovered during: preparation research for issue #455 (epic #136, child F13)
+
+- Issue: #458
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/458
+- Last Updated: 2026-08-08
+## Summary
+
+`WebView2BreadcrumbHost`'s constructor performs an unhook-then-hook sequence intended to be
+idempotent across pooled-viewer reuse, but the unhook cannot remove the previous instance's
+subscription. When a new `WebView2BreadcrumbHost` is constructed over a `WebView2` control that a
+prior host instance already wrapped, the prior instance stays subscribed to the control's
+`CoreWebView2InitializationCompleted` event. The old host is kept alive by the control, and
+initialization completion is handled more than once.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Runtime: .NET Framework 4.8.1 WinForms VSTO add-in with Microsoft WebView2
+- Affected path: pooled viewer reuse (`EfcViewerQueue` / `ItemViewerQueue` recycling a viewer whose
+  Designer-owned `WebView2` control is retained across uses)
+
+## Steps to Reproduce
+
+1. Construct a `WebView2BreadcrumbHost` over a Designer-owned `WebView2` control.
+2. Recycle the pooled viewer so a second `WebView2BreadcrumbHost` is constructed over the **same**
+   control instance.
+3. Drive CoreWebView2 initialization to completion.
+4. Observe that both host instances handle the completion: `IsCoreInitialized` is set and
+   `CoreInitialized` is raised on the stale instance as well as the live one.
+
+## Expected Behavior
+
+Exactly one host instance — the current one — is subscribed to the control's events, and exactly
+one `CoreInitialized` notification reaches the controller per initialization.
+
+## Actual Behavior
+
+Both instances remain subscribed. The stale instance is retained for the lifetime of the control.
+
+## Suspected Cause
+
+`QuickFiler/Viewers/WebView2BreadcrumbHost.cs:48-50`:
+
+```csharp
+// Idempotent hookup: pooled viewers re-run initialization, so unhook before hooking.
+_control.CoreWebView2InitializationCompleted -= OnCoreInitializationCompleted;
+_control.CoreWebView2InitializationCompleted += OnCoreInitializationCompleted;
+```
+
+`OnCoreInitializationCompleted` is an **instance** method. The delegate formed by `-=` in a
+constructor is bound to the instance under construction, which has never subscribed. Delegate
+equality is `(target, method)` pairwise, so the removal matches nothing and is a no-op. The
+comment's stated intent — de-duplicating across pooled-viewer re-initialization — is therefore not
+achieved. The pattern is only idempotent for repeated calls on the *same* instance.
+
+The same instance-bound unhook-then-hook pattern appears at
+`QuickFiler/Viewers/WebView2BreadcrumbHost.cs:131-132` for `core.WebMessageReceived`. That one is
+genuinely idempotent within a single instance, but has the same cross-instance leak when two hosts
+share one `CoreWebView2`.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+Consequences are a managed-object retention leak (each recycled viewer accumulates one dead host
+plus its event-handler chain) and duplicated `CoreInitialized` / `MessageReceived` notifications
+routed to `BreadcrumbBridgeRouter.NotifyCoreInitialized`. Duplicate notification can produce
+duplicate breadcrumb document initialization work. Severity is Medium rather than High because the
+stale host's handler does not throw and the observable breadcrumb output is idempotent in the
+common path.
+
+## Suggested Remediation
+
+Give the host an explicit `IDisposable` (or `Detach()`) that unsubscribes the live instance's
+handlers, and call it when the pooled viewer releases the host — rather than relying on a
+constructor-side unhook that cannot see the previous instance. Alternatively, store the
+subscription on the control (for example in a single owner field) so the new host can unsubscribe
+its predecessor explicitly.
+
+## Why this is not fixed under epic #136
+
+Epic #136 child F13 (issue #455) carries a hard no-behavior-change NFR: it raises coverage and
+removes unratified coverage exemptions without altering observable QuickFiler flows. Fixing this
+changes subscription lifetime and notification counts, which is a behavior change and belongs in
+its own issue.
+
+## Related
+
+- Issue #455 — F13, breadcrumb drop-down and WebView2 host coverage (where this was found).
+- Issue #136 — parent epic.
+- Issue #349 — the change that introduced the WebView2 breadcrumb control.
+
+## Next Step
+
+- [ ] Promote to GitHub issue
+- [ ] Reconcile against F13's plan before scheduling, since F13 adds tests over this file

--- a/docs/features/potential/promoted/2026-08-07-webview2breadcrumbhost-unmarshalled-sdk-call-and-unsynchronized-state.md
+++ b/docs/features/potential/promoted/2026-08-07-webview2breadcrumbhost-unmarshalled-sdk-call-and-unsynchronized-state.md
@@ -1,0 +1,121 @@
+# webview2breadcrumbhost-unmarshalled-sdk-call-and-unsynchronized-state (Issue #476)
+
+- Date captured: 2026-08-07
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/webview2breadcrumbhost-unmarshalled-sdk-call-and-unsynchronized-state/ (Issue #476)
+- Work Mode: full-bug
+- Discovered during: preparation research for issue #455 (epic #136, child F13)
+
+- Issue: #476
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/476
+- Last Updated: 2026-08-08
+## Summary
+
+`WebView2BreadcrumbHost` reaches the WebView2 SDK on the caller's thread with no UI marshalling, and
+publishes its initialization state through a non-volatile field read from other threads. The
+sibling adapter that serves the same purpose for the popup surface, `WebView2Messenger`, routes
+every SDK call through `BreadcrumbUiDispatcher`. The two adapters therefore disagree about the
+thread-affinity contract of the same SDK.
+
+Two related defects are filed together because they share one file, one root cause area, and one
+fix.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Runtime: .NET Framework 4.8.1 WinForms VSTO add-in
+- Package: `Microsoft.Web.WebView2` 1.0.4129.50 (`QuickFiler/packages.config:29`)
+- Sole construction site: `QuickFiler/Controllers/EfcFormController.cs:836` (EfcViewer surface)
+
+## Defect 1 — unmarshalled SDK call on the caller's thread
+
+`QuickFiler/Viewers/WebView2BreadcrumbHost.cs:72-84`:
+
+```csharp
+public void PostMessageJson(string json)
+{
+    CoreWebView2? core = _control.CoreWebView2;   // :74  SDK property read
+    if (core == null)
+    {
+        log.Error("PostMessageJson called before CoreWebView2 initialization; payload dropped.");
+        return;
+    }
+
+    core.PostWebMessageAsJson(json);             // :83  SDK call
+}
+```
+
+Both the property read at `:74` and the call at `:83` execute on whatever thread invoked
+`PostMessageJson`. WebView2 controls are documented as requiring the UI (STA) thread — a
+requirement this very file acknowledges at `:105` ("WebView2 controls must be touched on the
+WinForms UI (STA) thread") and honours in `InitializeAsync` by awaiting the UI
+`SynchronizationContext` before touching the control.
+
+Contrast `QuickFiler/Viewers/WebView2Messenger.cs:55-69`, which wraps the equivalent
+`PostWebMessageAsJson` forward inside `_dispatcher.Dispatch(...)`.
+
+`PostMessageJson` is reachable from `BreadcrumbBridgeRouter` / `BreadcrumbOutboundQueue`, which are
+not thread-affine, so a non-UI-thread caller is reachable in practice.
+
+`NavigateToString` at `:66-69` has the same shape and the same exposure.
+
+## Defect 2 — unsynchronized cross-thread state publication
+
+`QuickFiler/Viewers/WebView2BreadcrumbHost.cs:54`:
+
+```csharp
+public bool IsCoreInitialized { get; private set; }
+```
+
+Written at `:134` inside `OnCoreInitializationCompleted`, which runs on the UI thread. Read by
+outbound-queue code on other threads. The backing field is a plain non-volatile auto-property
+field, so there is no barrier and no guarantee a reader observes the write, nor that it observes the
+`core.WebMessageReceived` subscription at `:131-132` that precedes it.
+
+The compare-and-publish ordering at `:131-135` — subscribe, then set the flag, then raise
+`CoreInitialized` — is clearly intended to be an ordered publication. Without a barrier that
+ordering is not guaranteed to be visible to another thread.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+Defect 1 can throw `InvalidCastException`/`COMException` or corrupt COM apartment state when the
+breadcrumb document is posted to from a background thread; the symptom is intermittent and
+apartment-dependent, which makes it expensive to reproduce from a user report. Defect 2 can cause a
+reader to see `IsCoreInitialized == false` after initialization completed (dropping a payload
+through the `:76` guard) or to see it `true` before the subscription at `:131-132` is visible.
+
+Severity is High because the failure is silent-or-intermittent and concurrency-dependent rather
+than deterministic.
+
+## Suggested Remediation
+
+Give `WebView2BreadcrumbHost` the same `BreadcrumbUiDispatcher` treatment `WebView2Messenger`
+already has: route `NavigateToString`, `PostMessageJson`, and the `CoreWebView2` property read
+through the captured UI boundary. Make `IsCoreInitialized` a `Volatile.Read`/`Volatile.Write` pair
+over an explicit backing field, or publish state through the dispatcher so all access is
+single-threaded by construction.
+
+Aligning the two adapters on one thread-affinity contract also removes a standing source of
+confusion about which adapter is safe to call from where.
+
+## Why this is not fixed under epic #136
+
+Epic #136 child F13 (issue #455) carries a hard no-behavior-change NFR. Introducing dispatcher
+marshalling changes execution ordering and timing on a live UI path, which is a behavior change.
+
+## Related
+
+- Issue #455 — F13, breadcrumb drop-down and WebView2 host coverage (where this was found).
+- Issue #458 — `WebView2BreadcrumbHost` handler retention across pooled viewer reuse. Same file,
+  same lifecycle area; schedule together.
+- Issue #136 — parent epic.
+
+## Next Step
+
+- [ ] Promote to GitHub issue
+- [ ] Decide whether the two WebView2 adapters should converge on one thread-affinity contract

--- a/docs/features/potential/promoted/2026-08-08-breadcrumb-hub-postjson-caches-before-broadcast-starves-attachments.md
+++ b/docs/features/potential/promoted/2026-08-08-breadcrumb-hub-postjson-caches-before-broadcast-starves-attachments.md
@@ -1,0 +1,112 @@
+# breadcrumb-hub-postjson-caches-before-broadcast-starves-attachments (Issue #501)
+
+- Date captured: 2026-08-08
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/breadcrumb-hub-postjson-caches-before-broadcast-starves-attachments/ (Issue #501)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #501
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/501
+- Last Updated: 2026-08-08
+## Summary
+
+`BreadcrumbMessengerHub.PostJson` writes the message into its replay cache *before* broadcasting and
+wraps the broadcast in no `try`/`catch`. If one attached surface throws — which a disposed
+`WebView2Messenger` does — every attachment later in enumeration order silently never receives the
+message, yet the cache records it as delivered, so no re-delivery ever occurs and a later `Attach`
+replays a state the surviving surfaces never saw.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Python version: n/a (C# / .NET Framework 4.8.1 WinForms VSTO add-in with Microsoft WebView2)
+- Command/flags used: n/a — reached through the QuickFiler ItemViewer breadcrumb surfaces
+- Data source or fixture: two or more attached breadcrumb surfaces where one has been disposed
+
+## Steps to Reproduce
+
+1. Attach two breadcrumb surfaces to a single `BreadcrumbMessengerHub` — in production the inline
+   selector and the popup surface.
+2. Dispose one surface's `WebView2Messenger` without calling the hub's `Detach`. The two are
+   independently ordered calls (`QuickFiler/Viewers/BreadcrumbItemViewerLifecycleCoordinator.cs:277`
+   and `:288`), so this ordering is reachable.
+3. Post a breadcrumb message through the hub.
+4. Observe which surfaces received it, and inspect the hub's replay cache.
+
+## Expected Behavior
+
+Either every live attachment receives the message, or a failure to deliver is contained and the cache
+does not claim delivery. The hub already demonstrates the correct pattern in `Attach`, which wraps
+its replay in `try`/`catch` with an explicit rollback
+(`QuickFiler/Viewers/BreadcrumbMessengerHub.cs:82-93`).
+
+## Actual Behavior
+
+`PostJson` caches at `:130`, then enumerates attachments at `:131-134` with no exception handling. The
+disposed surface throws `ObjectDisposedException` from `WebView2Messenger.PostJson`
+(`QuickFiler/Viewers/WebView2Messenger.cs:61` via `:130-136`). The exception propagates out of the
+hub to the caller, attachments later in enumeration order are starved, and `_cachedStates` is not
+rolled back.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Snippet: `System.ObjectDisposedException` raised from `WebView2Messenger.PostJson`.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+Rationale: recorded by research as Low-Medium. Raised to Medium here because the corrupted replay
+cache makes the resulting stale-surface state persistent rather than transient — no subsequent post
+repairs it — and the ordering that triggers it is a normal disposal sequence rather than an exotic
+race.
+
+## Suspected Cause / Notes
+
+Verified call chain:
+
+1. `QuickFiler/Viewers/BreadcrumbMessengerHub.cs:130` — `CacheState(type, json)` records the message
+   **before** any surface has received it.
+2. `QuickFiler/Viewers/BreadcrumbMessengerHub.cs:131-134` — the broadcast `foreach` runs with no
+   `try`/`catch` anywhere in `PostJson`.
+3. A throw from the first attachment aborts the loop; attachments 2..n never receive the message and
+   `_cachedStates` is not rolled back.
+
+Contrast `Attach` at `:82-93`, which wraps its replay and rolls back on failure — the hub is
+internally inconsistent about this.
+
+No existing test covers the defect. The two `ThrowOnPost` tests
+(`QuickFiler.Test/Viewers/BreadcrumbMessengerHubTests.cs:199-217` and
+`QuickFiler.Test/Viewers/BreadcrumbMessengerHubCoverageTests.cs:317-322`) both throw during
+`Attach`-time replay, which *is* rolled back, never during a multi-surface broadcast.
+
+Related but distinct from **#476** (`webview2breadcrumbhost-unmarshalled-sdk-call-and-unsynchronized-state`),
+which concerns `WebView2BreadcrumbHost` rather than the hub's broadcast contract — cross-link rather
+than merge. Interacts with the lock-scope defect filed separately from the same research, because the
+throw occurs while the hub's `_sync` is held, which aborts the broadcast under the monitor.
+
+Discovered during preparation research for epic #136 child F12 (issue #495), recorded as LD-2 in
+`docs/features/active/2026-08-08-quickfiler-breadcrumb-bridge-coverage-495/research/2026-08-08T02-10-breadcrumb-messenger-hub.md`.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Unit coverage areas: a failing regression test first, per the repository Bugfix Workflow,
+      attaching two surfaces where the first throws on post, then asserting the second still received
+      the message and the cache does not record an undelivered state.
+- [ ] Integration scenario to retest: dispose the popup surface while the inline selector remains
+      attached, then drive a breadcrumb render and confirm the selector still updates.
+- [ ] Manual verification notes: three candidate fixes — catch per surface and continue; defer the
+      cache write until after a successful broadcast; or auto-detach a surface that throws. Each is an
+      observable behavior change, which is why this was out of scope for #495 under the epic's
+      no-behavior-change NFR. Auto-detach is the most invasive and should be weighed against simply
+      containing the throw.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-08-breadcrumb-router-segment-index-unvalidated-host-crash.md
+++ b/docs/features/potential/promoted/2026-08-08-breadcrumb-router-segment-index-unvalidated-host-crash.md
@@ -1,0 +1,103 @@
+# breadcrumb-router-segment-index-unvalidated-host-crash (Issue #498)
+
+- Date captured: 2026-08-08
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/breadcrumb-router-segment-index-unvalidated-host-crash/ (Issue #498)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #498
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/498
+- Last Updated: 2026-08-08
+## Summary
+
+An out-of-range `segmentIndex` in a `segmentDoubleClick` breadcrumb message passes codec validation,
+throws `ArgumentOutOfRangeException` deep in `BreadcrumbRow.CollapseAfter`, and escapes the
+`async void` host-event boundary in `BreadcrumbBridgeRouter.OnHostMessageReceived`, which catches
+only `BreadcrumbMessageException`. On .NET Framework 4.8 an exception rethrown on the captured
+`SynchronizationContext` from an `async void` method is unhandled, so a malformed message from the
+WebView2 document can terminate the Outlook host process.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Python version: n/a (C# / .NET Framework 4.8.1 WinForms VSTO add-in with Microsoft WebView2)
+- Command/flags used: n/a — reached through the EfcViewer folder-list breadcrumb surface
+- Data source or fixture: any breadcrumb row whose `segmentIndex` exceeds the row's segment count
+
+## Steps to Reproduce
+
+1. Open the EfcViewer folder list so the breadcrumb surface is hosted and
+   `EfcFormController.ConfigureBreadcrumbControl` (`QuickFiler/Controllers/EfcFormController.cs:834-854`)
+   has wired a `BreadcrumbBridgeRouter` to a `WebView2BreadcrumbHost`.
+2. Have the hosted document post the message
+   `{"type":"segmentDoubleClick","rowId":"row-1","segmentIndex":99}` for a row that has fewer than
+   100 segments.
+3. Observe the add-in host process.
+
+## Expected Behavior
+
+The router's own XML doc comment at `QuickFiler/Controllers/BreadcrumbBridgeRouter.cs:151-154` states
+the contract: a malformed payload should "fail fast with the codec's `BreadcrumbMessageException`
+(already logged) and leave state unchanged." An out-of-range index should therefore be rejected and
+logged, leaving row state untouched and the host running.
+
+## Actual Behavior
+
+`ArgumentOutOfRangeException` propagates out of `async void OnHostMessageReceived` and is rethrown on
+the captured `SynchronizationContext` (the Outlook UI thread in production), producing an unhandled
+exception and a host-process crash. The documented contract at `:151-154` is false for this input.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Snippet: `System.ArgumentOutOfRangeException` originating in `BreadcrumbRow.CollapseAfter`
+  (`QuickFiler/Controllers/BreadcrumbRow.cs:111-118`).
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+Rationale: the failure mode is host-process termination rather than a degraded feature, and the
+input arrives from the hosted WebView2 document rather than from trusted in-process code.
+
+## Suspected Cause / Notes
+
+Verified call chain:
+
+1. `QuickFiler/Controllers/BreadcrumbBridgeRouter.cs:169` —
+   `if (row.CollapseAfter(message.SegmentIndex!.Value))`, with no range check. The null-forgiving
+   operator asserts only that the codec validated *presence*.
+2. `QuickFiler/Controllers/BreadcrumbMessageCodec.cs:100` and `:142-158` — `OptionalInt` validates
+   only that the token is a JSON integer; `:103-106` validates only that the field is present for
+   `segmentDoubleClick`. **The codec performs no range validation.**
+3. `QuickFiler/Controllers/BreadcrumbRow.cs:111-118` — `CollapseAfter` throws
+   `ArgumentOutOfRangeException` when `segmentIndex < 0 || segmentIndex >= _segments.Count`.
+4. `QuickFiler/Controllers/BreadcrumbBridgeRouter.cs:193` — the `catch` clause is
+   `BreadcrumbMessageException`-only, so the exception escapes the `async void` boundary.
+
+Discovered during preparation research for epic #136 child F12 (issue #495), recorded in
+`docs/features/active/2026-08-08-quickfiler-breadcrumb-bridge-coverage-495/research/2026-08-08T02-10-breadcrumb-bridge-router.md`
+as LD-1. Not a duplicate of #440 (arrow-key tree semantics), #458 (host handler retention on pooled
+viewers), #462 (drop-down `closePending`), or #488 (ItemViewer breadcrumb pipeline lifecycle).
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Unit coverage areas: a failing regression test first, per the repository Bugfix Workflow,
+      driving a `segmentDoubleClick` message with an out-of-range `segmentIndex` through
+      `BreadcrumbBridgeRouter` and asserting no exception escapes and row state is unchanged.
+- [ ] Integration scenario to retest: EfcViewer folder-list breadcrumb double-click on a
+      multi-segment row, confirming normal collapse still works after the guard is added.
+- [ ] Manual verification notes: two candidate fixes — add a range guard at
+      `BreadcrumbBridgeRouter.cs:169`, or widen the `catch` at `:193`. The guard is preferable because
+      it preserves the documented "leave state unchanged" contract rather than merely suppressing the
+      throw. Either is an observable behavior change and so was out of scope for #495, whose epic
+      carries a no-behavior-change NFR.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-08-breadcrumb-router-stale-selectedfolderpath-after-rebind.md
+++ b/docs/features/potential/promoted/2026-08-08-breadcrumb-router-stale-selectedfolderpath-after-rebind.md
@@ -1,0 +1,104 @@
+# breadcrumb-router-stale-selectedfolderpath-after-rebind (Issue #499)
+
+- Date captured: 2026-08-08
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/breadcrumb-router-stale-selectedfolderpath-after-rebind/ (Issue #499)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #499
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/499
+- Last Updated: 2026-08-08
+## Summary
+
+`BreadcrumbBridgeRouter.BindRowsAsync` clears `_selectedRowId` but does not clear
+`SelectedFolderPath`. After a re-bind the UI shows no row highlighted while
+`EfcFormController.SelectedFolder` still reports the previously selected folder. Because
+`BindFolderRows` runs on every search keystroke, a confirm action taken at that moment can file mail
+to a folder the user can no longer see selected.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Python version: n/a (C# / .NET Framework 4.8.1 WinForms VSTO add-in with Microsoft WebView2)
+- Command/flags used: n/a — reached through the EfcViewer folder-list breadcrumb surface
+- Data source or fixture: any folder set where a selection is made and then the search text changes
+
+## Steps to Reproduce
+
+1. Open the EfcViewer folder list and type enough search text to show candidate folder rows.
+2. Select a folder row, so `SelectRow` sets both `_selectedRowId` and `SelectedFolderPath`.
+3. Type one more character in the search box. This reaches
+   `EfcFormController.BindFolderRows` (`QuickFiler/Controllers/EfcFormController.cs:873-883`) and so
+   `BreadcrumbBridgeRouter.BindRowsAsync`.
+4. Observe that no row is highlighted in the re-rendered document.
+5. Trigger a move or folder-open action.
+
+## Expected Behavior
+
+After a re-bind clears the visible selection, the controller's `SelectedFolder` should agree with the
+UI: either no folder is reported as the filing target, or the selection is visibly restored. The two
+state fields `_selectedRowId` and `SelectedFolderPath` are written together in `SelectRow` and should
+be cleared together.
+
+## Actual Behavior
+
+Only `_selectedRowId` is cleared. `SelectedFolderPath` retains the previous value, so
+`EfcFormController.SelectedFolder` keeps returning the old folder while the UI shows nothing
+selected. A move performed at that point targets the stale folder.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Snippet: n/a — this is a silent state divergence with no error text.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+Rationale: the consequence is mail filed to an unintended folder — a silent, user-visible data
+placement error with no exception to signal it. Recorded by research as Medium-High; raised to High
+here because `BindFolderRows` runs on every keystroke, so the divergent window is common rather than
+rare, and the failure is silent.
+
+## Suspected Cause / Notes
+
+Verified call chain:
+
+1. `QuickFiler/Controllers/BreadcrumbBridgeRouter.cs:114` — `_selectedRowId = null;` after a re-bind.
+   `SelectedFolderPath` (declared `:58`) is not reset; it is written only in `SelectRow` (`:372`).
+2. `QuickFiler/Controllers/BreadcrumbBridgeRouter.cs:399` — the re-rendered document is built with
+   `_selectedRowId = null`, so no row is visually highlighted.
+3. `QuickFiler/Controllers/EfcFormController.cs:289-294` —
+   `public string SelectedFolder => _router?.SelectedFolderPath;` still returns the previous value.
+4. `QuickFiler/Controllers/EfcFormController.cs:873-883` — `BindFolderRows` is invoked from the
+   `SearchText.TextChanged` path and from the delete-path trash rebind.
+5. `QuickFiler/Controllers/EfcFormController.cs:493` and `:772` pass `SelectedFolder` into the move
+   operation; `:478`, `:722`, and `:760` pass it into folder-open.
+
+Discovered during preparation research for epic #136 child F12 (issue #495), recorded in
+`docs/features/active/2026-08-08-quickfiler-breadcrumb-bridge-coverage-495/research/2026-08-08T02-10-breadcrumb-bridge-router.md`
+as LD-2. Not a duplicate: #462 concerns the drop-down coordinator's `closePending` flag, #488 the
+ItemViewer breadcrumb pipeline lifecycle, and #440 arrow-key tree semantics. None touches this field
+pair.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Unit coverage areas: a failing regression test first, per the repository Bugfix Workflow,
+      asserting that after `BindRowsAsync` re-binds, `SelectedFolderPath` no longer reports the
+      pre-rebind folder.
+- [ ] Integration scenario to retest: select a folder in EfcViewer, type an additional search
+      character, then confirm a move and verify the destination matches the visible selection.
+- [ ] Manual verification notes: the fix must decide whether clearing `SelectedFolderPath` should
+      also raise `SelectedFolderPathChanged(null)`, and whether re-binding should instead attempt to
+      restore the prior selection when the same folder is still present in the new row set. Either
+      choice is an observable production contract change, which is why it was out of scope for #495
+      under the epic's no-behavior-change NFR.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-08-breadcrumb-suggestions-upgrade-silently-stale-on-superseded-lease.md
+++ b/docs/features/potential/promoted/2026-08-08-breadcrumb-suggestions-upgrade-silently-stale-on-superseded-lease.md
@@ -1,0 +1,110 @@
+# breadcrumb-suggestions-upgrade-silently-stale-on-superseded-lease (Issue #502)
+
+- Date captured: 2026-08-08
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/breadcrumb-suggestions-upgrade-silently-stale-on-superseded-lease/ (Issue #502)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #502
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/502
+- Last Updated: 2026-08-08
+## Summary
+
+`BreadcrumbCoordinatorUpgradeLifetime.RunSynchronous` discards the `bool` that `TryRunCurrent`
+returns, so when a lease has been superseded the guarded action is skipped silently. In
+`BreadcrumbBridgeCoordinator.SetSuggestions` the assignment to the public `SuggestionsUpgrade` handle
+lives *inside* that skipped action, so the method returns normally while `SuggestionsUpgrade` still
+holds its previous value and the caller awaits an upgrade that will never run.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Python version: n/a (C# / .NET Framework 4.8.1 WinForms VSTO add-in with Microsoft WebView2)
+- Command/flags used: n/a — reached through the QuickFiler ItemViewer breadcrumb selector
+- Data source or fixture: two breadcrumb suggestion populations issued close enough together that the
+  first lease is superseded before its guarded action runs
+
+## Steps to Reproduce
+
+This is a concurrency and ordering defect established by code inspection. No existing test reproduces
+it, because nothing in the suite supersedes a lease between `BeginPopulation` and `RunSynchronous`.
+
+1. Call `BreadcrumbBridgeCoordinator.SetSuggestions` to begin a suggestion population.
+2. Arrange for the lease to be invalidated between `BeginPopulation`
+   (`QuickFiler/Viewers/BreadcrumbBridgeCoordinator.cs:104`) and `RunSynchronous` (`:105`) — nothing
+   spans the two atomically.
+3. Await the coordinator's `SuggestionsUpgrade` handle.
+
+## Expected Behavior
+
+Either the caller learns that the population was superseded — via a return value, an exception, or a
+`SuggestionsUpgrade` set to a completed or cancelled task — or `SuggestionsUpgrade` is left in a state
+that cannot be mistaken for a fresh in-flight upgrade.
+
+## Actual Behavior
+
+`SetSuggestions` returns normally. `SuggestionsUpgrade` silently retains its previous value, so a
+caller awaiting it either waits on a stale completed task or believes a new upgrade is in flight when
+none is. Nothing observable distinguishes this from a successful population.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Snippet: n/a — the defect is a silent no-op with no error text.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [ ] Medium
+- [x] Low
+
+Rationale: reachable only under a supersession race that current call patterns make narrow, and the
+observable consequence is a stale suggestion set rather than data loss. Recorded for traceability
+because the silent-skip mechanism is general and would become more reachable if suggestion population
+were made more concurrent.
+
+## Suspected Cause / Notes
+
+Verified call chain:
+
+1. `QuickFiler/Viewers/BreadcrumbCoordinatorUpgradeLifetime.cs:115` — `RunSynchronous` calls
+   `TryRunCurrent` and **discards its `bool` result**. This is the structural mechanism.
+2. `QuickFiler/Viewers/BreadcrumbCoordinatorUpgradeLifetime.cs:141` — `TryRunCurrent` evaluates lease
+   currency and returns `false` without running the action when the lease is not current.
+3. `QuickFiler/Viewers/BreadcrumbBridgeCoordinator.cs:105-114` — `SetSuggestions` passes a lambda to
+   `RunSynchronous`, and `:112` assigns `SuggestionsUpgrade = PopulateSuggestionsAsync(rows, lease)`
+   **inside** that lambda. If the lambda never runs, the assignment never happens.
+4. Nothing spans `BeginPopulation` (`:104`) and `RunSynchronous` (`:105`) atomically, so the
+   supersession window is real.
+
+`AddItems` (`QuickFiler/Viewers/BreadcrumbBridgeCoordinator.cs:131-147`) has the same structure but
+exposes no observable handle at all — its dispatch task is discarded at `:141` — so the same skip is
+entirely invisible there.
+
+Discovered during preparation research for epic #136 child F12 (issue #495), recorded as LD-3 in
+`.../research/2026-08-08T01-15-breadcrumb-bridge-coordinator.md` (the observable symptom) and as LD-B
+in `.../research/2026-08-08T01-15-breadcrumb-coordinator-upgrade-lifetime.md` (the mechanism), both
+under `docs/features/active/2026-08-08-quickfiler-breadcrumb-bridge-coverage-495/`.
+
+Distinct from the lock-scope defect filed from the same research, which concerns `action()` executing
+*inside* `_sync` rather than the discarded return value. The two share a file and should be
+cross-linked but have different fixes.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Unit coverage areas: a failing regression test first, per the repository Bugfix Workflow,
+      superseding a lease between `BeginPopulation` and `RunSynchronous` and asserting the caller can
+      observe that the population did not run.
+- [ ] Integration scenario to retest: rapid successive breadcrumb suggestion populations, confirming
+      the surface reflects the latest set.
+- [ ] Manual verification notes: candidate fixes are to surface `TryRunCurrent`'s `bool` through
+      `RunSynchronous` to its callers, or to hoist the `SuggestionsUpgrade` assignment out of the
+      guarded lambda so the handle is always replaced. Both change an observable contract, which is
+      why this was out of scope for #495 under the epic's no-behavior-change NFR.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-08-breadcrumb-webview-post-executes-under-upgrade-lifetime-lock.md
+++ b/docs/features/potential/promoted/2026-08-08-breadcrumb-webview-post-executes-under-upgrade-lifetime-lock.md
@@ -1,0 +1,123 @@
+# breadcrumb-webview-post-executes-under-upgrade-lifetime-lock (Issue #500)
+
+- Date captured: 2026-08-08
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/breadcrumb-webview-post-executes-under-upgrade-lifetime-lock/ (Issue #500)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #500
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/500
+- Last Updated: 2026-08-08
+## Summary
+
+`BreadcrumbCoordinatorUpgradeLifetime.TryRunCurrent` invokes the caller's action while holding its
+`_sync` monitor, so a WebView2 post runs under two nested locks (`lifetime._sync` then `hub._sync`)
+and reaches an out-of-process SDK call from inside both. Because `lock` is re-entrant, the lock does
+not deliver the atomicity it appears to: a re-entrant call on the same thread can mutate `_current`
+between the currency check and the completion of the action, which is the exact invariant
+`TryRunCurrent` exists to enforce.
+
+## Environment
+
+- OS/version: Windows 11 Pro 10.0.26200
+- Python version: n/a (C# / .NET Framework 4.8.1 WinForms VSTO add-in with Microsoft WebView2)
+- Command/flags used: n/a — reached through the QuickFiler ItemViewer breadcrumb selector
+- Data source or fixture: any breadcrumb suggestion population that issues a render/selector post
+
+## Steps to Reproduce
+
+This is a concurrency and re-entrancy defect established by code inspection rather than a
+deterministic user-facing repro. No existing test reproduces it, and constructing one requires a
+re-entrant STA message pump, which repository unit-test policy prohibits.
+
+1. Populate breadcrumb suggestions so `BreadcrumbBridgeCoordinator.PostRenderAndSelectorAsync` runs.
+2. Observe that `_messenger.PostJson` executes inside `BreadcrumbCoordinatorUpgradeLifetime._sync`.
+3. In production the messenger is `BreadcrumbMessengerHub`, whose `PostJson` takes its own `_sync`
+   and, still holding it, calls `PostToSurface`, reaching the WebView2 SDK.
+
+## Expected Behavior
+
+The currency check and the guarded action should be atomic with respect to lease invalidation, and
+no out-of-process SDK call should be made while a lock is held. Locks should cover state mutation
+only, with the action invoked outside them, re-checking currency as needed.
+
+## Actual Behavior
+
+The action runs inside the lock. Because `Monitor` is re-entrant, a re-entrant `BeginPopulation`,
+`Invalidate`, or `TryDispose` on the same thread acquires `lifetime._sync` successfully and mutates
+`_current` mid-action, defeating the guarantee. Separately, a re-entrant `Attach`/`Detach` during the
+hub's broadcast would throw `InvalidOperationException` because the hub holds `_sync` across its
+`foreach`.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Snippet: n/a — no exception is raised on the current wiring; the defect is a silently unenforced
+  invariant.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+Rationale: no deadlock is demonstrable on current code and the lock ordering is consistent, so this
+is a latent correctness hazard rather than an active failure. It is recorded at Medium because an STA
+COM call can pump messages and re-enter managed code, which is precisely the condition that voids the
+intended atomicity.
+
+## Suspected Cause / Notes
+
+Verified call chain, established independently from three files during preparation research for epic
+#136 child F12 (issue #495):
+
+1. `QuickFiler/Viewers/BreadcrumbBridgeCoordinator.cs:266-275` — the render post is wrapped by
+   `_upgradeLifetime.Guard(lease, ...)` and dispatched.
+2. `QuickFiler/Viewers/BreadcrumbCoordinatorUpgradeLifetime.cs:130` — `Guard` wraps the action in
+   `() => TryRunCurrent(lease, action)`.
+3. `QuickFiler/Viewers/BreadcrumbCoordinatorUpgradeLifetime.cs:139-146` — `TryRunCurrent` takes
+   `lock (_sync)` and calls `action()` at `:145` **inside** the lock.
+4. `QuickFiler/Viewers/BreadcrumbMessengerHub.cs:126` — `PostJson` takes the hub's own `_sync` and,
+   still holding it, calls `PostToSurface` at `:133`, holding `_sync` across the `foreach` at `:131`.
+
+Supporting observations:
+
+- **No lock inversion exists.** `BreadcrumbMessengerHub.OnSurfaceMessageReceived` (`:157-173`)
+  snapshots the handler under its lock and invokes it outside, so the inbound path does not take the
+  reverse order. No deadlock is demonstrable on current code.
+- **The exposure is wider than `Guard`.** `RunSynchronous`
+  (`BreadcrumbCoordinatorUpgradeLifetime.cs:115`) places the whole body of `SetSuggestions` under the
+  lock, including the async upgrade kick-off.
+- **Re-entrant self-acquisition is already routine on the happy path**, with no COM involved:
+  `SetSuggestions` produces three nested acquisitions on one thread
+  (`BreadcrumbCoordinatorUpgradeLifetime.cs:139` → `:105` → `:139`) because
+  `BreadcrumbUiDispatcher.cs:84` executes inline.
+- **The file contradicts itself.** `BreadcrumbCoordinatorUpgradeLifetime.cs` deliberately calls
+  `lease.Cancel()`, `DisposeLease`, and `_report` *outside* the lock in five places; `:145` is the
+  sole departure from its own convention.
+
+Recorded as LD-1 in
+`.../research/2026-08-08T01-15-breadcrumb-bridge-coordinator.md`, as LD-A in
+`.../research/2026-08-08T01-15-breadcrumb-coordinator-upgrade-lifetime.md`, and as LD-1 in
+`.../research/2026-08-08T02-10-breadcrumb-messenger-hub.md`, all under
+`docs/features/active/2026-08-08-quickfiler-breadcrumb-bridge-coverage-495/`.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Unit coverage areas: a test that proves the currency invariant holds across a re-entrant
+      mutation, using an injectable re-entrant action rather than a real message pump so it stays
+      within unit-test policy.
+- [ ] Integration scenario to retest: breadcrumb suggestion population followed by rapid
+      re-population, confirming no stale render reaches the surface.
+- [ ] Manual verification notes: the candidate fix is to move `action()` outside `lock (_sync)` in
+      `TryRunCurrent` and re-check currency after the call, matching the convention the same file
+      already follows in five other places. This changes concurrency semantics and so was out of
+      scope for #495 under the epic's no-behavior-change NFR. Consider also narrowing the hub's
+      `_sync` so `PostToSurface` is not called under it.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/potential/promoted/2026-08-08-quickfiler-breadcrumb-bridge-coverage.md
+++ b/docs/features/potential/promoted/2026-08-08-quickfiler-breadcrumb-bridge-coverage.md
@@ -1,0 +1,76 @@
+# quickfiler-breadcrumb-bridge-coverage (Promoted)
+
+- Date captured: 2026-08-08
+- Author: Dan Moisan
+- Status: Promoted -> Issue #495 -> `docs/features/active/2026-08-08-quickfiler-breadcrumb-bridge-coverage-495/`
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/495
+- Work Mode: full-feature
+- Parent epic: #136 (QuickFiler per-file 80% coverage)
+- Epic child: F12 of `quickfiler-per-file-coverage`
+- Integration branch: `epic/quickfiler-per-file-coverage-integration`
+- Upstream dependency: F1 `quickfiler-coverage-denominator-and-exemption-ledger` (issue #432)
+
+> Audit-trail note: the MCP promotion tool reported this destination path in its receipt but the
+> file was not present on disk afterwards, matching the behavior already recorded for sibling F13.
+> It is reconstructed here so the promotion lifecycle remains auditable. The authoritative record
+> is issue #495 and the active feature folder. Promotion was NOT re-run during the finishing pass —
+> re-invoking `potential_to_issue` would have duplicated issue #495.
+
+## Problem / Why
+
+Child F12 of epic #136 owns the QuickFiler breadcrumb bridge surface: five compiled files totalling
+roughly 2,183 lines — `Controllers/BreadcrumbBridgeRouter.cs` (450),
+`Viewers/BreadcrumbBridgeCoordinator.cs` (487), `Viewers/BreadcrumbCoordinatorUpgradeLifetime.cs`
+(309), `Viewers/BreadcrumbItemViewerLifecycleCoordinator.cs` (481), and
+`Viewers/BreadcrumbMessengerHub.cs` (456).
+
+All five clear the 80% per-file line floor, which made this child look close to a no-op on the line
+column alone. It is not. `BreadcrumbItemViewerLifecycleCoordinator.cs` sits at **66.44% branch
+across 146 branch points** against the epic's 75% branch floor — the largest single branch gap in
+the epic. Branch coverage, not line coverage, is the binding gate here.
+
+## Proposed Behavior
+
+Raise every file in the F12 assignment above both the 80% line and 75% branch floors, verified by
+recomputation from class-level Cobertura `<line>` elements keyed on `filename=` (never from the
+emitted `line-rate` / `branch-rate` attributes, per issues #441 and #478). No production `.cs`
+change and no observable behavior change to QuickFiler flows: the child is test-only.
+
+## Outcome of Preparation (2026-08-08)
+
+Promotion, five per-file research artifacts (including a 1,204-line lifecycle-coordinator study and
+946/956/1,051-line studies of the router, messenger hub, and upgrade lifetime), `issue.md`,
+`spec.md` (AC-1..AC-16), `user-story.md` (US-1..US-8), and an 8-phase / 108-task atomic plan were
+produced. The plan passes the MCP plan validator and cleared `atomic-executor` preflight on the
+fourth round.
+
+Preparation spanned three runs: two were terminated by infrastructure failures (a spend limit, then
+an expired login) and their work was salvaged and committed. The third run carried only the
+preflight-clearance step to completion.
+
+Preflight surfaced and closed four blocking defects across four iterations: a Phase 2 execution
+count that no vstest run could satisfy, an omitted path-scoped `.claude/rules/csharp.md` policy
+read, a touched-test-file count that contradicted the task's own scope clause, and an AC-14
+confirmation clause that was unsatisfiable against the plan's own Phase 1. A csproj insertion point
+was also relocated after direct inspection showed it would have landed outside the breadcrumb block
+that a later audit task checks.
+
+Five latent defects were promoted to their own issues rather than left as feature-folder prose, per
+the epic's Latent Defect Promotion rule: **#498, #499, #500, #501, #502**.
+
+## Known Conflict Risk
+
+Open issue **#440** (`breadcrumb-left-right-arrow-parent-child-navigation`) names
+`BreadcrumbBridgeRouter` and `BreadcrumbBridgeCoordinator` and will rewrite the Left/Right arrow-key
+semantics this child's tests pin. Per the epic ruling, **F12's tests pin current behavior, not
+corrected behavior**, and cite #440 in an in-code doc comment so a future break is legible. Whoever
+schedules #440 should expect to update those tests as part of the fix rather than treat them as a
+regression.
+
+## Next Step
+
+- [x] Promote to GitHub issue (#495)
+- [x] Create the active feature folder
+- [x] Research, feature documents, and atomic plan
+- [x] `atomic-executor` preflight — `PREFLIGHT: ALL CLEAR`
+- [ ] Atomic execution — deferred to `epic-orchestrator` after F1 (#432) merges


### PR DESCRIPTION
# docs: restore 61 promoted potential records stranded on an unmerged branch

## Summary

- Restores 61 promoted potential-bug records that exist **only** on `origin/epic/quickfiler-per-file-coverage-integration`, a branch that is not an ancestor of `main`. Deleting that branch would have destroyed them.
- These records are the only complete requirements source for the 48-item QuickFiler bug corpus. The corresponding GitHub issue bodies are stubs, with several sections reading `(not provided in potential file)`.
- Strictly additive: **61 files added, 0 modified, 0 deleted**, all under `docs/features/potential/promoted/`. The 41 records already on `main` are untouched.
- Unblocks epic preparation for the QuickFiler corpus. Without these records, per-feature specs would be written against terse issue prose rather than grounded requirements.

## Why

An epic-planning pass over the QuickFiler bug corpus found that its requirements documents were missing from `main`. Verification confirmed the gap and showed it is larger than first reported:

```
potential docs on epic branch : 102
potential docs on main        :  61
present on branch, absent on main : 61
branch merged into main?          : NOT merged
```

The records are substantially richer than the issues they back. For issue #475:

| Source | Size | Content |
| --- | --- | --- |
| Potential record | 5,749 bytes | Summary, Environment, Suspected Cause, **Production Call Sites (verified 2026-08-07)**, Steps to Reproduce, Expected Behavior, Actual Behavior, Impact / Severity, Suggested Remediation |
| GitHub issue body | 2,452 bytes | Summary, with later sections reading `(not provided in potential file)` |

Two distinct risks are closed. First, data loss: 61 documents of analysis sat on an unmerged branch, and routine branch cleanup would have taken them. Second, planning quality: any specification derived from the issue bodies alone would lack the verified call sites and remediation guidance that make these defects actionable.

## What Changed

| Path | Change |
| --- | --- |
| `docs/features/potential/promoted/*.md` | 61 files added (5,592 lines) |

Nothing else. No code, configuration, test, workflow, or pushed-down `.claude` path is touched.

## Verification

### Completed

| Check | Result |
| --- | --- |
| Restore scope | `git status` reports exactly 61 entries, all `A` (added) |
| Path confinement | 0 paths outside `docs/features/potential/promoted/` |
| Overwrite safety | The 41 records present on both `main` and the source branch were excluded from the restore set, so no existing record is modified |
| Push-down safety | 0 restored paths under `.claude/` or `config/` — none is a push-down destination, so the next sync cannot revert this |
| Diff shape | `61 files changed, 5592 insertions(+)`, 0 deletions |
| Source provenance | Every file restored from `origin/epic/quickfiler-per-file-coverage-integration` by exact path, computed as the `comm -23` set difference against `main` |

### Not applicable

The C# toolchain (CSharpier, analyzers, nullable, MSTest) is not exercised: the diff is Markdown only, with no `*.cs`, `*.csproj`, `*.props`, `*.targets`, `*.config`, or workflow file. CI runs regardless and gates the merge.

## Backward Compatibility / Migration Notes

None. Adding Markdown records changes no public surface, build input, or runtime behavior. The source branch is left intact; this PR copies from it rather than merging it, so no unrelated change on that branch is pulled in.

## Risks and Mitigations

| Risk | Assessment | Mitigation |
| --- | --- | --- |
| A restored record contains stale line references | **Confirmed for at least six records** — `286.md` is off by +17 lines, `462.md` by +46; `474.md` asserts an interface premise that is already false because `IQfcFormController.cs:13` inherits `IFilerFormController`; `482.md` misattributes registries; `498.md` places two files in the wrong project; `440.md` claims a shared row type that does not exist | Recorded as known-stale in the epic manifest. Each preparation child re-derives its own line numbers rather than trusting the record. Restoring a record with a drifted reference is still strictly better than having no record |
| Restoring a promoted record for an already-closed issue | Possible; the set was computed by path difference, not by issue state | Harmless — these are historical provenance artifacts, and their value is the analysis, not the issue's open/closed state |
| Divergence from the source branch later | The branch remains unmerged and may continue to move | This PR is a point-in-time restore of records that were otherwise unreachable from `main`; it does not attempt to track the branch |

Rollback is `git revert` of the single commit, with no build or data implications.

## Review Guide

61 files, one commit, additive only. Reviewing every record is not a good use of time. Suggested approach:

1. Confirm the shape: `git diff --shortstat main..HEAD` should report `61 files changed, 5592 insertions(+)` with **zero deletions**. A deletion would mean the restore set was computed wrongly.
2. Confirm confinement: every path begins `docs/features/potential/promoted/`.
3. Spot-read one record — `2026-08-07-breadcrumb-capturecurrentortests-silently-degrades-in-production.md` (backing #475) — against the issue body, to confirm the records really are the richer source.

## Follow-ups

- The six drifted line references above are recorded in the epic manifest rather than fixed here; correcting them belongs with the child that touches each file, which will re-derive the line numbers anyway.
- Worth deciding the fate of `origin/epic/quickfiler-per-file-coverage-integration`. With these records on `main` it no longer holds unique requirements content, but it should be inspected for anything else unique before deletion.
- The wider gap is process rather than content: promoted records were written on a feature branch and never reached `main`. A check that a promoted record accompanies its issue onto the default branch would prevent a recurrence.

## GitHub Auto-close

- None

This restores documentation for issues that remain open; it fixes none of them, so no closing keyword applies.
