### PR TITLE
fix(638): guard the three unguarded archive-root reads in EfcDataModel

### DIFF
--- a/QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs
+++ b/QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs
@@ -1,0 +1,389 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using QuickFiler.Controllers;
+using QuickFiler.Helper_Classes;
+using UtilitiesCS;
+
+namespace QuickFiler.Test.Controllers
+{
+    /// <summary>
+    /// Issue #638 regression tests for the three unguarded <c>ArchiveRootPath</c> reads in
+    /// <see cref="EfcDataModel"/>. Each read sits inside an <c>EmailFilerConfig</c> object
+    /// initializer and previously let the archive-root guard's exception escape onto the UI
+    /// thread. Reachable through the assembly's existing InternalsVisibleTo("QuickFiler.Test").
+    /// </summary>
+    [TestClass]
+    public class EfcDataModelArchiveRootTests
+    {
+        // ArchiveRootPathGuard is internal to the TaskMaster assembly, so QuickFiler.Test
+        // cannot reference its constants. These two fields are verbatim copies of
+        // TaskMaster/AppGlobals/ArchiveRootPathGuard.cs UnresolvableRule and CrossStoreRule.
+        private const string UnresolvableRuleText =
+            "The Outlook archive root folder could not be resolved in the default store. The path is withheld from this message because it contains a mailbox address.";
+
+        private const string CrossStoreRuleText =
+            "The Outlook archive root resolved to a folder outside the composed archive root path, which indicates a cross-store or renamed archive. The paths are withheld from this message because they contain a mailbox address.";
+
+        private const string ArchiveRootLiteral = @"\\mailbox@example.com\Archive";
+
+        private const string MailboxAddress = "mailbox@example.com";
+
+        private const string DestinationStem = @"Clients\North";
+
+        /// <summary>
+        /// Scenario: the archive root cannot be resolved in the default store, so the guard
+        /// throws while the move configuration is being built.
+        /// Expected outcome: the move reports failure by returning false instead of letting the
+        /// exception escape onto the UI thread.
+        /// </summary>
+        [TestMethod]
+        public async Task MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing()
+        {
+            // Arrange
+            var olObjects = CreateOlObjects();
+            olObjects
+                .SetupGet(value => value.ArchiveRootPath)
+                .Throws(() => new InvalidOperationException(UnresolvableRuleText));
+            var globals = CreateGlobals(olObjects, SpecialFoldersWithOneDrive());
+            var dataModel = new TestableEfcDataModel(globals.Object);
+
+            // Act
+            bool moved = await MoveAsync(dataModel);
+
+            // Assert
+            moved.Should().BeFalse();
+        }
+
+        /// <summary>
+        /// Scenario: the archive root resolves to a folder outside the composed path, the second
+        /// documented throw condition of the archive-root guard.
+        /// Expected outcome: the move reports failure by returning false instead of throwing.
+        /// </summary>
+        [TestMethod]
+        public async Task MoveToFolderAsync_WhenArchiveRootIsCrossStoreUnresolvable_ReturnsFalseInsteadOfThrowing()
+        {
+            // Arrange
+            var olObjects = CreateOlObjects();
+            olObjects
+                .SetupGet(value => value.ArchiveRootPath)
+                .Throws(() => new InvalidOperationException(CrossStoreRuleText));
+            var globals = CreateGlobals(olObjects, SpecialFoldersWithOneDrive());
+            var dataModel = new TestableEfcDataModel(globals.Object);
+
+            // Act
+            bool moved = await MoveAsync(dataModel);
+
+            // Assert
+            moved.Should().BeFalse();
+        }
+
+        /// <summary>
+        /// Scenario: the Outlook folder-open path reads an unresolvable archive root.
+        /// Expected outcome: the call returns without throwing and raises exactly one
+        /// user-facing diagnostic through the injectable seam.
+        /// </summary>
+        [TestMethod]
+        public async Task OpenOlFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns()
+        {
+            // Arrange
+            var olObjects = CreateOlObjects();
+            olObjects
+                .SetupGet(value => value.ArchiveRootPath)
+                .Throws(() => new InvalidOperationException(UnresolvableRuleText));
+            var globals = CreateGlobals(olObjects, SpecialFoldersWithOneDrive());
+            var dataModel = new TestableEfcDataModel(globals.Object);
+            var reported = new List<string>();
+            dataModel.UserDiagnosticAction = text => reported.Add(text);
+
+            // Act
+            await dataModel.OpenOlFolderAsync(DestinationStem);
+
+            // Assert
+            reported.Should().ContainSingle();
+        }
+
+        /// <summary>
+        /// Scenario: the file-system folder-open path reads an unresolvable archive root.
+        /// Expected outcome: the call returns without throwing and raises exactly one
+        /// user-facing diagnostic through the injectable seam.
+        /// </summary>
+        [TestMethod]
+        public async Task OpenFsFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns()
+        {
+            // Arrange
+            var olObjects = CreateOlObjects();
+            olObjects
+                .SetupGet(value => value.ArchiveRootPath)
+                .Throws(() => new InvalidOperationException(UnresolvableRuleText));
+            var globals = CreateGlobals(olObjects, SpecialFoldersWithOneDrive());
+            var dataModel = new TestableEfcDataModel(globals.Object);
+            var reported = new List<string>();
+            dataModel.UserDiagnosticAction = text => reported.Add(text);
+
+            // Act
+            await dataModel.OpenFsFolderAsync(DestinationStem);
+
+            // Assert
+            reported.Should().ContainSingle();
+        }
+
+        /// <summary>
+        /// Scenario: an archive-root failure raises a user-facing diagnostic.
+        /// Expected outcome: the message carries neither the mailbox address nor the archive
+        /// root path, matching the redaction contract the archive-root guard already honours.
+        /// </summary>
+        [TestMethod]
+        public async Task ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress()
+        {
+            // Arrange
+            var olObjects = CreateOlObjects();
+            olObjects
+                .SetupGet(value => value.ArchiveRootPath)
+                .Throws(() => new InvalidOperationException(UnresolvableRuleText));
+            var globals = CreateGlobals(olObjects, SpecialFoldersWithOneDrive());
+            var dataModel = new TestableEfcDataModel(globals.Object);
+            var reported = new List<string>();
+            dataModel.UserDiagnosticAction = text => reported.Add(text);
+
+            // Act
+            await dataModel.OpenOlFolderAsync(DestinationStem);
+
+            // Assert
+            reported.Should().ContainSingle();
+            reported[0].Should().NotContain(MailboxAddress);
+            reported[0].Should().NotContain(ArchiveRootLiteral);
+        }
+
+        /// <summary>
+        /// Scenario: the archive root resolves normally, so the guard must not change the
+        /// success path.
+        /// Expected outcome: the archive root is read exactly once. The move still fails deeper
+        /// in the filer with a null reference, because the test mail helper carries no folder
+        /// information; that is the barrier that stops any second archive-root read.
+        /// </summary>
+        [TestMethod]
+        public async Task MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce()
+        {
+            // Arrange
+            var olObjects = CreateOlObjects();
+            olObjects.SetupGet(value => value.ArchiveRootPath).Returns(ArchiveRootLiteral);
+            var globals = CreateGlobals(olObjects, SpecialFoldersWithOneDrive());
+            var dataModel = new TestableEfcDataModel(globals.Object);
+            Func<Task> act = () => MoveAsync(dataModel);
+
+            // Act
+            await act.Should().ThrowAsync<NullReferenceException>();
+
+            // Assert
+            olObjects.VerifyGet(value => value.ArchiveRootPath, Times.Once());
+        }
+
+        /// <summary>
+        /// Scenario: no mail item is selected, so the model's mail information is null and the
+        /// method's first guard returns immediately.
+        /// Expected outcome: the move returns false and the archive root is never read.
+        /// </summary>
+        [TestMethod]
+        public async Task MoveToFolderAsync_WhenMailInfoIsNull_ReturnsFalseWithoutReadingArchiveRoot()
+        {
+            // Arrange
+            var olObjects = CreateOlObjects();
+            olObjects
+                .SetupGet(value => value.ArchiveRootPath)
+                .Throws(() => new InvalidOperationException(UnresolvableRuleText));
+            var globals = CreateGlobals(olObjects, SpecialFoldersWithOneDrive());
+            var dataModel = new EfcDataModel(
+                globals.Object,
+                null,
+                new CancellationTokenSource(),
+                CancellationToken.None
+            );
+
+            // Act
+            bool moved = await MoveAsync(dataModel);
+
+            // Assert
+            moved.Should().BeFalse();
+            olObjects.VerifyGet(value => value.ArchiveRootPath, Times.Never());
+        }
+
+        /// <summary>
+        /// Scenario: the OneDrive special folder is missing, so the OneDrive guard returns before
+        /// the archive-root read.
+        /// Expected outcome: the move returns false and the archive root is never read. This pins
+        /// the ordering constraint from the production side.
+        /// </summary>
+        [TestMethod]
+        public async Task MoveToFolderAsync_WhenOneDriveIsMissing_ReturnsFalseWithoutReadingArchiveRoot()
+        {
+            // Arrange
+            var olObjects = CreateOlObjects();
+            olObjects
+                .SetupGet(value => value.ArchiveRootPath)
+                .Throws(() => new InvalidOperationException(UnresolvableRuleText));
+            var globals = CreateGlobals(olObjects, SpecialFoldersWithoutOneDrive());
+            var dataModel = new TestableEfcDataModel(globals.Object);
+
+            // Act
+            bool moved = await MoveAsync(dataModel);
+
+            // Assert
+            moved.Should().BeFalse();
+            olObjects.VerifyGet(value => value.ArchiveRootPath, Times.Never());
+        }
+
+        /// <summary>
+        /// Scenario: the archive-root read fails with a COM failure rather than with the guard's
+        /// own exception type.
+        /// Expected outcome: the COM exception still propagates. The guard narrows only the
+        /// documented archive-root failure and must not become a broad catch.
+        /// </summary>
+        [TestMethod]
+        public async Task MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates()
+        {
+            // Arrange
+            var olObjects = CreateOlObjects();
+            olObjects
+                .SetupGet(value => value.ArchiveRootPath)
+                .Throws(() => new COMException("com failure"));
+            var globals = CreateGlobals(olObjects, SpecialFoldersWithOneDrive());
+            var dataModel = new TestableEfcDataModel(globals.Object);
+            Func<Task> act = () => MoveAsync(dataModel);
+
+            // Act / Assert
+            await act.Should().ThrowAsync<COMException>();
+        }
+
+        /// <summary>
+        /// Scenario: the OneDrive special folder is missing on the Outlook folder-open path.
+        /// Expected outcome: the call returns without throwing and never reads the archive root.
+        /// </summary>
+        [TestMethod]
+        public async Task OpenOlFolderAsync_WhenOneDriveIsMissing_ReturnsWithoutReadingArchiveRoot()
+        {
+            // Arrange
+            var olObjects = CreateOlObjects();
+            olObjects
+                .SetupGet(value => value.ArchiveRootPath)
+                .Throws(() => new InvalidOperationException(UnresolvableRuleText));
+            var globals = CreateGlobals(olObjects, SpecialFoldersWithoutOneDrive());
+            var dataModel = new TestableEfcDataModel(globals.Object);
+
+            // Act
+            await dataModel.OpenOlFolderAsync(DestinationStem);
+
+            // Assert
+            olObjects.VerifyGet(value => value.ArchiveRootPath, Times.Never());
+        }
+
+        /// <summary>
+        /// Scenario: the OneDrive special folder is missing on the file-system folder-open path.
+        /// Expected outcome: the call returns without throwing and never reads the archive root.
+        /// </summary>
+        [TestMethod]
+        public async Task OpenFsFolderAsync_WhenOneDriveIsMissing_ReturnsWithoutReadingArchiveRoot()
+        {
+            // Arrange
+            var olObjects = CreateOlObjects();
+            olObjects
+                .SetupGet(value => value.ArchiveRootPath)
+                .Throws(() => new InvalidOperationException(UnresolvableRuleText));
+            var globals = CreateGlobals(olObjects, SpecialFoldersWithoutOneDrive());
+            var dataModel = new TestableEfcDataModel(globals.Object);
+
+            // Act
+            await dataModel.OpenFsFolderAsync(DestinationStem);
+
+            // Assert
+            olObjects.VerifyGet(value => value.ArchiveRootPath, Times.Never());
+        }
+
+        /// <summary>
+        /// Invokes the five-argument move overload with the argument values every test in this
+        /// class shares, so no test repeats the argument list.
+        /// </summary>
+        private static Task<bool> MoveAsync(EfcDataModel dataModel)
+        {
+            return dataModel.MoveToFolderAsync(
+                DestinationStem,
+                saveAttachments: false,
+                saveEmail: false,
+                savePictures: false,
+                moveConversation: false
+            );
+        }
+
+        /// <summary>
+        /// A strict <see cref="IOlObjects"/> mock with no member configured. Callers add the
+        /// single archive-root behavior the scenario needs; every other member stays
+        /// unconfigured so an unexpected read fails loudly.
+        /// </summary>
+        private static Mock<IOlObjects> CreateOlObjects()
+        {
+            return new Mock<IOlObjects>(MockBehavior.Strict);
+        }
+
+        /// <summary>
+        /// A strict <see cref="IApplicationGlobals"/> mock whose <c>Ol</c> getter returns the
+        /// supplied Outlook seam and whose <c>FS</c> getter returns a stub exposing the supplied
+        /// special-folder dictionary.
+        /// </summary>
+        private static Mock<IApplicationGlobals> CreateGlobals(
+            Mock<IOlObjects> olObjects,
+            ConcurrentDictionary<string, string> specialFolders
+        )
+        {
+            var fileSystem = new Mock<IFileSystemFolderPaths>(MockBehavior.Strict);
+            fileSystem.SetupGet(value => value.SpecialFolders).Returns(specialFolders);
+
+            var globals = new Mock<IApplicationGlobals>(MockBehavior.Strict);
+            globals.SetupGet(value => value.Ol).Returns(olObjects.Object);
+            globals.SetupGet(value => value.FS).Returns(fileSystem.Object);
+            return globals;
+        }
+
+        /// <summary>A special-folder dictionary that resolves the OneDrive root.</summary>
+        private static ConcurrentDictionary<string, string> SpecialFoldersWithOneDrive()
+        {
+            var specialFolders = new ConcurrentDictionary<string, string>();
+            specialFolders["OneDrive"] = "OneDriveRoot";
+            return specialFolders;
+        }
+
+        /// <summary>A special-folder dictionary with no OneDrive entry.</summary>
+        private static ConcurrentDictionary<string, string> SpecialFoldersWithoutOneDrive()
+        {
+            return new ConcurrentDictionary<string, string>();
+        }
+
+        /// <summary>
+        /// The only arrangement in these tests that yields a non-null mail information snapshot
+        /// without an Outlook COM fixture. The base constructor receives a null mail item, so the
+        /// first-selection lookup absorbs the strict mock's failure on the unstubbed Outlook
+        /// application and builds no resolver; the derived constructor then assigns the protected
+        /// setter with a two-argument resolver, whose constructor stores its two fields and does
+        /// no work, carrying a parameterless <see cref="MailItemHelper"/> whose folder information
+        /// is null and which installs no lazy folder factory. The five-parameter resolver
+        /// constructor must not be used here: it builds its helper through the lazy factory, whose
+        /// materialization reads the archive root a second time.
+        /// </summary>
+        private sealed class TestableEfcDataModel : EfcDataModel
+        {
+            public TestableEfcDataModel(IApplicationGlobals globals)
+                : base(globals, null, new CancellationTokenSource(), CancellationToken.None)
+            {
+                ConversationResolver = new ConversationResolver(globals, null)
+                {
+                    MailHelper = new MailItemHelper(),
+                };
+            }
+        }
+    }
+}

--- a/QuickFiler.Test/QuickFiler.Test.csproj
+++ b/QuickFiler.Test/QuickFiler.Test.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Controllers\QfcQueuePurePathsTests.cs" />
     <Compile Include="Controllers\EfcDataModelIssue614Tests.cs" />
     <Compile Include="Controllers\EfcDataModelTests.cs" />
+    <Compile Include="Controllers\EfcDataModelArchiveRootTests.cs" />
     <Compile Include="Controllers\EfcFormControllerTests.cs" />
     <Compile Include="Controllers\EfcHomeControllerDependenciesTests.cs" />
     <Compile Include="Controllers\EfcHomeControllerDependenciesProductionFactoryTests.cs" />

--- a/QuickFiler/Controllers/EfcDataModel.cs
+++ b/QuickFiler/Controllers/EfcDataModel.cs
@@ -145,6 +145,14 @@ namespace QuickFiler.Controllers
 
         #region Public Properties
 
+        /// <summary>
+        /// Injectable sink for a user-facing diagnostic raised on a folder-open path.
+        /// Production never assigns this seam, so the default delegate shows the message
+        /// box; tests replace it with a capturing delegate so no modal dialog is shown and
+        /// the message text can be asserted.
+        /// </summary>
+        internal Action<string> UserDiagnosticAction { get; set; } = text => MessageBox.Show(text);
+
         private IApplicationGlobals _globals;
         public IApplicationGlobals Globals
         {
@@ -252,6 +260,42 @@ namespace QuickFiler.Controllers
             }
         }
 
+        /// <summary>
+        /// The user-facing text raised when the archive root cannot be resolved. It names no
+        /// path and no mailbox address, because both identify the user's mailbox.
+        /// </summary>
+        private const string ArchiveRootUnavailableMessage =
+            "Cannot open the folder because the Outlook archive root could not be resolved. "
+            + "The details are withheld from this message because they contain a mailbox address.";
+
+        /// <summary>
+        /// Reads the Outlook archive root exactly once and reports whether it resolved.
+        /// The archive-root validator raises <see cref="InvalidOperationException"/> when the
+        /// root is unresolvable or lies in another store; that is a recoverable user-facing
+        /// condition, so it is absorbed here rather than escaping onto the UI thread. Any other
+        /// failure, including a COM failure, still propagates.
+        /// </summary>
+        /// <param name="archiveRoot">The resolved archive root, or null on failure.</param>
+        /// <returns>True when the archive root resolved; otherwise false.</returns>
+        private bool TryGetArchiveRoot(out string archiveRoot)
+        {
+            try
+            {
+                archiveRoot = Globals.Ol.ArchiveRootPath;
+                return true;
+            }
+            catch (InvalidOperationException ex)
+            {
+                archiveRoot = null;
+                logger.Warn(
+                    "Cannot resolve the Outlook archive root. Details are withheld from this "
+                        + "message because they contain a mailbox address.",
+                    ex
+                );
+                return false;
+            }
+        }
+
         #endregion Public Properties
 
         #region Public Methods
@@ -279,6 +323,12 @@ namespace QuickFiler.Controllers
                 logger.Warn($"Cannot sort without OneDrive location");
                 return false;
             }
+
+            if (!TryGetArchiveRoot(out var olAncestor))
+            {
+                return false;
+            }
+
             var config = new EmailFilerConfig()
             {
                 SaveMsg = saveEmail,
@@ -286,7 +336,7 @@ namespace QuickFiler.Controllers
                 SavePictures = savePictures,
                 DestinationOlStem = folderpath,
                 Globals = Globals,
-                OlAncestor = Globals.Ol.ArchiveRootPath,
+                OlAncestor = olAncestor,
                 FsAncestorEquivalent = folderRoot,
             };
 
@@ -303,11 +353,17 @@ namespace QuickFiler.Controllers
                 return;
             }
 
+            if (!TryGetArchiveRoot(out var olAncestor))
+            {
+                UserDiagnosticAction(ArchiveRootUnavailableMessage);
+                return;
+            }
+
             var config = new EmailFilerConfig()
             {
                 DestinationOlStem = folderpath,
                 Globals = Globals,
-                OlAncestor = Globals.Ol.ArchiveRootPath,
+                OlAncestor = olAncestor,
                 FsAncestorEquivalent = oneDrive,
             };
 
@@ -321,11 +377,17 @@ namespace QuickFiler.Controllers
             {
                 return;
             }
+            if (!TryGetArchiveRoot(out var olAncestor))
+            {
+                UserDiagnosticAction(ArchiveRootUnavailableMessage);
+                return;
+            }
+
             var config = new EmailFilerConfig()
             {
                 DestinationOlStem = folderpath,
                 Globals = Globals,
-                OlAncestor = Globals.Ol.ArchiveRootPath,
+                OlAncestor = olAncestor,
                 FsAncestorEquivalent = oneDrive,
             };
 

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/code-review.2026-08-29T13-06.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/code-review.2026-08-29T13-06.md
@@ -1,0 +1,223 @@
+# Code Review — Issue #638 (EFC unguarded archive-root read)
+
+- **Branch:** `bug/efc-unguarded-archive-root-read-crashes-ui-thread-638`
+- **Base:** `ecdb1c84ba8541ab67042985919cfed4df768c01`
+- **Head:** `af1b36e2d93c6beeeb98bbe4998d752e1ebfd732`
+- **Review date:** 2026-08-29T13-06
+- **Scope:** full branch diff against the base — 3 source files and 35 feature-folder documents
+
+## Verdict
+
+**PASS. 0 blocking findings.** Seven non-blocking findings are recorded below: one Minor design
+observation, one Minor test-robustness finding, one Minor coverage-value finding, and four Trivial
+or informational items.
+
+The fix is close to the smallest change that resolves the defect. It reuses two shapes that already
+exist in this codebase — the `return false` degrade that the adjacent OneDrive guard uses, and the
+injectable `Action` seam that `EfcHomeController.MoveFailureMessageAction` uses — rather than
+inventing new ones. The catch is correctly narrowed by type, the guard ordering preserves both
+load-bearing invariants, and the user-facing text is redacted.
+
+## Findings
+
+| ID | Severity | Blocking | Area | Summary |
+|---|---|---|---|---|
+| CR-1 | Minor | No | Test robustness | `MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce` depends on a `NullReferenceException` thrown by an unrelated collaborator as its stopping barrier |
+| CR-2 | Minor | No | Test value | The two `InvalidOperationException` tests differ only by message text, and production dispatches by type, so the second exercises no additional production path |
+| CR-3 | Minor | No | Layering | The diagnostic seam's default delegate binds `EfcDataModel` to `MessageBox`, deepening a pre-existing UI coupling in a data-model class |
+| CR-4 | Trivial | No | Organization | `TryGetArchiveRoot` and `ArchiveRootUnavailableMessage` are declared inside `#region Public Properties` |
+| CR-5 | Trivial | No | Duplication | `UserDiagnosticAction(ArchiveRootUnavailableMessage)` is written out at both `Open*` call sites |
+| CR-6 | Informational | No | Test comment | The two rule-text constants are described as verbatim copies of another assembly's internals, implying a coupling that is not actually load-bearing |
+| CR-7 | Informational | No | Residual defect | Five equivalent unguarded reads remain in `EfcFormController`, one of them on a path with no local catch |
+
+### CR-1 — Success-path test uses an incidental crash as its barrier (Minor, non-blocking)
+
+`QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs:172-186` arranges a resolving archive
+root, then asserts:
+
+```csharp
+await act.Should().ThrowAsync<NullReferenceException>();
+olObjects.VerifyGet(value => value.ArchiveRootPath, Times.Once());
+```
+
+The `VerifyGet` is the assertion that matters — it is what pins AC7's single-read invariant. The
+`ThrowAsync<NullReferenceException>()` above it is not a property of the unit under test; it is the
+`EmailFiler` collaborator dereferencing a `MailItemHelper` whose folder information is null, several
+frames past the code this change touches. The fixture's XML doc is honest about this and explains
+precisely why the arrangement is shaped that way, which is better than most tests of this kind. The
+concern is durability rather than correctness: if `EmailFiler.SortAsync` later gains a null guard and
+returns `false` instead of throwing, this test fails with a message about an expected
+`NullReferenceException`, which points a future maintainer at the wrong subsystem entirely.
+
+The test is also the only one that reaches line 339 (`OlAncestor = olAncestor,` on the move path), so
+losing it would drop changed-line coverage from 93.10 to roughly 89.7 percent.
+
+Suggested direction, for a follow-up rather than for this change: introduce a filer-construction seam
+on `EfcDataModel` so the success path can terminate deliberately, and then assert only the
+`VerifyGet`. That is a larger change than the Bugfix Workflow permits here.
+
+### CR-2 — The second throw-condition test adds coverage without discriminating power (Minor, non-blocking)
+
+`MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing` and
+`MoveToFolderAsync_WhenArchiveRootIsCrossStoreUnresolvable_ReturnsFalseInsteadOfThrowing` are
+identical except for the message string carried by the injected `InvalidOperationException`
+(`UnresolvableRuleText` versus `CrossStoreRuleText`). `TryGetArchiveRoot` dispatches on exception
+*type* and never inspects the message, so both tests drive exactly the same production statements. A
+defect that broke one would break both; neither can fail while the other passes.
+
+This is not a defect in the change. `spec.md` AC9 asks that both documented throw conditions be
+exercised, and at the `IOlObjects.ArchiveRootPath` seam the only observable difference between the
+two conditions *is* the message. A stronger test is not constructible without moving the assertion up
+into `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs`, where
+`TaskMaster.Test/AppGlobals/AppOlObjectsArchiveRootValidationTests.cs` already pins both conditions
+and which this change correctly leaves untouched. The finding is recorded so that the AC9 evidence is
+understood for what it is: documentation that the guard is message-agnostic, not an independent
+second proof.
+
+### CR-3 — The seam default couples the data model to `MessageBox` (Minor, non-blocking)
+
+`QuickFiler/Controllers/EfcDataModel.cs:154`:
+
+```csharp
+internal Action<string> UserDiagnosticAction { get; set; } = text => MessageBox.Show(text);
+```
+
+The General Code Change Policy's fourth design principle asks that pure logic be kept separate from
+UI. A data-model class that owns a default `MessageBox.Show` is on the wrong side of that line.
+
+Three facts make this an accepted trade-off rather than a defect, and they are worth recording so the
+decision is not silently re-litigated:
+
+1. It is not new coupling. `System.Windows.Forms` was already imported at
+   `QuickFiler/Controllers/EfcDataModel.cs:10` and `MessageBox.Show` is already called at `:417`, in
+   the pre-existing `MAPIFolder` overload of `MoveToFolderAsync`. The change matches existing style,
+   as § 7.1 of the policy requires.
+2. The alternative was evaluated and rejected on stronger grounds. `spec.md` § Backward-compatibility
+   records that widening `OpenOlFolderAsync` and `OpenFsFolderAsync` to `Task<bool>` would leave all
+   five production call sites discarding the value, converting one silent-swallow site into five.
+3. The seam makes the coupling testable and overridable, which is exactly what the class previously
+   lacked at `:417` — that call site is still a hard-coded modal dialog and remains uncoverable.
+
+A future cleanup could hoist the reporting responsibility into `EfcHomeController`, which already owns
+`MoveFailureMessageAction`, and let `EfcDataModel` stay UI-free. That belongs with follow-up issue
+#697, which covers the reporting surface at the boundaries.
+
+### CR-4 — Private members declared under a "Public Properties" region (Trivial, non-blocking)
+
+`ArchiveRootUnavailableMessage` (`:264-268`) and `TryGetArchiveRoot` (`:270-296`) sit inside the
+`#region Public Properties` block that closes at `:299`. One is a private constant and the other is a
+private method, so neither belongs there. `UserDiagnosticAction` at `:154` is a property and is
+`internal`, so its placement is defensible.
+
+The file already carries a `#region Public Methods` and a `#region Constructors and Initializers`, so
+the convention exists to follow. Moving the two members to a private-helpers region would cost three
+lines and would not affect any gate. Suggested for a later touch of this file, not for this change.
+
+### CR-5 — Diagnostic invocation duplicated across the two `Open*` call sites (Trivial, non-blocking)
+
+```csharp
+if (!TryGetArchiveRoot(out var olAncestor))
+{
+    UserDiagnosticAction(ArchiveRootUnavailableMessage);
+    return;
+}
+```
+
+appears verbatim at `:356-360` and `:380-384`. Two occurrences is at the low end of what the
+"avoid copy-paste" rule targets, and keeping the invocation at the call site rather than inside
+`TryGetArchiveRoot` is a defensible choice: it keeps the helper free of UI concerns, which is why
+`MoveToFolderAsync` can use the same helper without raising a dialog. Recorded as an observation, not
+a change request.
+
+One asymmetry is worth noting for readability: `OpenOlFolderAsync` separates its two guards with a
+blank line (`:354-355`) while `OpenFsFolderAsync` does not (`:379-380`). CSharpier does not normalize
+this, so it is a hand-formatting inconsistency between two adjacent, otherwise identical methods.
+
+### CR-6 — The copied rule-text constants imply a coupling that is not load-bearing (Informational)
+
+`QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs:25-32` carries a comment stating that
+`UnresolvableRuleText` and `CrossStoreRuleText` are "verbatim copies" of the constants in
+`TaskMaster/AppGlobals/ArchiveRootPathGuard.cs`. That reads as a maintenance obligation, but no
+assertion in the file compares against the real constants — the two strings are only payloads for
+`new InvalidOperationException(...)`, and production never inspects them. If the real constants change
+the copies will drift and every test will keep passing, correctly, because nothing depends on the
+equality. Rewording the comment to say the strings are *representative of* the guard's messages rather
+than copies of them would prevent a future maintainer from believing a sync obligation exists.
+
+The redaction test, `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress`, does
+not depend on these constants either: it asserts over the *seam's* captured message, which is
+`ArchiveRootUnavailableMessage`, against the `mailbox@example.com` and archive-path literals declared
+locally at `:34-36`. That is the right target — it verifies the change's own output rather than the
+upstream guard's.
+
+### CR-7 — Equivalent unguarded reads remain in `EfcFormController` (Informational, filed as #698)
+
+Confirmed present at head and correctly excluded from this change's scope:
+`QuickFiler/Controllers/EfcFormController.cs:529`, `:539`, `:836`, `:846` and `:987` all read
+`_globals.Ol.ArchiveRootPath` without a guard. The `:836` and `:846` pair sits in `CreateFolderAsync`,
+which has no local `try`/`catch`; that path is reached from the keyboard `'N'` binding and terminates
+in `KeyboardHandler`'s log-only catch, so the same silent-swallow symptom this issue fixed in
+`EfcDataModel` is still reachable there.
+
+This is exactly non-goal (c) in `spec.md` § Scope & Non-Goals and is filed as issue #698 with all five
+citations re-derived in `evidence/other/p8-t2-followup-issue-dossier.md`. It is recorded here only so a
+reader of the diff does not mistake the remaining reads for an incomplete fix. The `EfcDataModel`
+helper the dossier proposes those five sites adopt is the one this change introduces.
+
+## What the change does well
+
+- **The `try` placement problem is solved cleanly.** All three reads sit syntactically inside
+  `EmailFilerConfig` object initializers, where a `try` cannot be written without restructuring. The
+  `bool TryGetArchiveRoot(out string)` shape lifts the read out of the initializer, keeps the
+  initializer a single assignment from a local, and reads naturally next to the existing
+  `Globals.FS.SpecialFolders.TryGetValue(...)` guard directly above it.
+- **Guard ordering is correct in all three methods and pinned from both sides.** The `MailInfo is
+  null` check remains first in `MoveToFolderAsync` (`:311-314`); the OneDrive `SpecialFolders` read is
+  second (`:321-325`); the archive-root guard is third (`:327-330`). Both `Open*` methods place the
+  new guard after their OneDrive guard. The ordering is asserted from the production side by three
+  `VerifyGet(..., Times.Never())` tests and from the untouched side by
+  `EfcHomeControllerLifecycleTests.cs:217`'s `SpecialFoldersAccessCount.Should().Be(2)`, which still
+  passes with that file unmodified. Reversing the order would have broken that assertion two ways at
+  once — the count would drop to 0, and the probe's null `Ol` would raise a `NullReferenceException`
+  the narrow catch cannot absorb.
+- **The catch is narrow by type and the narrowness is pinned by a test.**
+  `catch (InvalidOperationException ex)` at `:287`, with
+  `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates` asserting that a
+  `COMException` from the same getter is not absorbed. That keeps follow-up issue #696 visible rather
+  than silently swallowing it, and it satisfies the fail-fast rule.
+- **No degradation to an empty root.** The failure branch returns before `new EmailFiler(config)` at
+  `:343`, `:370` and `:394`, so no partially populated `EmailFilerConfig` is constructed and
+  `OlAncestor` is never assigned an empty or synthesized value. That avoids reintroducing the #614
+  store-root-leak failure mode.
+- **Redaction is preserved in both channels.** `ArchiveRootUnavailableMessage` names the rule and
+  withholds the path; `logger.Warn` passes a redacted string plus the exception object rather than
+  interpolating the exception message into user-visible text.
+- **The single-read performance invariant is honoured and pinned.** `Globals.Ol.ArchiveRootPath` is
+  COM-backed on first resolution, so a double read would add a real round trip. The helper reads once
+  and `VerifyGet(..., Times.Once())` pins it.
+- **The fixture design is documented rather than merely working.** `TestableEfcDataModel`'s XML doc
+  explains why the two-argument `ConversationResolver` constructor is required and states that the
+  five-argument constructor would materialize its helper through the lazy factory and read the archive
+  root a second time. That is the kind of comment the "why, not what" rule asks for, and it prevents a
+  future maintainer from making the change that silently breaks AC7.
+- **The new test file is registered and proven registered.** Both projects are legacy non-SDK and
+  enumerate every source file. The `<Compile Include>` entry was added, and the evidence goes further
+  than asserting the line exists: it confirms all 11 tests appear in the full-suite TRX, which is the
+  only thing that distinguishes a registered file from a silently absent one.
+
+## Diff hygiene
+
+- No unused `using` directive was added; all 12 imports in the new test file are consumed
+  (`System.Runtime.InteropServices` by the `COMException` test,
+  `System.Collections.Concurrent` by the special-folder dictionaries,
+  `QuickFiler.Helper_Classes` by `ConversationResolver`, and `UtilitiesCS` by `MailItemHelper`,
+  `IApplicationGlobals`, `IOlObjects` and `IFileSystemFolderPaths`).
+- No commented-out code, no `TODO`, no debug output added.
+- No `#pragma warning disable`, `[SuppressMessage]` or `[ExcludeFromCodeCoverage]` added.
+- No absolute filesystem path, account name or machine name appears in either source file or in any
+  of the 35 feature-folder documents; verified by recursive case-insensitive grep.
+- The `.csproj` edit is a single line inserted in alphabetical proximity to the two sibling
+  `EfcDataModel` test registrations; no other project property was touched, and CSharpier is not
+  applied to `*.csproj` (`.csharpierignore:12`), so no formatter churn was introduced there.
+- Both changed source files are under the 500-line cap: 485 and 389. `EfcDataModel.cs` has 15 lines
+  of headroom remaining, which is worth remembering before the next addition to that file.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t10-msbuild-analyzers.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t10-msbuild-analyzers.md
@@ -1,0 +1,35 @@
+# [P0-T10] MSBuild analyzer baseline (Issue 638)
+
+Timestamp: 2026-08-29T12-18
+
+Command:
+
+```
+$mb = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" | Select-Object -First 1
+& $mb TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true 2>&1 | Tee-Object -FilePath 'TestResults\msbuild\p0-t10.log'
+```
+
+The MSBuild path is recorded unresolved, as the vswhere expression, because the resolved
+path is absolute. The `| Select-Object -First 1` suffix is present because `-find` can
+emit several matching paths.
+
+EXIT_CODE: 0
+
+Output Summary:
+
+MSBuild's own summary lines, quoted verbatim:
+
+```
+    5 Warning(s)
+    0 Error(s)
+```
+
+BASELINE_ANALYZER_ERRORS: 0
+
+The baseline is clean, so the [P6-T3] acceptance of `0 Error(s)` is reachable. Console
+output was tee'd to `TestResults\msbuild\p0-t10.log`, which `.gitignore:39`
+(`[Tt]est[Rr]esult*/`) keeps outside the diff.
+
+`scripts/vscode/Invoke-VSBuild.ps1` was not invoked: it runs
+`scripts/vscode/Sync-PackageReferences.ps1` over every `.csproj` and would rewrite project
+files outside this change footprint.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t11-msbuild-nullable.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t11-msbuild-nullable.md
@@ -1,0 +1,30 @@
+# [P0-T11] MSBuild nullable baseline (Issue 638)
+
+Timestamp: 2026-08-29T12-19
+
+Command:
+
+```
+$mb = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" | Select-Object -First 1
+& $mb TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:TreatWarningsAsErrors=true 2>&1 | Tee-Object -FilePath 'TestResults\msbuild\p0-t11.log'
+```
+
+Same vswhere-resolved MSBuild as [P0-T10], including the `| Select-Object -First 1`
+suffix. The command carries neither `/p:Nullable=enable` nor `/t:Build`.
+
+EXIT_CODE: 0
+
+Output Summary:
+
+MSBuild's summary lines, quoted verbatim:
+
+```
+    5 Warning(s)
+    0 Error(s)
+```
+
+BASELINE_NULLABLE_ERRORS: 0
+
+The baseline is clean, so the [P6-T4] acceptance of `0 Error(s)` is reachable. Console
+output was tee'd to `TestResults\msbuild\p0-t11.log`, outside the diff under
+`.gitignore:39`.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t12-direct-harness-baseline.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t12-direct-harness-baseline.md
@@ -1,0 +1,81 @@
+# [P0-T12 companion] Direct-harness baseline failure set (Issue 638)
+
+Timestamp: 2026-08-29T12-23
+
+Command:
+
+```
+$vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -find "Common7\IDE\Extensions\TestPlatform\vstest.console.exe" | Select-Object -First 1
+# assembly list built by the [P6-T5] rules (see below)
+& $vs <assembly list> /EnableCodeCoverage /InIsolation /Logger:trx /ResultsDirectory:TestResults\p0-t12-direct /TestCaseFilter:"TestCategory!=LiveOutlook"
+```
+
+The `vstest.console.exe` path is recorded unresolved, as the vswhere expression, because
+the resolved path is absolute. The run was launched through `Start-Process -Wait
+-NoNewWindow`, with output redirected to `TestResults\p0-t12-direct.out.log` and
+`TestResults\p0-t12-direct.err.log` (gitignored under `.gitignore:39`).
+
+EXIT_CODE: 0
+
+`ExpectedExitCode:` is omitted, per the task rule: this run exited 0 and its
+`BASELINE_FAILURE_SET:` is the literal `none`.
+
+Output Summary:
+
+## Assembly list
+
+Built by the [P6-T5] rules: `Get-ChildItem -Path . -Recurse -Filter '*.Test.dll'`, keeping
+only paths under `\bin\Debug\`, rejecting paths under `\obj\` or `\ref\`, and rejecting
+only **relative** paths containing `\.claude\`, where the relative path is computed as
+`$_.FullName.Substring((Get-Location).Path.Length)`.
+
+DISCOVERED_ASSEMBLY_COUNT: 9
+
+```
+\QuickFiler.Test\bin\Debug\QuickFiler.Test.dll
+\SVGControl.Test\bin\Debug\SVGControl.Test.dll
+\Tags.Test\bin\Debug\Tags.Test.dll
+\TaskMaster.Test\bin\Debug\TaskMaster.Test.dll
+\TaskTree.Test\bin\Debug\TaskTree.Test.dll
+\TaskVisualization.Test\bin\Debug\TaskVisualization.Test.dll
+\ToDoModel.Test\bin\Debug\ToDoModel.Test.dll
+\UtilitiesCS.Test\bin\Debug\UtilitiesCS.Test.dll
+\VBFunctions.Test\bin\Debug\VBFunctions.Test.dll
+```
+
+## Direct-harness counts
+
+```
+DIRECT_HARNESS_TOTAL_TESTS: 6859
+DIRECT_HARNESS_PASSED:      6859
+DIRECT_HARNESS_FAILED:      0
+DIRECT_HARNESS_SKIPPED:     0
+```
+
+The runner emitted `Test Run Successful.` and no `Failed:` or `Skipped:` summary line, so
+both counts are 0. Total time reported: 51.7657 seconds.
+
+## BASELINE_FAILURE_SET
+
+BASELINE_FAILURE_SET: none
+
+This is the carve-out list [P6-T5] consumes. It is empty, so [P6-T5] admits no
+baseline exception and [P8-T18] can only take the AC16 check-off branch if [P6-T5] itself
+records `Failed: 0` for both namespaces.
+
+## Divergence against the coverage-harness run
+
+COVERAGE_HARNESS_FAILURE_SET (copied from `p0-t12-vstest-coverage.md`):
+`QuickFiler.Controllers.Tests.QfcDatamodelLivenessTests.RemainingLoadActive_WhenLoaderThrows_IsStillClearedByFinally`
+
+Tests appearing in one set and not the other:
+
+- `QuickFiler.Controllers.Tests.QfcDatamodelLivenessTests.RemainingLoadActive_WhenLoaderThrows_IsStillClearedByFinally`
+  — present in `COVERAGE_HARNESS_FAILURE_SET:`, absent from `BASELINE_FAILURE_SET:`.
+
+Both runs executed the same 6859 tests. The divergence is therefore a test whose outcome
+depends on the instrumentation path rather than on any source change: it asserts that a
+started worker reaches an injected loader within a five-second wall-clock wait, and the
+`dotnet-coverage`-instrumented harness is slower than the direct
+`vstest.console.exe /EnableCodeCoverage` harness. It is not a defect introduced by this
+change, which had not yet been made when both runs executed.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t12-vstest-coverage.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t12-vstest-coverage.md
@@ -1,0 +1,103 @@
+# [P0-T12] Baseline test suite in coverage mode (Issue 638)
+
+Timestamp: 2026-08-29T12-20
+
+Command: `pwsh -NoProfile -File scripts/vscode/Invoke-MSTestWithCoverage.ps1 -SearchRoot . -Configuration Debug -CoverageOutput coverage/coverage.cobertura.xml`
+
+Run through `Start-Process -Wait -NoNewWindow`, with standard output and standard error
+redirected to `TestResults\p0-t12-harness.out.log` and `TestResults\p0-t12-harness.err.log`
+(gitignored under `.gitignore:39`), because the full suite takes longer than a single
+foreground command window is reliable for.
+
+EXIT_CODE: 1
+
+`ExpectedExitCode:` is deliberately **not** declared. See "Exit-code justification" below.
+
+Output Summary:
+
+## vstest counts observed in this coverage-harness run
+
+```
+Total tests: 6859
+     Passed: 6858
+     Failed: 1
+```
+
+`Skipped:` was not emitted by the runner for this run, so the skipped count is 0.
+
+Total time reported: 46.7143 seconds.
+
+## COVERAGE_HARNESS_FAILURE_SET
+
+COVERAGE_HARNESS_FAILURE_SET: `QuickFiler.Controllers.Tests.QfcDatamodelLivenessTests.RemainingLoadActive_WhenLoaderThrows_IsStillClearedByFinally`
+
+The recorded failure message is a FluentAssertions timing assertion:
+
+```
+Expected entered.Task.Wait(TimeSpan.FromSeconds(5)) to be True because the started worker must reach the injected loader, but found False.
+```
+
+The stack trace is deliberately not reproduced here: its frames carry absolute source
+paths, and no artifact this plan writes may contain an absolute filesystem path, an account
+name or a machine name. The exception surface is a FluentAssertions assertion failure
+raised from a five-second wall-clock wait, in a test unrelated to the archive-root read
+sites this change touches.
+
+`BASELINE_FAILURE_SET:` is **not** set from this run. It is set in the companion artifact
+`p0-t12-direct-harness-baseline.md` from the second, direct-harness run, so that the
+carve-out list [P6-T5] consumes is commensurable with the harness that gates it.
+
+## Coverage
+
+Read from the root `coverage` element of `coverage/coverage.cobertura.xml`:
+
+```
+line-rate      = 0.7069679346308415
+branch-rate    = 0.5934052103872132
+lines-covered  = 58228
+lines-valid    = 82363
+package count  = 14
+```
+
+BASELINE_REPO_LINE_COVERAGE_PERCENT: 70.70
+
+COVERAGE_XML_MODE: raw
+
+The script exited non-zero, so per the task rule the mode is `raw`.
+`scripts/vscode/Invoke-MSTestWithCoverage.ps1:341` asserts the threshold on the
+post-processed content and `:343` writes that content back only afterwards; this run
+terminated at `:236`, well before either, so the file on disk carries the raw
+`dotnet-coverage` root attributes computed over every instrumented module — including the
+fourteen packages listed, which contain `.Test` assemblies that
+`scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1:417-421` would have removed and
+`:442-445` would have recomputed around.
+
+## Exit-code justification — REMEDIATION-REQUIRED
+
+The task text authorizes `ExpectedExitCode: 1` only when the terminating message emitted by
+`scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1:489` — the one ending with the
+literal `is below the required 80% threshold.` — is present in the run output.
+
+A `Select-String -SimpleMatch 'is below the required 80% threshold.'` over both redirected
+logs returned **0** matches. The literal is absent.
+
+The non-zero exit came from a different cause. The terminating message was raised at
+`scripts/vscode/Invoke-MSTestWithCoverage.ps1:236`:
+
+```
+MSTest with coverage failed with exit code 1
+```
+
+preceded by `Test Run Failed.` — that is, the single failing test above, not the coverage
+threshold. The script therefore never reached its `:341` threshold assert.
+
+Per the task's own branch, this artifact records the observed `EXIT_CODE:` without an
+`ExpectedExitCode:` field, and the task outcome is:
+
+REMEDIATION-REQUIRED: [P0-T12] coverage-harness run exited 1 for a cause other than the
+80 percent coverage threshold — one pre-existing failing test,
+`QuickFiler.Controllers.Tests.QfcDatamodelLivenessTests.RemainingLoadActive_WhenLoaderThrows_IsStillClearedByFinally`,
+which is a five-second wall-clock timing assertion in a test file this change does not
+touch. The numeric coverage value required by the acceptance is still readable and is
+recorded above, and both `COVERAGE_XML_MODE:` and `COVERAGE_HARNESS_FAILURE_SET:` are
+recorded, so the artifact's own field-completeness acceptance is met.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t6-dotnet-tool-restore.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t6-dotnet-tool-restore.md
@@ -1,0 +1,39 @@
+# [P0-T6] dotnet tool restore (Issue 638)
+
+Timestamp: 2026-08-29T12-17
+
+Command: `dotnet tool restore` (run from the worktree root)
+
+EXIT_CODE: 0
+
+Output Summary:
+
+Two invocations were required, in the order the task text authorizes.
+
+1. First invocation of `dotnet tool restore` failed. The repo-local .NET SDK directory
+   named in `global.json:7` was absent in this fresh worktree, and the muxer reported:
+
+   ```
+   The command could not be loaded, possibly because:
+     * You intended to execute a .NET application:
+         The application 'tool' does not exist or is not a managed .dll or .exe.
+     * You intended to execute a .NET SDK command:
+         The repo-local .NET SDK is missing. Run ./scripts/vscode/Install-RepoDotNetSdk.ps1 from the repository root, then retry dotnet format TaskMaster.sln.
+   ```
+
+2. `pwsh -NoProfile -File scripts/vscode/Install-RepoDotNetSdk.ps1` was run and exited 0:
+
+   ```
+   Downloading .NET SDK 8.0.205 from https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.205/dotnet-sdk-8.0.205-win-x64.zip...
+   Installed repo-local .NET SDK 8.0.205 to <worktree-root>\.dotnet-sdk.
+   ```
+
+3. `dotnet tool restore` was retried and exited 0:
+
+   ```
+   Tool 'csharpier' (version '1.2.6') was restored. Available commands: csharpier
+
+   Restore was successful.
+   ```
+
+CSharpier version restored: **1.2.6**, matching the `dotnet-tools.json:6` pin.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t7-solution-restore.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t7-solution-restore.md
@@ -1,0 +1,92 @@
+# [P0-T7] Solution restore and analyzer skew resolution (Issue 638)
+
+Timestamp: 2026-08-29T12-20
+
+Command: `pwsh -NoProfile -File scripts/vscode/Invoke-Restore.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform "Any CPU"`
+
+EXIT_CODE: 0
+
+Output Summary:
+
+## 1. Solution restore
+
+The restore reported:
+
+```
+    Installed:
+        172 package(s) to packages.config projects
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+```
+
+This materialized the previously absent repository-root `packages/` directory.
+
+## 2. Analyzer wiring comparison
+
+`Select-String -Path 'QuickFiler.Test/QuickFiler.Test.csproj' -SimpleMatch 'Meziantou.Analyzer.','Roslynator.Analyzers.' | ForEach-Object { $_.Line.Trim() }`
+returned seven matches. Two are excluded from the comparison per the task text, because
+they are not `<Analyzer Include>` items and name the packages.config version rather than
+the analyzer-item version:
+
+- `:3` — `<Import Project="..\packages\Meziantou.Analyzer.3.0.174\build\Meziantou.Analyzer.props" ... />`
+- `:490` — `<Error Condition="!Exists('..\packages\Meziantou.Analyzer.3.0.174\build\Meziantou.Analyzer.props')" ... />`
+
+The five `<Analyzer Include>` items considered are:
+
+- `:499` — `..\packages\Meziantou.Analyzer.3.0.156\analyzers\dotnet\roslyn5.0\cs\Meziantou.Analyzer.dll`
+- `:500` — `..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator.CSharp.Analyzers.dll`
+- `:501` — `..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Common.dll`
+- `:502` — `..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.Core.dll`
+- `:503` — `..\packages\Roslynator.Analyzers.4.16.0\analyzers\dotnet\roslyn4.7\cs\Roslynator_Analyzers_Roslynator.CSharp.dll`
+
+`QuickFiler.Test/packages.config` pins `Meziantou.Analyzer` to `version="3.0.174"` at
+`:11-12` and `Roslynator.Analyzers` to `version="4.16.1"` at `:140-141`, so the restore
+installed `packages/Meziantou.Analyzer.3.0.174` and `packages/Roslynator.Analyzers.4.16.1`
+and neither `<Analyzer Include>` directory existed.
+
+## 3. ANALYZER_SKEW — first check (before remediation)
+
+ANALYZER_SKEW: `Meziantou.Analyzer.3.0.156`, `Roslynator.Analyzers.4.16.0`
+
+Directory existence, first check:
+
+```
+packages/Meziantou.Analyzer.3.0.156  : False
+packages/Roslynator.Analyzers.4.16.0 : False
+packages/Meziantou.Analyzer.3.0.174  : True
+packages/Roslynator.Analyzers.4.16.1 : True
+```
+
+## 4. Remediation
+
+```
+nuget install Meziantou.Analyzer -Version 3.0.156 -OutputDirectory packages   -> exit 0
+nuget install Roslynator.Analyzers -Version 4.16.0 -OutputDirectory packages  -> exit 0
+```
+
+Both reported `Successfully installed ... to <worktree-root>\packages`.
+
+## 5. ANALYZER_SKEW — second check (after remediation)
+
+ANALYZER_SKEW: none
+
+Directory existence, second check:
+
+```
+packages/Meziantou.Analyzer.3.0.156  : True
+packages/Roslynator.Analyzers.4.16.0 : True
+```
+
+Both of the two ids this task inspects (`Meziantou.Analyzer` and `Roslynator.Analyzers`)
+now resolve.
+
+## 6. Tracked-file impact
+
+`git status --porcelain -- '*.csproj' '*/packages.config' 'packages'` output, verbatim:
+
+```
+```
+
+The output is empty. The remediation touched no tracked file; `.gitignore:191` ignores
+`**/[Pp]ackages/*`.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t8-dotnet-coverage-probe.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t8-dotnet-coverage-probe.md
@@ -1,0 +1,23 @@
+# [P0-T8] dotnet-coverage probe (Issue 638)
+
+Timestamp: 2026-08-29T12-21
+
+Command: `Get-Command dotnet-coverage -ErrorAction SilentlyContinue`
+
+EXIT_CODE: 0
+
+Resolution: already present
+
+Output Summary:
+
+`Get-Command dotnet-coverage` resolved the global tool, so no
+`dotnet tool install --global dotnet-coverage` was required.
+
+`dotnet-coverage --version` reported:
+
+```
+18.5.2+6e39b75eaf98f2691cf62dbf259669cc13851fd3
+```
+
+Resolved `dotnet-coverage` version string: **18.5.2**
+(commit `6e39b75eaf98f2691cf62dbf259669cc13851fd3`).

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t9-csharpier-check.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t9-csharpier-check.md
@@ -1,0 +1,28 @@
+# [P0-T9] CSharpier baseline check (Issue 638)
+
+Timestamp: 2026-08-29T12-23
+
+Command: `dotnet tool run csharpier check .` (run from the worktree root)
+
+EXIT_CODE: 0
+
+Output Summary:
+
+Final summary line, quoted verbatim:
+
+```
+Checked 1560 files in 4829ms.
+```
+
+That line's N is the number of files processed, not the number of unformatted files. The
+unformatted count is derived from the `Error <path> - Was not formatted.` lines, of which
+the run emitted none.
+
+BASELINE_UNFORMATTED_COUNT: 0
+
+BASELINE_UNFORMATTED_FILES: none
+
+Consequence for later phases: [P6-T1] takes the unscoped branch and runs
+`dotnet tool run csharpier format .` against `.` as written; [P6-T2]'s acceptance is
+`EXIT_CODE: 0`; and [P8-T15] takes the AC13 check-off branch rather than the
+REMEDIATION-REQUIRED branch, provided [P6-T2] records `EXIT_CODE: 0`.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p1-t4-tree-facts.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p1-t4-tree-facts.md
@@ -1,0 +1,66 @@
+# [P1-T4] Pre-change tree facts (Issue 638)
+
+Timestamp: 2026-08-29T12-25
+
+Command: `(Get-Content -LiteralPath 'QuickFiler/Controllers/EfcDataModel.cs').Count`
+
+`Measure-Object -Line` was deliberately not used: it reports a different figure for a file
+with a trailing newline.
+
+EXIT_CODE: 0
+
+Output Summary:
+
+PRECHANGE_EFCDATAMODEL_LINE_COUNT: 423
+
+HEADROOM_TO_CAP: 77
+
+The four re-derived facts from [P1-T1] through [P1-T4], each against the working tree of
+this worktree at branch head `f07b6299`:
+
+## [P1-T1] The three unguarded archive-root read sites
+
+`Select-String -Path 'QuickFiler/Controllers/EfcDataModel.cs' -SimpleMatch 'OlAncestor = Globals.Ol.ArchiveRootPath'`
+returned exactly three matches:
+
+```
+LINE 289: OlAncestor = Globals.Ol.ArchiveRootPath,
+LINE 310: OlAncestor = Globals.Ol.ArchiveRootPath,
+LINE 328: OlAncestor = Globals.Ol.ArchiveRootPath,
+```
+
+Line numbers 289, 310 and 328 match the plan's Verified Facts exactly. They sit inside the
+`EmailFilerConfig` object initializers of `MoveToFolderAsync(string, bool, bool, bool, bool)`,
+`OpenOlFolderAsync(string)` and `OpenFsFolderAsync(string)` respectively.
+
+## [P1-T2] The ordering sentinel
+
+`Select-String -Path 'QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs' -SimpleMatch 'SpecialFoldersAccessCount.Should().Be(2)'`
+returned exactly one match:
+
+```
+LINE 217: probe.FileSystem.SpecialFoldersAccessCount.Should().Be(2);
+```
+
+Line number 217 matches the plan exactly. This test pins the archive-root guard's placement
+strictly **after** the OneDrive `SpecialFolders` read in all three methods.
+
+## [P1-T3] The new test file is not yet registered
+
+`Select-String -Path 'QuickFiler.Test/QuickFiler.Test.csproj' -SimpleMatch 'EfcDataModelArchiveRootTests.cs'`
+returned **0** matches.
+
+`Select-String -Path 'QuickFiler.Test/QuickFiler.Test.csproj' -SimpleMatch 'Controllers\EfcDataModelTests.cs'`
+returned exactly one match:
+
+```
+LINE 115: <Compile Include="Controllers\EfcDataModelTests.cs" />
+```
+
+Line number 115 matches the plan exactly and is the insertion anchor for [P3-T2].
+
+## [P1-T4] Pre-change file size
+
+`QuickFiler/Controllers/EfcDataModel.cs` is 423 lines, matching the plan's Verified Facts.
+The 500-line cap in `.claude/rules/general-code-change.md` therefore leaves 77 lines of
+headroom for the Phase 2 seam and the Phase 4 guard.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/phase0-instructions-read.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/phase0-instructions-read.md
@@ -1,0 +1,73 @@
+# Phase 0 — Policy Instructions Read (Issue 638)
+
+Timestamp: 2026-08-29T12-15
+
+Policy Order:
+
+1. `CLAUDE.md`
+2. `.claude/rules/general-code-change.md`
+3. `.claude/rules/general-unit-test.md`
+4. `.claude/rules/csharp.md`
+
+Files read (explicit list):
+
+- `CLAUDE.md`
+- `.claude/rules/general-code-change.md`
+- `.claude/rules/general-unit-test.md`
+- `.claude/rules/csharp.md`
+
+## [P0-T1] `CLAUDE.md`
+
+Read in full. Four embedded policies recorded: General Code Change Policy, General Unit
+Test Policy, C# Code Change Policy, C# Unit Test Policy. The
+`## C# Toolchain (run in this exact order)` section names four commands, quoted verbatim:
+
+1. `dotnet tool run csharpier format .` (verify: `dotnet tool run csharpier check .`; always via `dotnet tool run`, never a global install)
+2. `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
+3. `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:TreatWarningsAsErrors=true`
+4. `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage`
+
+If any step fails, fix and restart from step 1.
+
+## [P0-T2] `.claude/rules/general-code-change.md`
+
+Read in full. Recorded for [P0-T5]:
+
+- **File Size Limit**: no production code, test code, or reusable script file may exceed
+  **500 lines**. Exceptions are throwaway agent-session scripts, raw text fixtures for
+  language-processing test data, and Markdown documentation files.
+- **Mandatory Toolchain Loop**: seven stages in order — formatting, linting, type
+  checking, architecture-boundary tests, unit tests, contract/schema compatibility checks,
+  integration tests. Restart from step 1 if any stage fails or auto-fixes any file.
+
+## [P0-T3] `.claude/rules/general-unit-test.md`
+
+Read in full. Recorded:
+
+- **Coverage Exclusion Policy**: no production file may be excluded from coverage
+  measurement; every production source file is in the denominator. Permitted `exclude`
+  entries cover build output, test files and test infrastructure, non-production config
+  files and `node_modules/**` only. Any `exclude` entry matching a production source path
+  is a Blocking finding for feature-review agents.
+- **Test File Location clause**: test files must live in a `tests/` directory tree
+  mirroring the production source structure; colocation in the production source tree is
+  not permitted.
+- **Note on D1**: scope decision D1 in the plan supersedes the `tests/` mirroring clause
+  for C# in this repository. `.claude/skills/policy-compliance-order/SKILL.md` ranks
+  `CLAUDE.md` above `.claude/rules/general-unit-test.md`; the unit-test policies embedded
+  in `CLAUDE.md` impose no `tests/` mirroring requirement; and the General Code Change
+  Policy requires matching existing repository style, which for every C# test project here
+  is a sibling `<Project>.Test` project. The new test file therefore lives at
+  `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`.
+
+## [P0-T4] `.claude/rules/csharp.md`
+
+Read in full. Recorded: the same four toolchain commands with `/t:Rebuild` required
+locally; the prohibition on `/p:Nullable=enable`; MSTest + Moq + FluentAssertions as the
+test stack; repository-wide line coverage `>= 80%` and `>= 90%` for any new module, class
+or method; coverage regression on changed lines is a blocking finding; the DI-seam
+preference order (interface seam, then injectable delegate seam, then adapter seam) which
+authorizes the `Action<string>` delegate seam this plan introduces; the five-package
+analyzer stack and its severity-first ordering invariant
+(`.editorconfig` severities at `suggestion` before any `<Analyzer Include>` wiring); and
+the prohibition on weakening assertions or relaxing test expectations to make tests pass.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p2-t3-seam-compile.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p2-t3-seam-compile.md
@@ -1,0 +1,33 @@
+# [P2-T3] Seam-declaration compile (Issue 638)
+
+Timestamp: 2026-08-29T12-27
+
+Command:
+
+```
+$mb = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" | Select-Object -First 1
+& $mb TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" 2>&1 | Tee-Object -FilePath 'TestResults\msbuild\p2-t3.log'
+```
+
+Same vswhere-resolved MSBuild as [P0-T10], including the `| Select-Object -First 1` suffix.
+The resolved path is absolute and is therefore recorded unresolved.
+
+EXIT_CODE: 0
+
+Output Summary:
+
+MSBuild's summary lines, quoted verbatim:
+
+```
+    5 Warning(s)
+    0 Error(s)
+```
+
+The declaration-only seam added by [P2-T1] compiles. `[P2-T2]` confirmed the seam has
+exactly one occurrence across `QuickFiler`, `TaskMaster`, `UtilitiesCS` and `ToDoModel`
+(excluding `obj` and `bin`), so it adds no call site and changes no behavior. Phase 3's
+expected red will therefore be caused by the missing archive-root guard rather than by the
+seam.
+
+Console output was tee'd to `TestResults\msbuild\p2-t3.log`, outside the diff under
+`.gitignore:39`.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p3-t14-tests-compile.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p3-t14-tests-compile.md
@@ -1,0 +1,33 @@
+# [P3-T14] Regression-test compile (Issue 638)
+
+Timestamp: 2026-08-29T12-31
+
+Command:
+
+```
+$mb = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" | Select-Object -First 1
+& $mb TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" 2>&1 | Tee-Object -FilePath 'TestResults\msbuild\p3-t14.log'
+```
+
+Same vswhere-resolved MSBuild as [P0-T10], including the `| Select-Object -First 1` suffix.
+The resolved path is absolute and is therefore recorded unresolved.
+
+EXIT_CODE: 0
+
+Output Summary:
+
+MSBuild's summary lines, quoted verbatim:
+
+```
+    5 Warning(s)
+    0 Error(s)
+```
+
+The eleven new tests in `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`
+compile, and the `<Compile Include="Controllers\EfcDataModelArchiveRootTests.cs" />` entry
+added by [P3-T2] at `QuickFiler.Test/QuickFiler.Test.csproj:116` is picked up by the build.
+The warning count is unchanged from the [P0-T10], [P0-T11] and [P2-T3] baselines, so the
+new file introduces no diagnostic.
+
+The [P3-T15] fail-before evidence can therefore be a runtime failure rather than a build
+failure, which is the ordering hazard this task exists to close.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p4-t6-fix-compile.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p4-t6-fix-compile.md
@@ -1,0 +1,35 @@
+# [P4-T6] Post-fix compile (Issue 638)
+
+Timestamp: 2026-08-29T12-34
+
+Command:
+
+```
+$mb = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" | Select-Object -First 1
+& $mb TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" 2>&1 | Tee-Object -FilePath 'TestResults\msbuild\p4-t6.log'
+```
+
+Same vswhere-resolved MSBuild as [P0-T10], including the `| Select-Object -First 1` suffix.
+The resolved path is absolute and is therefore recorded unresolved.
+
+EXIT_CODE: 0
+
+Output Summary:
+
+MSBuild's summary lines, quoted verbatim:
+
+```
+    5 Warning(s)
+    0 Error(s)
+```
+
+The `TryGetArchiveRoot(out string archiveRoot)` helper added by [P4-T1] and the three call
+sites added by [P4-T2] through [P4-T4] compile. The warning count is unchanged from the
+[P0-T10], [P0-T11], [P2-T3] and [P3-T14] runs, so the fix introduces no new diagnostic.
+
+[P4-T5] confirmed immediately before this build that
+`Select-String -SimpleMatch 'OlAncestor = Globals.Ol.ArchiveRootPath'` returns **0** matches
+and that `Select-String -SimpleMatch 'Globals.Ol.ArchiveRootPath'` returns exactly **1**
+match, at `QuickFiler/Controllers/EfcDataModel.cs:284`, which is the executable assignment
+`archiveRoot = Globals.Ol.ArchiveRootPath;` inside the `TryGetArchiveRoot` body declared at
+`:280`. It is not a comment, and no commented-out copy of the old expression exists.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p4-t7-file-size.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p4-t7-file-size.md
@@ -1,0 +1,36 @@
+# [P4-T7] Post-fix file sizes against the 500-line cap (Issue 638)
+
+Timestamp: 2026-08-29T12-34
+
+Command:
+
+```
+(Get-Content -LiteralPath 'QuickFiler/Controllers/EfcDataModel.cs').Count
+(Get-Content -LiteralPath 'QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs').Count
+```
+
+`Measure-Object -Line` was deliberately not used: it reports a different figure for a file
+with a trailing newline.
+
+EXIT_CODE: 0
+
+Output Summary:
+
+POSTFIX_EFCDATAMODEL_LINE_COUNT: 485
+
+POSTFIX_ARCHIVEROOTTESTS_LINE_COUNT: 389
+
+Both counts are at or below the 500-line cap in `.claude/rules/general-code-change.md`, so
+no tightening was required and no other file absorbed any overflow.
+
+`QuickFiler/Controllers/EfcDataModel.cs` grew from the
+`PRECHANGE_EFCDATAMODEL_LINE_COUNT: 423` recorded in [P1-T4] to 485, consuming 62 of the
+77 lines of headroom and leaving 15. The growth comprises the [P2-T1] seam and its XML doc
+comment, the redacted user-facing message constant, the `TryGetArchiveRoot` helper and its
+XML doc comment, and the three guard blocks added by [P4-T2] through [P4-T4].
+
+`QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` landed at 389 lines, close to
+the plan's budget guidance of roughly 385.
+
+Because CSharpier can change line counts, [P8-T21] re-runs both counts after the [P6-T1]
+formatting pass before checking off AC19.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p5-t3-untouched-tests.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p5-t3-untouched-tests.md
@@ -1,0 +1,53 @@
+# [P5-T3] Existing test files are unedited (Issue 638)
+
+Timestamp: 2026-08-29T12-36
+
+Command:
+
+```
+git diff --name-only ecdb1c84ba8541ab67042985919cfed4df768c01 -- QuickFiler.Test TaskMaster.Test
+git status --porcelain -uall -- QuickFiler.Test TaskMaster.Test
+```
+
+The anchored diff enumerates tracked modifications; the porcelain status is its required
+companion because a name-listing diff is blind to files this plan created. Neither alone is
+sufficient.
+
+EXIT_CODE: 0
+
+Output Summary:
+
+## `git diff --name-only` output, verbatim
+
+```
+QuickFiler.Test/QuickFiler.Test.csproj
+```
+
+## `git status --porcelain -uall` output, verbatim
+
+```
+ M QuickFiler.Test/QuickFiler.Test.csproj
+?? QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs
+```
+
+## Assessment
+
+The union of the two outputs is exactly:
+
+- `QuickFiler.Test/QuickFiler.Test.csproj` (modified — the single
+  `<Compile Include="Controllers\EfcDataModelArchiveRootTests.cs" />` entry added at `:116`
+  by [P3-T2])
+- `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` (untracked — created by
+  [P3-T1])
+
+Neither output names any of the six existing test files the spec protects:
+
+- `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs` — absent
+- `QuickFiler.Test/Controllers/EfcHomeControllerExecuteMovesTests.cs` — absent
+- `QuickFiler.Test/Controllers/EfcDataModelTests.cs` — absent
+- `QuickFiler.Test/Controllers/EfcDataModelIssue614Tests.cs` — absent
+- `QuickFiler.Test/Controllers/EfcFormControllerTests.cs` — absent
+- `TaskMaster.Test/AppGlobals/AppOlObjectsArchiveRootValidationTests.cs` — absent
+
+All six are therefore unmodified, and the two sentinel tests among them passed unchanged in
+[P5-T2].

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p8-t2-followup-issue-dossier.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p8-t2-followup-issue-dossier.md
@@ -114,3 +114,22 @@ above with the scaffold headings preserved, then promoted with the issue-promoti
 promotion type bug and work mode full-bug. The promoted records are retained under
 docs/features/potential/promoted/. The numbers are recorded in the spec Rollout and Follow-up
 section and AC20 is checked off.
+
+### Clarification for review finding G5 (2026-08-29T13-20)
+
+The review noted that the promoted records for 696, 697 and 698 are not present in this
+worktree. That is correct and intended. The records were created in the orchestration session
+checkout, not on this branch, because AC18 pins this branch footprint to the three code files
+plus this feature folder; committing files under docs/features/potential/promoted/ here would
+have broken AC18 and the [P9-T2] footprint gate. Their existence was verified on disk in that
+checkout at 2026-08-29T12-56, and all three issues were confirmed OPEN on the remote. They are
+queued there for a separate documentation commit alongside other promotions from the same
+orchestration session, and that queue is the parent session responsibility rather than this
+branch.
+
+One further follow-up was filed from the code review of this change, and is recorded here for
+the same audit trail even though it is not one of the three spec non-goals:
+
+- Code-review finding CR-1, the success-path test that terminates on an incidental collaborator
+  crash rather than a deliberate stopping point: issue 699 -
+  https://github.com/drmoisan/TaskMaster/issues/699

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p8-t2-followup-issue-dossier.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p8-t2-followup-issue-dossier.md
@@ -1,0 +1,102 @@
+# [P8-T2] Follow-up issue dossier for the three non-goals (Issue 638)
+
+Timestamp: 2026-08-29T12-46
+
+Command: citation re-derivation only — `Select-String` over the three cited files; no build
+or test command was run.
+
+EXIT_CODE: 0
+
+Output Summary: three ready-to-file follow-up issues, one per non-goal recorded in the
+spec's Scope & Non-Goals section. Each carries a title, a one-paragraph body, its verified
+citations and a `ProposedLabels:` line. Filing is an orchestrator responsibility under
+`.claude/skills/feature-promotion-lifecycle/SKILL.md` and is not performed by this plan.
+
+## Non-goal (a) — Guard the archive-root getter against COM failure, not only against an unresolvable root
+
+Body. `IOlObjects.ArchiveRootPath` is implemented by `AppOlObjects` as a lazily computed
+property whose getter makes two live Outlook COM calls before it can validate anything. When
+either call fails — a disconnected or restarting Outlook process, a store that has gone
+offline, an RPC server that is unavailable — the getter raises a `COMException`, not the
+`InvalidOperationException` that the archive-root validator raises for an unresolvable or
+cross-store root. Issue 638 deliberately narrowed its guard to `InvalidOperationException`
+and added a regression test,
+`MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates`, that pins the
+COM failure as still propagating, so the narrowing is a documented decision rather than an
+oversight. The follow-up is to decide, at the `AppOlObjects` boundary rather than at each
+call site, whether a COM failure reading the archive root should surface as a redacted
+user-facing diagnostic in the same shape the validator already uses, or should continue to
+propagate. Deciding it at the boundary avoids duplicating the choice across the eight
+archive-root call sites that exist across `EfcDataModel` and `EfcFormController`.
+
+Verified citations.
+
+- `TaskMaster/AppGlobals/AppOlObjects.cs:253-267` — the `ArchiveRootPath` getter.
+- `TaskMaster/AppGlobals/AppOlObjects.cs:260` — `Path.Combine(Root.FolderPath, "Archive")`,
+  a live COM read of `Root.FolderPath`.
+- `TaskMaster/AppGlobals/AppOlObjects.cs:261` — `ArchiveRoot?.FolderPath`, a second live COM
+  read.
+- `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:44` and `:56` — the only two throw sites,
+  both raising `InvalidOperationException`.
+- `QuickFiler/Controllers/EfcDataModel.cs:287` — the narrowed
+  `catch (InvalidOperationException ex)` added by issue 638.
+
+ProposedLabels: bug, quickfiler, outlook-interop, follow-up
+
+## Non-goal (b) — Review the log-only `async void` boundary sinks in `EfcFormController`
+
+Body. `EfcFormController` exposes five `async void` WinForms click handlers, each of which
+immediately awaits an `internal async Task` sibling that wraps its work in
+`try { ... } catch (System.Exception ex) { BoundaryErrorSink(ex.Message, ex); }`. The sink
+defaults to `(message, exception) => logger.Error(message, exception)`, so every failure
+reaching one of these boundaries is written to the log and nothing is shown to the user; the
+button appears to do nothing. That is the same silent-swallow symptom issue 638 addressed
+inside `EfcDataModel`, but at a different layer and with a different remedy, so it was
+excluded from 638's scope. The follow-up is to decide which of these boundaries should also
+raise a redacted user-facing diagnostic, and whether `BoundaryErrorSink` should gain a
+user-notification arm rather than each handler growing its own.
+
+Verified citations.
+
+- `QuickFiler/Controllers/EfcFormController.cs:442`, `:460`, `:477`, `:495`, `:557` — the
+  five `async void` click handlers.
+- `QuickFiler/Controllers/EfcFormController.cs:445-458` — the representative sibling
+  `ButtonCancelClickAsync`, showing the `catch` at `:454-457` and the sink call at `:456`.
+- `QuickFiler/Controllers/EfcFormController.cs:129` —
+  `(message, exception) => logger.Error(message, exception)`, the default sink, which is
+  log-only.
+
+ProposedLabels: bug, quickfiler, ui-diagnostics, follow-up
+
+## Non-goal (c) — Guard the five archive-root reads in `EfcFormController`
+
+Body. Issue 638 guarded the three unguarded `ArchiveRootPath` reads in `EfcDataModel` and
+left `EfcFormController` untouched, because widening the change would have taken the
+diff outside the footprint AC18 pins and would have required a different test arrangement
+for each site. `EfcFormController` still reads `_globals.Ol.ArchiveRootPath` at five places,
+none of them guarded, so an unresolvable or cross-store archive root still raises
+`InvalidOperationException` from each. Four of the five are absorbed by the boundary sinks
+described in non-goal (b) and therefore present as a silent no-op; the fifth sits on the
+breadcrumb bind path. The follow-up is to route all five through the same
+`TryGetArchiveRoot`-shaped helper issue 638 introduced, or through a shared helper promoted
+to a location both controllers can reach, and to add the equivalent regression tests.
+
+Verified citations.
+
+- `QuickFiler/Controllers/EfcFormController.cs:529` — `_globals.Ol.ArchiveRootPath,`
+- `QuickFiler/Controllers/EfcFormController.cs:539` — `_globals.Ol.ArchiveRootPath,`
+- `QuickFiler/Controllers/EfcFormController.cs:836` — `_globals.Ol.ArchiveRootPath,`
+- `QuickFiler/Controllers/EfcFormController.cs:846` — `_globals.Ol.ArchiveRootPath,`
+- `QuickFiler/Controllers/EfcFormController.cs:987` —
+  `await _router.BindRowsAsync(rows, scores, _globals.Ol.ArchiveRootPath, Token);`
+- `QuickFiler/Controllers/EfcDataModel.cs:280-297` — `TryGetArchiveRoot`, the helper shape
+  issue 638 introduced and the one these five sites would adopt.
+
+ProposedLabels: bug, quickfiler, outlook-interop, follow-up
+
+REMEDIATION-REQUIRED: AC20 unmet — three follow-up issues not yet filed. This dossier is the
+ready-to-file input: it carries one section per non-goal with a title, a body, verified
+citations and proposed labels. The filing route is the promotion lifecycle defined by
+`.claude/skills/feature-promotion-lifecycle/SKILL.md`, which the orchestrator runs after
+this plan returns. AC20 is left unchecked in `spec.md` until the three issue numbers are
+recorded in the spec's Rollout & Follow-up section.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p8-t2-followup-issue-dossier.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p8-t2-followup-issue-dossier.md
@@ -100,3 +100,17 @@ citations and proposed labels. The filing route is the promotion lifecycle defin
 `.claude/skills/feature-promotion-lifecycle/SKILL.md`, which the orchestrator runs after
 this plan returns. AC20 is left unchecked in `spec.md` until the three issue numbers are
 recorded in the spec's Rollout & Follow-up section.
+
+## RESOLVED 2026-08-29T13-02 (appended after plan execution; nothing above is edited)
+
+The three follow-up issues were filed through the repository promotion lifecycle:
+
+- Non-goal (a): issue 696 - https://github.com/drmoisan/TaskMaster/issues/696
+- Non-goal (b): issue 697 - https://github.com/drmoisan/TaskMaster/issues/697
+- Non-goal (c): issue 698 - https://github.com/drmoisan/TaskMaster/issues/698
+
+Each entry was scaffolded with the bug-entry MCP tool, filled from the corresponding section
+above with the scaffold headings preserved, then promoted with the issue-promotion MCP tool at
+promotion type bug and work mode full-bug. The promoted records are retained under
+docs/features/potential/promoted/. The numbers are recorded in the spec Rollout and Follow-up
+section and AC20 is checked off.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/ac17-coverage-delta-recomputed.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/ac17-coverage-delta-recomputed.md
@@ -1,0 +1,72 @@
+# AC17 — coverage delta recomputed over equal modes (Issue 638)
+
+Timestamp: 2026-08-29T13-02
+
+Command: derivation only — the fields below are copied from
+`evidence/remediation-baseline/ac17-commensurable-baseline.md` and
+`evidence/qa-gates/p7-t1-coverage-postchange.md` and differenced; no new command was run.
+
+EXIT_CODE: 0
+
+Output Summary: with both figures measured in `koverage-processed` mode, the repository-wide
+line coverage moves from 85.26 percent at the merge base to 85.33 percent after the change, a
+delta of +0.07 points. Branch coverage moves from 79.24 to 79.31, also +0.07 points. The
+change does not lower either figure, which is what AC17 requires of the repository-wide
+measurement. The blocking change-scoped clause was already satisfied at 93.10 percent.
+
+## Numeric fields
+
+```
+BASELINE_REPO_LINE_COVERAGE_PERCENT:     85.26   (remediation baseline, merge base ecdb1c84)
+POSTCHANGE_REPO_LINE_COVERAGE_PERCENT:   85.33   (from [P7-T1])
+DELTA_REPO_LINE_COVERAGE_POINTS:         +0.07
+CHANGED_LINE_COVERAGE_PERCENT:           93.10   (from [P7-T2])
+
+BASELINE_REPO_BRANCH_COVERAGE_PERCENT:   79.24
+POSTCHANGE_REPO_BRANCH_COVERAGE_PERCENT: 79.31
+DELTA_REPO_BRANCH_COVERAGE_POINTS:       +0.07
+
+BASELINE_COVERAGE_XML_MODE:              koverage-processed
+POSTCHANGE_COVERAGE_XML_MODE:            koverage-processed
+```
+
+The two recorded modes are equal, which was the clause `[P7-T3]` could not satisfy.
+
+## Underlying counts
+
+```
+                 lines-covered   lines-valid   packages
+baseline                 54735         64195          9
+post-change              54802         64221          9
+difference                 +67           +26          0
+```
+
+The denominator grew by 26 executable lines, which are the executable lines the change adds to
+`QuickFiler/Controllers/EfcDataModel.cs`. The numerator grew by 67, so 41 lines that were
+executable and uncovered at the merge base are covered after the change: the eleven new tests
+in `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` reach guard and early-return
+paths in `EfcDataModel` that no prior test exercised. Package count is identical at 9, so the
+allowlist filter selected the same assemblies in both runs and the denominators are
+constructed the same way.
+
+Line-covered counts drift slightly between runs of an unchanged tree on a suite this size, so
+the +0.07 point movement is small relative to the tolerance the plan set. It is reported as
+"not lowered" rather than as a measured improvement, which is the claim AC17 actually requires
+and the claim the evidence supports.
+
+## Threshold conformance
+
+- Change-scoped line coverage 93.10 percent is at or above the 90.0 percent floor AC17 sets
+  for changed lines, measured entirely inside the single `[P7-T1]` post-processed artifact, so
+  the mode question never affected it.
+- Repository-wide line coverage 85.33 percent clears the 80 percent floor in `CLAUDE.md` § UT2
+  and the 85 percent floor in `.claude/rules/general-unit-test.md`.
+- Repository-wide branch coverage 79.31 percent clears the 75 percent floor in
+  `.claude/rules/quality-tiers.md`.
+
+## Disposition
+
+`[P7-T3]`'s `REMEDIATION-REQUIRED` finding is resolved. Its artifact is left unedited as the
+record of the state at plan-execution time; this artifact and
+`evidence/remediation-baseline/ac17-commensurable-baseline.md` carry the resolution. AC17 is
+checked off in `spec.md` on this evidence.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t1-csharpier-format.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t1-csharpier-format.md
@@ -1,0 +1,58 @@
+# [P6-T1] CSharpier format (Issue 638)
+
+Timestamp: 2026-08-29T12-36
+
+Command: `dotnet tool run csharpier format .`
+
+Branch taken: **unscoped**. [P0-T9] recorded `BASELINE_UNFORMATTED_COUNT: 0`, so the command
+runs against `.` as written, with no scoping to the two owned files.
+
+EXIT_CODE: 0
+
+Output Summary:
+
+The command is write-mode: its exit code is 0 whether or not it rewrote anything, so this
+task is judged on a tree observation — the SHA-256 of the two owned files before and after
+— rather than on the exit code.
+
+## Pass 1 (rejected; the loop restarted)
+
+```
+BeforeHashes:
+  QuickFiler/Controllers/EfcDataModel.cs                        995BB6452CDD1DD012713DC856EEA8F9897401F0F261BCA38166B2A05B2A5E2A
+  QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs   81E1AA23B5F25702B56BD71B09D14AAEC992D8535A40ADA7D630C6DB0002B148
+
+AfterHashes:
+  QuickFiler/Controllers/EfcDataModel.cs                        995BB6452CDD1DD012713DC856EEA8F9897401F0F261BCA38166B2A05B2A5E2A
+  QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs   A20BCF32C44D861F96304152864C7C5D4891CA7F696988E3F2798432987794EB
+```
+
+Final summary line: `Formatted 1561 files in 4454ms.` (a processed count, not a changed
+count).
+
+The hash of `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` changed, so per
+the Phase 6 preamble and `CLAUDE.md` § "After Making Changes" the loop restarted from
+[P6-T1]. The change was line-ending normalization: the file was created with LF endings and
+CSharpier rewrote it to the CRLF used throughout this worktree under `core.autocrlf=true`.
+The line count was 389 before and 389 after, and a post-format measurement confirmed
+`LF=389 CRLF=389`, that is, every LF is part of a CRLF. `git status --porcelain -uall`
+after the pass named only the three paths in this change's footprint, so no other file was
+rewritten.
+
+## Pass 2 (the accepted pass)
+
+```
+BeforeHashes:
+  QuickFiler/Controllers/EfcDataModel.cs                        995BB6452CDD1DD012713DC856EEA8F9897401F0F261BCA38166B2A05B2A5E2A
+  QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs   A20BCF32C44D861F96304152864C7C5D4891CA7F696988E3F2798432987794EB
+
+AfterHashes:
+  QuickFiler/Controllers/EfcDataModel.cs                        995BB6452CDD1DD012713DC856EEA8F9897401F0F261BCA38166B2A05B2A5E2A
+  QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs   A20BCF32C44D861F96304152864C7C5D4891CA7F696988E3F2798432987794EB
+```
+
+Final summary line: `Formatted 1561 files in 1321ms.`
+
+Both hash pairs are equal, so this pass is a fixpoint and the formatting step changed no
+file. [P6-T2] through [P6-T5] ran after this pass; the `AfterHashes:` values above are the
+ones [P6-T6] compares against.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t2-csharpier-check.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t2-csharpier-check.md
@@ -1,0 +1,30 @@
+# [P6-T2] CSharpier check (Issue 638)
+
+Timestamp: 2026-08-29T12-36
+
+Command: `dotnet tool run csharpier check .`
+
+EXIT_CODE: 0
+
+Output Summary:
+
+Final summary line, quoted verbatim:
+
+```
+Checked 1561 files in 4097ms.
+```
+
+The unformatted count is derived, as in [P0-T9], from the
+`Error <path> - Was not formatted.` lines rather than from that summary line, whose N is a
+processed count. The run emitted **0** such lines.
+
+[P0-T9] recorded `BASELINE_UNFORMATTED_COUNT: 0`, so this task's acceptance is the
+`EXIT_CODE: 0` branch, which is met. The subset branch does not apply and no
+`REMEDIATION-REQUIRED:` line is appended here; [P8-T15] therefore takes the AC13 check-off
+branch.
+
+The file count rose from the 1560 checked at baseline to 1561 because
+`QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` is new.
+`QuickFiler.Test/QuickFiler.Test.csproj` is excluded from the check by `.csharpierignore:12`
+(`*.csproj`), and the feature folder's evidence artifacts by `.csharpierignore:4`
+(`**/evidence/**`), so neither is subject to this gate.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t3-msbuild-analyzers.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t3-msbuild-analyzers.md
@@ -1,0 +1,40 @@
+# [P6-T3] MSBuild analyzer gate (Issue 638)
+
+Timestamp: 2026-08-29T12-37
+
+Command:
+
+```
+$mb = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" | Select-Object -First 1
+& $mb TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true 2>&1 | Tee-Object -FilePath 'TestResults\msbuild\p6-t3.log'
+```
+
+Same vswhere-resolved MSBuild as [P0-T10], including the `| Select-Object -First 1` suffix.
+The resolved path is absolute and is therefore recorded unresolved.
+
+EXIT_CODE: 0
+
+Output Summary:
+
+MSBuild's own summary lines, quoted verbatim:
+
+```
+    5 Warning(s)
+    0 Error(s)
+```
+
+The error count is read from that summary line, not by counting `error CS` occurrences.
+
+## Non-vacuity
+
+The tee'd log `TestResults\msbuild\p6-t3.log` contains **0** occurrences of the literal
+`Skipping target "CoreCompile"`, so no project skipped compilation and the analyzers
+actually ran. For contrast, the same log contains 86 lines mentioning `CoreCompile`,
+which are the target invocations themselves.
+
+This is why `/t:Rebuild` is used rather than `/t:Build`: MSBuild's incremental up-to-date
+check does not invalidate on a command-line `/p:` change, so a warm `/t:Build` would return
+exit 0 with `CoreCompile` skipped on every project and would run no analyzers at all.
+
+The warning count is unchanged from the `BASELINE_ANALYZER_ERRORS: 0` / 5-warning baseline
+recorded by [P0-T10], so this change introduces no analyzer diagnostic.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t4-msbuild-nullable.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t4-msbuild-nullable.md
@@ -1,0 +1,43 @@
+# [P6-T4] MSBuild nullable / warnings-as-errors gate (Issue 638)
+
+Timestamp: 2026-08-29T12-37
+
+Command:
+
+```
+$mb = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" | Select-Object -First 1
+& $mb TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:TreatWarningsAsErrors=true 2>&1 | Tee-Object -FilePath 'TestResults\msbuild\p6-t4.log'
+```
+
+The `Command:` above contains neither `/p:Nullable=enable` nor `/t:Build`. Both omissions
+are load-bearing and are recorded in `CLAUDE.md` § C#1.3: `/p:Nullable=enable` is a
+solution-wide opt-in absent from CI's command that conscripts every file which has never
+adopted the pragma, and a warm `/t:Build` returns exit 0 having skipped `CoreCompile` on
+every project.
+
+Same vswhere-resolved MSBuild as [P0-T10], including the `| Select-Object -First 1` suffix.
+The resolved path is absolute and is therefore recorded unresolved.
+
+EXIT_CODE: 0
+
+Output Summary:
+
+MSBuild's own summary lines, quoted verbatim:
+
+```
+    5 Warning(s)
+    0 Error(s)
+```
+
+## Non-vacuity
+
+The tee'd log `TestResults\msbuild\p6-t4.log` contains **0** occurrences of the literal
+`Skipping target "CoreCompile"`, so compiler and nullable-flow diagnostics actually ran on
+every project.
+
+The warning count is unchanged from the `BASELINE_NULLABLE_ERRORS: 0` / 5-warning baseline
+recorded by [P0-T11], so this change introduces no nullable or compiler diagnostic. Neither
+`QuickFiler/Controllers/EfcDataModel.cs` nor
+`QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` carries a `#nullable enable`
+directive, so neither opts into nullable flow analysis; the gate still compiles both under
+warnings-as-errors.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t5-vstest-coverage.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t5-vstest-coverage.md
@@ -1,0 +1,96 @@
+# [P6-T5] Full suite with code coverage (Issue 638)
+
+Timestamp: 2026-08-29T12-38
+
+Command:
+
+```
+$vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -find "Common7\IDE\Extensions\TestPlatform\vstest.console.exe" | Select-Object -First 1
+# assembly list built by the rules below
+& $vs <assembly list> /EnableCodeCoverage /InIsolation /Logger:trx /ResultsDirectory:TestResults\p6-t5 /TestCaseFilter:"TestCategory!=LiveOutlook"
+```
+
+The `vstest.console.exe` path is recorded unresolved, as the vswhere expression, because
+the resolved path is absolute. The `| Select-Object -First 1` suffix is required because
+`-find` can emit several matching paths. The run was launched through
+`Start-Process -Wait -NoNewWindow`, with output redirected under `TestResults\`
+(gitignored under `.gitignore:39`).
+
+EXIT_CODE: 0
+
+Output Summary:
+
+## Assembly discovery
+
+`Get-ChildItem -Path . -Recurse -Filter '*.Test.dll'`, keeping only paths under
+`\bin\Debug\`, rejecting paths under `\obj\` or `\ref\`, and rejecting only **relative**
+paths containing `\.claude\`, where the relative path is computed as
+`$_.FullName.Substring((Get-Location).Path.Length)`. The absolute path is deliberately not
+tested for `\.claude\`: a worktree rooted under `.claude\worktrees` would match on every
+candidate and yield an empty assembly list, which vstest reports as a run with zero
+failures.
+
+DISCOVERED_ASSEMBLY_COUNT: 9
+
+Worktree-relative paths, computed as `$_.FullName.Substring((Get-Location).Path.Length)`:
+
+```
+\QuickFiler.Test\bin\Debug\QuickFiler.Test.dll
+\SVGControl.Test\bin\Debug\SVGControl.Test.dll
+\Tags.Test\bin\Debug\Tags.Test.dll
+\TaskMaster.Test\bin\Debug\TaskMaster.Test.dll
+\TaskTree.Test\bin\Debug\TaskTree.Test.dll
+\TaskVisualization.Test\bin\Debug\TaskVisualization.Test.dll
+\ToDoModel.Test\bin\Debug\ToDoModel.Test.dll
+\UtilitiesCS.Test\bin\Debug\UtilitiesCS.Test.dll
+\VBFunctions.Test\bin\Debug\VBFunctions.Test.dll
+```
+
+The count is at least 4, and the list contains a path ending `QuickFiler.Test.dll` and a
+path ending `TaskMaster.Test.dll`.
+
+## Run totals
+
+Console totals:
+
+```
+Total tests: 6870
+     Passed: 6870
+```
+
+No `Failed:` or `Skipped:` summary line was emitted, so both are 0. The total is the 6859
+of the [P0-T12] direct-harness baseline plus the 11 new tests.
+
+## Per-namespace failure figures, derived from the TRX
+
+Derived from the single TRX under `TestResults\p6-t5` by joining each
+`UnitTestResult/@testId` to its `UnitTest/TestMethod` `className` and `name`, not from the
+console `Failed:` total, which is an all-assembly aggregate:
+
+```
+TRX result rows:                6870   (Passed 6870, Failed 0)
+QUICKFILER_NS_FAILED:              0   (fully qualified name begins "QuickFiler.")
+TASKMASTER_NS_FAILED:              0   (fully qualified name begins "TaskMaster.")
+Failures in any other namespace:   0
+```
+
+Baseline exceptions taken: **none**. The direct-harness `BASELINE_FAILURE_SET:` recorded by
+[P0-T12] in `evidence/baseline/p0-t12-direct-harness-baseline.md` is the literal `none`, so
+no carve-out was available and none was needed. No test in `EfcDataModelArchiveRootTests`
+appears among any failures, because there are none.
+
+Because the exception list is empty and both namespace figures are `Failed: 0`, [P8-T18]
+takes the AC16 check-off branch and no `REMEDIATION-REQUIRED:` line is appended here.
+
+## New tests executed
+
+ARCHIVEROOT_TESTS_EXECUTED: 11 — all eleven tests whose fully qualified name contains
+`EfcDataModelArchiveRootTests` appear in the TRX, so [P8-T13]'s AC11 precondition is met.
+
+## LiveOutlook category
+
+Executed tests carrying `[TestCategory("LiveOutlook")]`: **0**. Counted from the TRX by
+intersecting the executed `testId` set with the `TestDefinitions` entries whose
+`TestCategory/TestCategoryItem/@TestCategory` equals `LiveOutlook`. The run's
+`/TestCaseFilter:"TestCategory!=LiveOutlook"` matches
+`.github/workflows/_mstest-coverage.yml:83`.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t6-loop-closure.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t6-loop-closure.md
@@ -1,0 +1,46 @@
+# [P6-T6] Toolchain loop closure (Issue 638)
+
+Timestamp: 2026-08-29T12-39
+
+Command: `Get-FileHash -Algorithm SHA256` on the two files in this change's footprint,
+taken immediately after [P6-T5].
+
+EXIT_CODE: 0
+
+Output Summary:
+
+## Timestamps of the final accepted pass
+
+| Task | Step | Timestamp | Result |
+|---|---|---|---|
+| [P6-T1] | `dotnet tool run csharpier format .` (pass 2, accepted) | 2026-08-29T12-36 | EXIT 0, fixpoint |
+| [P6-T2] | `dotnet tool run csharpier check .` | 2026-08-29T12-36 | EXIT 0, 0 unformatted |
+| [P6-T3] | msbuild analyzers | 2026-08-29T12-37 | EXIT 0, `0 Error(s)` |
+| [P6-T4] | msbuild warnings-as-errors | 2026-08-29T12-37 | EXIT 0, `0 Error(s)` |
+| [P6-T5] | vstest full suite with coverage | 2026-08-29T12-38 | EXIT 0, 6870 passed, 0 failed |
+
+The five timestamps are non-decreasing.
+
+The loop ran twice. Pass 1's [P6-T1] rewrote
+`QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` (line-ending normalization on
+a newly created file), which under `CLAUDE.md` § "After Making Changes" required a restart
+from step 1. Pass 2's [P6-T1] was a fixpoint, and [P6-T2] through [P6-T5] all ran after it.
+
+## Hashes taken immediately after [P6-T5]
+
+```
+QuickFiler/Controllers/EfcDataModel.cs                        995BB6452CDD1DD012713DC856EEA8F9897401F0F261BCA38166B2A05B2A5E2A
+QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs   A20BCF32C44D861F96304152864C7C5D4891CA7F696988E3F2798432987794EB
+```
+
+## Comparison against the [P6-T1] `AfterHashes:`
+
+```
+QuickFiler/Controllers/EfcDataModel.cs                        995BB6452CDD1DD012713DC856EEA8F9897401F0F261BCA38166B2A05B2A5E2A   EQUAL
+QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs   A20BCF32C44D861F96304152864C7C5D4891CA7F696988E3F2798432987794EB   EQUAL
+```
+
+Both pairs are equal, so no file in the change footprint changed between the formatting step
+and the test step. The four toolchain commands of `CLAUDE.md`
+§ "C# Toolchain (run in this exact order)" therefore all passed against one and the same
+tree state.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t1-coverage-postchange.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t1-coverage-postchange.md
@@ -1,0 +1,58 @@
+# [P7-T1] Post-change repository coverage (Issue 638)
+
+Timestamp: 2026-08-29T12-41
+
+Command: `pwsh -NoProfile -File scripts/vscode/Invoke-MSTestWithCoverage.ps1 -SearchRoot . -Configuration Debug -CoverageOutput coverage/coverage.cobertura.xml`
+
+Run through `Start-Process -Wait -NoNewWindow`, with output redirected under `TestResults\`
+(gitignored under `.gitignore:39`).
+
+EXIT_CODE: 0
+
+`ExpectedExitCode:` is omitted: the run exited 0, so the non-zero branch does not apply and
+this task is not REMEDIATION-REQUIRED.
+
+Output Summary:
+
+## Test outcome
+
+```
+Total tests: 6870
+     Passed: 6870
+ Total time: 44.4908 Seconds
+```
+
+The run completed through post-processing, emitting
+`Post-processing coverage XML for Koverage compatibility...` and then `Done.`.
+
+## Root `coverage` element attributes
+
+Read from `coverage/coverage.cobertura.xml`:
+
+```
+line-rate      = 0.853335
+branch-rate    = 0.79311
+lines-covered  = 54802
+lines-valid    = 64221
+package count  = 9
+```
+
+POSTCHANGE_REPO_LINE_COVERAGE_PERCENT: 85.33
+
+POSTCHANGE_REPO_BRANCH_COVERAGE_PERCENT: 79.31
+
+COVERAGE_XML_MODE: koverage-processed
+
+The script exited 0, so per the same rule [P0-T12] applies, the mode is
+`koverage-processed`. `scripts/vscode/Invoke-MSTestWithCoverage.ps1:341` asserted the
+80 percent threshold on the post-processed content and `:343` wrote that content back, so
+the file on disk carries the first-party root attributes recomputed by
+`scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1:442-445` after `:417-421` removed
+every non-allowlisted `<package>`, including every `.Test` assembly. The package count is
+9, against the 14 the raw baseline file carried.
+
+## Note on comparability with the baseline
+
+[P0-T12] recorded `COVERAGE_XML_MODE: raw` because that run terminated on a failing test
+before reaching post-processing. The two figures are therefore computed over different
+denominators. [P7-T3] records that mode mismatch and its consequence.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t2-coverage-changed-lines.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t2-coverage-changed-lines.md
@@ -1,0 +1,112 @@
+# [P7-T2] Changed-line coverage (Issue 638)
+
+Timestamp: 2026-08-29T12-43
+
+Command:
+
+```
+git diff -U0 ecdb1c84ba8541ab67042985919cfed4df768c01 -- QuickFiler/Controllers/EfcDataModel.cs
+# then, over coverage/coverage.cobertura.xml, aggregate every <class> whose filename
+# resolves to QuickFiler/Controllers/EfcDataModel.cs and intersect its <line number=...>
+# entries with the post-image line numbers named by the + hunks above
+```
+
+EXIT_CODE: 0
+
+Output Summary:
+
+COVERAGE_XML_MODE: koverage-processed (copied from [P7-T1])
+
+In this mode `Merge-CoberturaClassesByFilename`
+(`scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1:428`) has already merged the async
+state machine's generated class into the file-level entry, and `filename` is repo-relative.
+The aggregation confirmed this: exactly **1** `<class>` element resolved to
+`QuickFiler/Controllers/EfcDataModel.cs`, carrying 284 `<line>` entries. Aggregation is by
+`filename` rather than by `class`, because a C# async state machine emits its lines under a
+separate generated class and a per-class figure would understate the method.
+
+## Changed-line derivation
+
+`git diff -U0` hunk headers, verbatim:
+
+```
+@@ -147,0 +148,8 @@ namespace QuickFiler.Controllers
+@@ -254,0 +263,36 @@ namespace QuickFiler.Controllers
+@@ -281,0 +326,6 @@ namespace QuickFiler.Controllers
+@@ -289 +339 @@ namespace QuickFiler.Controllers
+@@ -305,0 +356,6 @@ namespace QuickFiler.Controllers
+@@ -310 +366 @@ namespace QuickFiler.Controllers
+@@ -323,0 +380,6 @@ namespace QuickFiler.Controllers
+@@ -328 +390 @@ namespace QuickFiler.Controllers
+```
+
+The post-image lines those `+` hunks name are 148-155, 263-298, 326-331, 339, 356-361, 366,
+380-385 and 390: **65** lines in total. Intersecting that set with the line numbers that
+appear as `<line number=...>` entries under the aggregated filename leaves **29** lines.
+The 36 excluded lines are non-executable — XML doc comments, brace-only lines that emit no
+sequence point, blank lines, and the two-part string constant — and are correctly outside
+the denominator.
+
+CHANGED_LINES_VALID: 29
+
+CHANGED_LINES_COVERED: 27
+
+CHANGED_LINE_COVERAGE_PERCENT: 93.10
+
+93.10 is at or above the required 90.0.
+
+## Per-line detail, so a third party can re-derive the figure
+
+| Line | Hits | Marker | Source |
+|---|---|---|---|
+| 154 | 1 | COVERED | `internal Action<string> UserDiagnosticAction { get; set; } = text => MessageBox.Show(text);` |
+| 281 | 1 | COVERED | `{` (helper body open) |
+| 283 | 1 | COVERED | `{` (try block open) |
+| 284 | 1 | COVERED | `archiveRoot = Globals.Ol.ArchiveRootPath;` |
+| 285 | 1 | COVERED | `return true;` |
+| 287 | 1 | COVERED | `catch (InvalidOperationException ex)` |
+| 288 | 1 | COVERED | `{` |
+| 289 | 1 | COVERED | `archiveRoot = null;` |
+| 290 | 1 | COVERED | `logger.Warn(` |
+| 291 | 1 | COVERED | `"Cannot resolve the Outlook archive root. Details are withheld from this "` |
+| 292 | 1 | COVERED | `+ "message because they contain a mailbox address.",` |
+| 293 | 1 | COVERED | `ex` |
+| 294 | 1 | COVERED | `);` |
+| 295 | 1 | COVERED | `return false;` |
+| 297 | 1 | COVERED | `}` |
+| 327 | 1 | COVERED | `if (!TryGetArchiveRoot(out var olAncestor))` (move path) |
+| 328 | 1 | COVERED | `{` |
+| 329 | 1 | COVERED | `return false;` |
+| 339 | 1 | COVERED | `OlAncestor = olAncestor,` (move path) |
+| 356 | 1 | COVERED | `if (!TryGetArchiveRoot(out var olAncestor))` (Outlook open path) |
+| 357 | 1 | COVERED | `{` |
+| 358 | 1 | COVERED | `UserDiagnosticAction(ArchiveRootUnavailableMessage);` |
+| 359 | 1 | COVERED | `return;` |
+| 366 | 0 | UNCOVERED | `OlAncestor = olAncestor,` (Outlook open path) |
+| 380 | 1 | COVERED | `if (!TryGetArchiveRoot(out var olAncestor))` (file-system open path) |
+| 381 | 1 | COVERED | `{` |
+| 382 | 1 | COVERED | `UserDiagnosticAction(ArchiveRootUnavailableMessage);` |
+| 383 | 1 | COVERED | `return;` |
+| 390 | 0 | UNCOVERED | `OlAncestor = olAncestor,` (file-system open path) |
+
+## The two uncovered lines
+
+Lines 366 and 390 are the `OlAncestor = olAncestor,` initializer members on the **success**
+branch of `OpenOlFolderAsync` and `OpenFsFolderAsync`. No test in this change reaches them:
+each folder-open test either fails the archive-root guard (lines 356-359 and 380-383) or
+fails the OneDrive guard above it, and driving the success branch would require constructing
+a real `EmailFiler` against a live Outlook folder, which is a COM dependency the test policy
+forbids. The move path's equivalent line, 339, is covered because
+`MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce` reaches it before
+`EmailFiler.SortAsync` raises its null reference.
+
+## Note on the seam's default lambda
+
+The plan anticipated that the lambda body of [P2-T1]'s default seam value would be
+uncovered, because every test replaces the seam before invoking the paths that use it. The
+observed figure is more favourable than that: line 154 reports `hits=1`. The property's
+initializer runs on every construction, and CSharpier keeps the declaration and its lambda
+body on the same source line, so the emitted sequence point covers the line even though no
+test executes `MessageBox.Show`. The line is therefore reported COVERED above; had the
+formatter split it, the lambda body would have appeared as a third uncovered line and the
+figure would be 27 of 30, or 90.00, still at or above the floor.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t3-coverage-delta.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t3-coverage-delta.md
@@ -69,3 +69,16 @@ Remediation route. Re-running
 `ecdb1c84ba8541ab67042985919cfed4df768c01` until the flaky liveness test passes would yield
 a `koverage-processed` baseline commensurable with [P7-T1], after which the delta could be
 recomputed and AC17 evaluated. That is outside this plan's task set.
+
+## RESOLVED 2026-08-29T13-02 (appended after plan execution; nothing above is edited)
+
+The mode mismatch this artifact reported has been remediated. The merge-base coverage harness
+was re-run in a separate detached worktree at ecdb1c84ba8541ab67042985919cfed4df768c01 with the
+same analyzer package set and SDK; it exited 0, all 6859 tests passed, post-processing ran, and
+it produced BASELINE_REPO_LINE_COVERAGE_PERCENT: 85.26 in koverage-processed mode.
+
+Both figures are now koverage-processed, so the modes are equal and the recomputed delta is
++0.07 points (85.26 to 85.33), at or above the -0.50 tolerance. See
+evidence/remediation-baseline/ac17-commensurable-baseline.md for the measurement and
+evidence/qa-gates/ac17-coverage-delta-recomputed.md for the recomputed delta. AC17 is checked
+off in spec.md on that evidence.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t3-coverage-delta.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t3-coverage-delta.md
@@ -1,0 +1,71 @@
+# [P7-T3] Coverage delta report (Issue 638)
+
+Timestamp: 2026-08-29T12-44
+
+Command: derivation only — the four numeric fields below are copied from the [P0-T12],
+[P7-T1] and [P7-T2] artifacts and differenced; no new command was run.
+
+EXIT_CODE: 0
+
+Output Summary:
+
+## Numeric fields
+
+```
+BASELINE_REPO_LINE_COVERAGE_PERCENT:    70.70   (from [P0-T12])
+POSTCHANGE_REPO_LINE_COVERAGE_PERCENT:  85.33   (from [P7-T1])
+CHANGED_LINE_COVERAGE_PERCENT:          93.10   (from [P7-T2])
+DELTA_REPO_LINE_COVERAGE_POINTS:       +14.63   (85.33 - 70.70)
+```
+
+All four are present and none reads `UNVERIFIED`.
+
+## Modes
+
+```
+BASELINE_COVERAGE_XML_MODE:    raw                  (from [P0-T12])
+POSTCHANGE_COVERAGE_XML_MODE:  koverage-processed   (from [P7-T1])
+```
+
+The two recorded modes are **not equal**.
+
+## Outcome — REMEDIATION-REQUIRED
+
+`DELTA_REPO_LINE_COVERAGE_POINTS: +14.63` is at or above the `-0.50` tolerance, so the
+delta clause alone would pass. The mode clause does not:
+
+REMEDIATION-REQUIRED: [P7-T3] the baseline and post-change coverage figures were computed in
+different modes (`raw` versus `koverage-processed`), so their difference measures the
+denominator rather than this change. The task's acceptance requires the two modes to be
+equal and records a mismatch as REMEDIATION-REQUIRED rather than as a pass.
+
+Cause and scope. `scripts/vscode/Invoke-MSTestWithCoverage.ps1:341` asserts the coverage
+threshold on the post-processed content and `:343` writes that content back only afterwards,
+so a run that terminates earlier leaves the raw `dotnet-coverage` root attributes on disk.
+The [P0-T12] baseline run terminated at `:236` on a single pre-existing failing test,
+`QuickFiler.Controllers.Tests.QfcDatamodelLivenessTests.RemainingLoadActive_WhenLoaderThrows_IsStillClearedByFinally`,
+a five-second wall-clock timing assertion in a file this change does not touch and one that
+passed in the same task's direct-harness run. It therefore never reached post-processing.
+The [P7-T1] post-change run passed all 6870 tests and did reach post-processing. The two
+denominators differ accordingly: the raw file carried 14 `<package>` elements including
+every `.Test` assembly and `lines-valid=82363`, while the post-processed file carries 9 and
+`lines-valid=64221`, because
+`scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1:417-421` removes every
+non-allowlisted package and `:442-445` recomputes the root attributes over what remains.
+
+Consequence. Per the task text this is recorded as REMEDIATION-REQUIRED rather than as a
+pass, and [P8-T19] therefore leaves AC17 unchecked.
+
+What is not in doubt. The repo-wide figure is recorded and reported per AC17 but is not
+itself a blocking threshold. The blocking clause is the change-scoped one in [P7-T2], and
+it passes: `CHANGED_LINE_COVERAGE_PERCENT: 93.10` is at or above the required 90.0, measured
+entirely within the single `koverage-processed` artifact, so the mode mismatch does not
+affect it. The post-change repo-wide figure of 85.33 also clears both the 80 percent floor
+in `CLAUDE.md` § UT2 and the 85 percent floor in `.claude/rules/general-unit-test.md`, and
+the post-change branch figure of 79.31 clears the 75 percent branch floor.
+
+Remediation route. Re-running
+`scripts/vscode/Invoke-MSTestWithCoverage.ps1` on the merge base
+`ecdb1c84ba8541ab67042985919cfed4df768c01` until the flaky liveness test passes would yield
+a `koverage-processed` baseline commensurable with [P7-T1], after which the delta could be
+recomputed and AC17 evaluated. That is outside this plan's task set.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t4-canonical-coverage-artifact.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t4-canonical-coverage-artifact.md
@@ -1,0 +1,88 @@
+# [P7-T4] Canonical review coverage artifact decision (Issue 638)
+
+Timestamp: 2026-08-29T12-44
+
+Command:
+
+```
+# read the decision inputs from [P7-T1]
+# then, because the decision is WRITTEN, emit the JaCoCo-shaped file:
+$x = [xml](Get-Content 'coverage/coverage.cobertura.xml')
+$covered = [int]$x.coverage.'lines-covered'; $valid = [int]$x.coverage.'lines-valid'
+$missed = $valid - $covered
+# write artifacts/csharp/coverage.xml with <report><counter type="LINE" missed="..." covered="..."/></report>
+([xml](Get-Content 'artifacts/csharp/coverage.xml')).report.counter
+```
+
+EXIT_CODE: 0
+
+MEASURED_REPO_LINE_COVERAGE_PERCENT: 85.33
+
+COVERAGE_XML_MODE: koverage-processed
+
+Decision: WRITTEN
+
+Output Summary:
+
+## Decision derivation
+
+`COVERAGE_XML_MODE:` reads `koverage-processed`, so the `NOT WRITTEN — measured figure is a
+raw denominator that includes test assemblies` branch does not apply. The measured value
+85.33 is greater than or equal to 85.0, so the `NOT WRITTEN — measured figure below 85.0`
+branch does not apply either. The file is therefore written.
+
+This three-way decision exists because
+`.claude/hooks/validate-feature-review-coverage.ps1:313` applies a hard-coded 85.0 floor
+whenever `artifacts/csharp/coverage.xml` exists, while this repository's policy floor is
+80 percent on the testable denominator. Emitting the file while the measured figure sat
+between those two values would force a false failure downstream. Here the measured figure
+clears the hook's own floor, so emitting it is safe.
+
+## Derivation of the emitted counter values
+
+Source attributes, from the root `coverage` element of `coverage/coverage.cobertura.xml`
+(post-processed, so these are the first-party values recomputed by
+`scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1:442-445`):
+
+```
+lines-covered = 54802
+lines-valid   = 64221
+```
+
+Emitted counter values:
+
+```
+covered = lines-covered            = 54802
+missed  = lines-valid - covered    = 64221 - 54802 = 9419
+```
+
+## The emitted file
+
+`artifacts/csharp/coverage.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<report name="TaskMaster">
+  <counter type="LINE" missed="9419" covered="54802"/>
+</report>
+```
+
+It is JaCoCo-shaped, not Cobertura-shaped: the hook reads it with `Get-JacocoRepoCoverage`
+at `.claude/hooks/validate-feature-review-coverage.ps1:253`, which selects
+`//counter[@type="LINE"]` at `:229` and sums the `missed` and `covered` attributes. A
+Cobertura-shaped file would yield no counters and the hook would read nothing.
+
+## Verification
+
+```
+([xml](Get-Content artifacts/csharp/coverage.xml)).report.counter  -> returns a node
+  type=LINE  missed=9419  covered=54802
+```
+
+The `Decision:` line reads `WRITTEN` and `artifacts/csharp/coverage.xml` is present on disk,
+so the two agree. Recomputing the hook's own figure from the emitted counter gives
+`54802 / (9419 + 54802) = 85.33` percent, matching `MEASURED_REPO_LINE_COVERAGE_PERCENT:`
+and clearing the hook's 85.0 floor.
+
+`git check-ignore -v` reports `.gitignore:57:artifacts/`, so the file is gitignored and
+stays outside this change's diff, as the plan's Change Footprint records.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p9-t2-change-footprint.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p9-t2-change-footprint.md
@@ -1,0 +1,98 @@
+# [P9-T2] Change footprint against the merge base (Issue 638)
+
+Timestamp: 2026-08-29T12-50
+
+Command:
+
+```
+git diff --name-only ecdb1c84ba8541ab67042985919cfed4df768c01..HEAD
+git status --porcelain -uall -- QuickFiler QuickFiler.Test docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638
+```
+
+The anchored diff enumerates the tracked change against the `origin/main` merge base; the
+porcelain status is its required companion, because a name-listing diff is blind to files
+this plan created that are not yet committed.
+
+EXIT_CODE: 0
+
+Output Summary:
+
+## `git diff --name-only ecdb1c84ba8541ab67042985919cfed4df768c01..HEAD`, verbatim
+
+```
+QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs
+QuickFiler.Test/QuickFiler.Test.csproj
+QuickFiler/Controllers/EfcDataModel.cs
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t10-msbuild-analyzers.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t11-msbuild-nullable.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t12-direct-harness-baseline.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t12-vstest-coverage.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t6-dotnet-tool-restore.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t7-solution-restore.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t8-dotnet-coverage-probe.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t9-csharpier-check.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p1-t4-tree-facts.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/phase0-instructions-read.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p2-t3-seam-compile.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p3-t14-tests-compile.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p4-t6-fix-compile.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p4-t7-file-size.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p5-t3-untouched-tests.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p8-t2-followup-issue-dossier.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t1-csharpier-format.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t2-csharpier-check.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t3-msbuild-analyzers.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t4-msbuild-nullable.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t5-vstest-coverage.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t6-loop-closure.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t1-coverage-postchange.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t2-coverage-changed-lines.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t3-coverage-delta.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t4-canonical-coverage-artifact.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p3-t15-regression-fail-before.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p5-t1-regression-pass-after.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p5-t2-sentinel-tests.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/issue.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/plan.2026-08-29T07-41.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/research/2026-08-29T08-05-archive-root-guard-research.md
+docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md
+```
+
+36 paths.
+
+## `git status --porcelain -uall` companion, verbatim
+
+```
+```
+
+The output is empty: everything within the three pathspecs is committed.
+
+## Assessment against the acceptance conditions
+
+- Names `QuickFiler/Controllers/EfcDataModel.cs`: **yes**.
+- Names `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`: **yes**.
+- Names `QuickFiler.Test/QuickFiler.Test.csproj`: **yes**.
+- Names no path under `QuickFiler/` other than `QuickFiler/Controllers/EfcDataModel.cs`:
+  **satisfied** — the only other `QuickFiler`-prefixed paths are under `QuickFiler.Test/`,
+  a different directory.
+- Names no path under `TaskMaster/`, `UtilitiesCS/`, `ToDoModel/` or `.github/`:
+  **satisfied** — none appears.
+- Every remaining named path lies under
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/`:
+  **satisfied** — the remaining 33 paths are all under that folder. `issue.md` and
+  `research/2026-08-29T08-05-archive-root-guard-research.md` appear because they were added
+  by the branch's earlier commit `f07b6299`, unmodified by this plan, exactly as the plan's
+  Change Footprint anticipated.
+
+In particular the diff does **not** name any of the four read-only citations:
+
+- `QuickFiler/Controllers/EfcFormController.cs` — absent
+- `TaskMaster/AppGlobals/AppOlObjects.cs` — absent
+- `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs` — absent
+- `UtilitiesCS/Interfaces/IGlobals/IOlObjects.cs` — absent
+
+It also does not name `QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs` or
+`QuickFiler/Controllers/EfcSelectionGuard.cs`, the two remaining read-only citations.
+
+Commit: `254fd56d2e9415753c12b677476b441129306366` —
+`fix(638): guard the three unguarded archive-root reads in EfcDataModel`.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p9-t3-clean-tree.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p9-t3-clean-tree.md
@@ -1,0 +1,140 @@
+# [P9-T3] Plan execution summary and evidence index (Issue 638)
+
+Timestamp: 2026-08-29T12-52
+
+Command: `git add -- docs/.../2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638`
+then `git commit`, using the same three pathspecs as [P9-T1].
+
+EXIT_CODE: 0
+
+Output Summary: every phase of
+`plan.2026-08-29T07-41.md` executed in order. Two tasks recorded a
+REMEDIATION-REQUIRED outcome on a branch their own task text defines; both are itemized
+below. All other tasks passed their acceptance conditions.
+
+## Per-phase outcome
+
+| Phase | Title | Outcome |
+|---|---|---|
+| 0 | Baseline capture and policy reads | COMPLETE; [P0-T12] recorded REMEDIATION-REQUIRED on its exit-code justification |
+| 1 | Scope lock and citation re-derivation | COMPLETE; all four citations re-derived exactly as the plan states |
+| 2 | Diagnostic seam declaration | COMPLETE |
+| 3 | Regression tests, fail before the fix | COMPLETE; 11 tests, 5 failed as required by the `[expect-fail]` task |
+| 4 | Minimal fix | COMPLETE |
+| 5 | Regression pass after the fix | COMPLETE; 11 of 11 pass, both sentinels pass unedited |
+| 6 | Final QC toolchain loop | COMPLETE; loop ran twice, second pass clean in all five steps |
+| 7 | Coverage measurement and delta | COMPLETE; [P7-T3] recorded REMEDIATION-REQUIRED on the mode-equality clause |
+| 8 | Acceptance criteria and spec updates | COMPLETE; 18 of 20 criteria checked off, AC17 and AC20 left unchecked |
+| 9 | Commit, footprint verification, clean tree | COMPLETE |
+
+## Non-passing outcomes
+
+1. **[P0-T12] — REMEDIATION-REQUIRED.** The baseline coverage-harness run exited 1 for a
+   cause other than the 80 percent coverage threshold: one pre-existing failing test,
+   `QuickFiler.Controllers.Tests.QfcDatamodelLivenessTests.RemainingLoadActive_WhenLoaderThrows_IsStillClearedByFinally`,
+   a five-second wall-clock timing assertion in a file this change does not touch. The
+   literal `is below the required 80% threshold.` was absent from the run output, so the
+   task's own branch required recording the observed exit code without `ExpectedExitCode:`
+   and treating the task as REMEDIATION-REQUIRED. The same task's direct-harness run
+   exited 0 with `BASELINE_FAILURE_SET: none`, so the carve-out list [P6-T5] consumes is
+   empty. Every acceptance field the task requires is present.
+2. **[P7-T3] — REMEDIATION-REQUIRED.** `BASELINE_COVERAGE_XML_MODE: raw` does not equal
+   `POSTCHANGE_COVERAGE_XML_MODE: koverage-processed`, a direct consequence of the [P0-T12]
+   outcome above: the baseline run terminated before the script's post-processing step and
+   left raw root attributes on disk. The delta clause itself passes at `+14.63` points
+   against a `-0.50` tolerance, and the blocking change-scoped clause in [P7-T2] passes at
+   93.10 percent, but the mode mismatch means the repo-wide delta measures the denominator
+   rather than this change. [P8-T19] therefore left AC17 unchecked.
+
+## Measured figures
+
+```
+BASELINE_UNFORMATTED_COUNT:               0
+BASELINE_ANALYZER_ERRORS:                 0
+BASELINE_NULLABLE_ERRORS:                 0
+BASELINE_REPO_LINE_COVERAGE_PERCENT:      70.70   (COVERAGE_XML_MODE: raw)
+BASELINE_FAILURE_SET:                     none    (direct harness, exit 0)
+PRECHANGE_EFCDATAMODEL_LINE_COUNT:        423
+POSTFIX_EFCDATAMODEL_LINE_COUNT:          485
+POSTFIX_ARCHIVEROOTTESTS_LINE_COUNT:      389
+[P3-T15] fail-before:                     Total 11, Failed 5, Passed 6
+[P5-T1] pass-after:                       Total 11, Passed 11, Failed 0
+[P5-T2] sentinels:                        Total 2,  Passed 2,  Failed 0
+[P6-T5] full suite:                       Total 6870, Passed 6870, Failed 0
+[P6-T5] QuickFiler. namespace failures:   0
+[P6-T5] TaskMaster. namespace failures:   0
+POSTCHANGE_REPO_LINE_COVERAGE_PERCENT:    85.33   (COVERAGE_XML_MODE: koverage-processed)
+POSTCHANGE_REPO_BRANCH_COVERAGE_PERCENT:  79.31
+CHANGED_LINE_COVERAGE_PERCENT:            93.10   (27 of 29 lines)
+DELTA_REPO_LINE_COVERAGE_POINTS:          +14.63
+[P7-T4] Decision:                         WRITTEN
+```
+
+## Evidence artifacts produced by this plan
+
+| # | Artifact | EXIT_CODE |
+|---|---|---|
+| 1 | `evidence/baseline/phase0-instructions-read.md` | n/a (policy-read record) |
+| 2 | `evidence/baseline/p0-t6-dotnet-tool-restore.md` | 0 |
+| 3 | `evidence/baseline/p0-t7-solution-restore.md` | 0 |
+| 4 | `evidence/baseline/p0-t8-dotnet-coverage-probe.md` | 0 |
+| 5 | `evidence/baseline/p0-t9-csharpier-check.md` | 0 |
+| 6 | `evidence/baseline/p0-t10-msbuild-analyzers.md` | 0 |
+| 7 | `evidence/baseline/p0-t11-msbuild-nullable.md` | 0 |
+| 8 | `evidence/baseline/p0-t12-vstest-coverage.md` | 1 (REMEDIATION-REQUIRED) |
+| 9 | `evidence/baseline/p0-t12-direct-harness-baseline.md` | 0 |
+| 10 | `evidence/baseline/p1-t4-tree-facts.md` | 0 |
+| 11 | `evidence/other/p2-t3-seam-compile.md` | 0 |
+| 12 | `evidence/other/p3-t14-tests-compile.md` | 0 |
+| 13 | `evidence/regression-testing/p3-t15-regression-fail-before.md` | 1 (ExpectedExitCode 1) |
+| 14 | `evidence/other/p4-t6-fix-compile.md` | 0 |
+| 15 | `evidence/other/p4-t7-file-size.md` | 0 |
+| 16 | `evidence/regression-testing/p5-t1-regression-pass-after.md` | 0 |
+| 17 | `evidence/regression-testing/p5-t2-sentinel-tests.md` | 0 |
+| 18 | `evidence/other/p5-t3-untouched-tests.md` | 0 |
+| 19 | `evidence/qa-gates/p6-t1-csharpier-format.md` | 0 |
+| 20 | `evidence/qa-gates/p6-t2-csharpier-check.md` | 0 |
+| 21 | `evidence/qa-gates/p6-t3-msbuild-analyzers.md` | 0 |
+| 22 | `evidence/qa-gates/p6-t4-msbuild-nullable.md` | 0 |
+| 23 | `evidence/qa-gates/p6-t5-vstest-coverage.md` | 0 |
+| 24 | `evidence/qa-gates/p6-t6-loop-closure.md` | 0 |
+| 25 | `evidence/qa-gates/p7-t1-coverage-postchange.md` | 0 |
+| 26 | `evidence/qa-gates/p7-t2-coverage-changed-lines.md` | 0 |
+| 27 | `evidence/qa-gates/p7-t3-coverage-delta.md` | 0 (REMEDIATION-REQUIRED) |
+| 28 | `evidence/qa-gates/p7-t4-canonical-coverage-artifact.md` | 0 |
+| 29 | `evidence/other/p8-t2-followup-issue-dossier.md` | 0 |
+| 30 | `evidence/qa-gates/p9-t2-change-footprint.md` | 0 |
+| 31 | `evidence/qa-gates/p9-t3-clean-tree.md` | 0 (this file) |
+
+31 artifact paths, all relative to
+`docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/`.
+
+## Acceptance-criteria status against `spec.md`
+
+- Source: `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md`
+- Total AC items: 20
+- Checked off: 18 (AC1 through AC16, AC18, AC19)
+- Remaining: 2
+  - **AC17** — coverage. Left unchecked because [P7-T3] is REMEDIATION-REQUIRED on the
+    mode-equality clause. The change-scoped measurement it also demands passes at 93.10
+    percent.
+  - **AC20** — the three follow-up issues for the non-goals are not yet filed. The
+    ready-to-file dossier is `evidence/other/p8-t2-followup-issue-dossier.md`; filing is an
+    orchestrator responsibility under
+    `.claude/skills/feature-promotion-lifecycle/SKILL.md`.
+
+## Files changed by this plan
+
+- `QuickFiler/Controllers/EfcDataModel.cs` (modified)
+- `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` (created)
+- `QuickFiler.Test/QuickFiler.Test.csproj` (modified — one `<Compile Include>` entry)
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md`
+  (AC check-offs and header fields)
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/plan.2026-08-29T07-41.md`
+  (checklist and header)
+- the 31 evidence artifacts listed above
+
+Paths written but outside the diff because they are gitignored:
+`artifacts/csharp/coverage.xml`, `coverage/coverage.cobertura.xml`, the `TestResults`
+run directories and MSBuild transcripts, and the `packages/` directory materialized by
+[P0-T7].

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p3-t15-regression-fail-before.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p3-t15-regression-fail-before.md
@@ -1,0 +1,68 @@
+# [P3-T15] `[expect-fail]` regression run before the fix (Issue 638)
+
+Timestamp: 2026-08-29T12-32
+
+Command:
+
+```
+$vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -find "Common7\IDE\Extensions\TestPlatform\vstest.console.exe" | Select-Object -First 1
+& $vs QuickFiler.Test\bin\Debug\QuickFiler.Test.dll /InIsolation /Logger:trx /ResultsDirectory:TestResults\p3-t15 /TestCaseFilter:"FullyQualifiedName~EfcDataModelArchiveRootTests"
+```
+
+The `vstest.console.exe` path is recorded unresolved, as the vswhere expression, because
+the resolved path is absolute. `QuickFiler.Test\bin\Debug\QuickFiler.Test.dll` is the
+Debug|AnyCPU `<OutputPath>` at `QuickFiler.Test/QuickFiler.Test.csproj:36`. The run has its
+own `/ResultsDirectory` so its TRX cannot collide with the Phase 5 and Phase 6 runs.
+
+EXIT_CODE: 1
+
+ExpectedExitCode: 1
+
+Output Summary:
+
+This is the `[expect-fail]` task. A failing run is the expected and required outcome here,
+because the archive-root guard has not been written yet; Phase 4 adds it and [P5-T1]
+re-runs the same eleven tests and requires them all to pass.
+
+## Counts
+
+```
+Total tests: 11
+     Passed: 6
+     Failed: 5
+```
+
+## The five failing tests
+
+Exactly the five the plan names, and no others:
+
+1. `MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing`
+2. `MoveToFolderAsync_WhenArchiveRootIsCrossStoreUnresolvable_ReturnsFalseInsteadOfThrowing`
+3. `OpenOlFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns`
+4. `OpenFsFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns`
+5. `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress`
+
+Each of the five failure messages names `InvalidOperationException`. A
+`Select-String -SimpleMatch 'InvalidOperationException'` over the run output returned
+exactly **5** matches, one per failing test. Each message takes the form:
+
+```
+Test method QuickFiler.Test.Controllers.EfcDataModelArchiveRootTests.<test name> threw exception: System.InvalidOperationException: ...
+```
+
+The failures are therefore genuine runtime failures caused by the unguarded archive-root
+read escaping the method, not build failures — [P3-T14] recorded `0 Error(s)` immediately
+before this run. Stack traces are deliberately not reproduced: their frames carry absolute
+source paths, which no artifact this plan writes may contain.
+
+## The six tests that already pass
+
+These pin behavior that is correct before the fix and are expected to pass in this run,
+which they did:
+
+- `MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce`
+- `MoveToFolderAsync_WhenMailInfoIsNull_ReturnsFalseWithoutReadingArchiveRoot`
+- `MoveToFolderAsync_WhenOneDriveIsMissing_ReturnsFalseWithoutReadingArchiveRoot`
+- `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates`
+- `OpenOlFolderAsync_WhenOneDriveIsMissing_ReturnsWithoutReadingArchiveRoot`
+- `OpenFsFolderAsync_WhenOneDriveIsMissing_ReturnsWithoutReadingArchiveRoot`

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p5-t1-regression-pass-after.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p5-t1-regression-pass-after.md
@@ -1,0 +1,45 @@
+# [P5-T1] Regression run after the fix (Issue 638)
+
+Timestamp: 2026-08-29T12-35
+
+Command:
+
+```
+$vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -find "Common7\IDE\Extensions\TestPlatform\vstest.console.exe" | Select-Object -First 1
+& $vs QuickFiler.Test\bin\Debug\QuickFiler.Test.dll /InIsolation /Logger:trx /ResultsDirectory:TestResults\p5-t1 /TestCaseFilter:"FullyQualifiedName~EfcDataModelArchiveRootTests"
+```
+
+Identical to [P3-T15] in executable resolution, assembly and filter; only the
+`/ResultsDirectory` differs, so the TRX cannot collide with the [P3-T15] or Phase 6 runs.
+The `vstest.console.exe` path is recorded unresolved because the resolved path is absolute.
+
+EXIT_CODE: 0
+
+Output Summary:
+
+## Counts
+
+```
+Total tests: 11
+     Passed: 11
+```
+
+No `Failed:` summary line was emitted, so Failed: 0.
+
+## The eleven test names, all passing
+
+1. `MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing`
+2. `MoveToFolderAsync_WhenArchiveRootIsCrossStoreUnresolvable_ReturnsFalseInsteadOfThrowing`
+3. `OpenOlFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns`
+4. `OpenFsFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns`
+5. `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress`
+6. `MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce`
+7. `MoveToFolderAsync_WhenMailInfoIsNull_ReturnsFalseWithoutReadingArchiveRoot`
+8. `MoveToFolderAsync_WhenOneDriveIsMissing_ReturnsFalseWithoutReadingArchiveRoot`
+9. `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates`
+10. `OpenOlFolderAsync_WhenOneDriveIsMissing_ReturnsWithoutReadingArchiveRoot`
+11. `OpenFsFolderAsync_WhenOneDriveIsMissing_ReturnsWithoutReadingArchiveRoot`
+
+The five tests that [P3-T15] recorded failing with `InvalidOperationException` now pass,
+and the six that already passed before the fix still pass. Together with
+`p3-t15-regression-fail-before.md` this is the fail-before / pass-after pair.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p5-t2-sentinel-tests.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p5-t2-sentinel-tests.md
@@ -1,0 +1,42 @@
+# [P5-T2] Ordering-sentinel tests (Issue 638)
+
+Timestamp: 2026-08-29T12-35
+
+Command:
+
+```
+$vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -find "Common7\IDE\Extensions\TestPlatform\vstest.console.exe" | Select-Object -First 1
+& $vs QuickFiler.Test\bin\Debug\QuickFiler.Test.dll /InIsolation /Logger:trx /ResultsDirectory:TestResults\p5-t2 /TestCaseFilter:"FullyQualifiedName~OpenFolderMethods_DelegateToDataModelWithoutExternalServices|FullyQualifiedName~HandleMoveResult_WhenMoveFails_RoutesMessageThroughInjectedAction"
+```
+
+Same executable resolution and assembly as [P3-T15]. The `vstest.console.exe` path is
+recorded unresolved because the resolved path is absolute.
+
+EXIT_CODE: 0
+
+Output Summary:
+
+```
+  Passed HandleMoveResult_WhenMoveFails_RoutesMessageThroughInjectedAction [133 ms]
+  Passed OpenFolderMethods_DelegateToDataModelWithoutExternalServices [65 ms]
+Total tests: 2
+     Passed: 2
+```
+
+No `Failed:` summary line was emitted, so Failed: 0.
+
+Both sentinels pass unmodified. Their significance:
+
+- `OpenFolderMethods_DelegateToDataModelWithoutExternalServices`
+  (`QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs:207-218`) asserts
+  `probe.FileSystem.SpecialFoldersAccessCount.Should().Be(2)` at `:217`. It still passes,
+  which proves the archive-root guard was placed strictly **after** the OneDrive
+  `SpecialFolders` read in both folder-open methods. Placing the guard first would have
+  dropped that counter from 2 to 0 and additionally raised `NullReferenceException` from
+  the probe's null `Ol` at `:388`, which a `catch (InvalidOperationException)` does not
+  absorb.
+- `HandleMoveResult_WhenMoveFails_RoutesMessageThroughInjectedAction`
+  (`QuickFiler.Test/Controllers/EfcHomeControllerExecuteMovesTests.cs:160-175`) asserts the
+  exact string `Cannot move to folderpath Archive/Target` at `:174`. It still passes,
+  which proves the new `UserDiagnosticAction` seam did not disturb the existing
+  `MoveFailureMessageAction` routing it is modelled on.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/remediation-baseline/ac17-commensurable-baseline.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/remediation-baseline/ac17-commensurable-baseline.md
@@ -1,0 +1,72 @@
+# AC17 remediation — commensurable merge-base coverage baseline (Issue 638)
+
+Timestamp: 2026-08-29T12-57
+
+Command: `pwsh -NoProfile -File scripts/vscode/Invoke-MSTestWithCoverage.ps1 -SearchRoot . -Configuration Debug -CoverageOutput coverage/coverage.cobertura.xml`
+
+EXIT_CODE: 0
+
+Output Summary: the merge-base coverage harness completed successfully and reached
+post-processing, producing a `koverage-processed` baseline commensurable with the
+post-change `[P7-T1]` figure. `Test Run Successful. Total tests: 6859, Passed: 6859,
+Total time: 44.9009 Seconds.` Root attributes of the post-processed Cobertura file:
+`line-rate=0.852636`, `branch-rate=0.792376`, `lines-covered=54735`, `lines-valid=64195`,
+across 9 `<package>` elements.
+
+```
+BASELINE_REPO_LINE_COVERAGE_PERCENT:    85.26
+BASELINE_REPO_BRANCH_COVERAGE_PERCENT:  79.24
+BASELINE_LINES_COVERED:                 54735
+BASELINE_LINES_VALID:                   64195
+BASELINE_PACKAGE_COUNT:                 9
+COVERAGE_XML_MODE:                      koverage-processed
+```
+
+## Why this measurement was taken
+
+`[P7-T3]` recorded `REMEDIATION-REQUIRED` because `[P0-T12]` produced
+`COVERAGE_XML_MODE: raw` while `[P7-T1]` produced `COVERAGE_XML_MODE: koverage-processed`.
+A raw figure and a post-processed figure are computed over different denominators — the raw
+file carried 14 `<package>` elements including every `.Test` assembly and `lines-valid=82363`,
+the post-processed file carries 9 and `lines-valid=64221` — so their difference measures the
+denominator rather than this change. AC17 requires the repository-wide figure to be captured
+for both runs and the change shown not to lower it, which is not evaluable across unequal
+modes.
+
+The cause of the raw baseline was not this change. `[P0-T12]`'s harness run terminated early
+on one pre-existing failing test,
+`QuickFiler.Controllers.Tests.QfcDatamodelLivenessTests.RemainingLoadActive_WhenLoaderThrows_IsStillClearedByFinally`,
+a five-second wall-clock timing assertion in a file this change does not touch, so the run
+never reached the post-processing step. `scripts/vscode/Invoke-MSTestWithCoverage.ps1:341`
+asserts the threshold on post-processed content and `:343` writes that content back only
+afterwards, so an earlier termination leaves the raw `dotnet-coverage` root attributes on
+disk.
+
+## How this measurement was isolated
+
+The measurement was taken at the merge base `ecdb1c84ba8541ab67042985919cfed4df768c01` in a
+separate detached git worktree, so the feature worktree, its build outputs and its committed
+evidence were not disturbed. The gitignored `packages/` and `.dotnet-sdk/` directories were
+copied from the feature worktree rather than restored, so the analyzer package set and SDK
+version are identical between the two measurements and cannot contribute to the difference.
+The solution was rebuilt with `/t:Rebuild` before the harness ran.
+
+The same flaky liveness test passed in this run, all 6859 tests passed, the harness exited 0
+and the post-processing step ran. That is the whole of the remediation: the baseline is now
+measured in the same mode as the post-change figure.
+
+## Relationship to the original baseline
+
+The original `[P0-T12]` artifact remains the authoritative record of what was measured during
+plan execution and is not superseded or edited. This artifact adds the commensurable
+measurement that `[P7-T3]` identified as missing, per the remediation-reconciliation rule in
+`.claude/skills/evidence-and-timestamp-conventions/SKILL.md`. The recomputed delta is recorded
+in `evidence/qa-gates/ac17-coverage-delta-recomputed.md`.
+
+## Negative evidence claims
+
+SearchScope: `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/`
+SearchPatterns: `p0-t12-*.md`
+SearchResult: `p0-t12-vstest-coverage.md` (raw mode) and `p0-t12-direct-harness-baseline.md`
+(direct harness, exit 0, `BASELINE_FAILURE_SET: none`). No pre-existing `koverage-processed`
+baseline artifact existed before this measurement.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/feature-audit.2026-08-29T13-06.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/feature-audit.2026-08-29T13-06.md
@@ -1,0 +1,146 @@
+# Feature Audit — Issue #638 (EFC unguarded archive-root read)
+
+- **Branch:** `bug/efc-unguarded-archive-root-read-crashes-ui-thread-638`
+- **Base / merge base:** `ecdb1c84ba8541ab67042985919cfed4df768c01`
+- **Head:** `af1b36e2d93c6beeeb98bbe4998d752e1ebfd732`
+- **Audit date:** 2026-08-29T13-06
+- **Work mode:** `full-bug` — marker read from `issue.md:8`
+- **AC source:** `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md` § Acceptance Criteria, **sole** source
+- **`user-story.md`:** correctly absent. Under `full-bug`, `.claude/skills/acceptance-criteria-tracking/SKILL.md` names `spec.md` only. Its absence is not a defect and is not reported as one.
+
+## Verdict
+
+**PASS. 20 of 20 acceptance criteria verified. 0 blocking findings.**
+
+All 20 criteria were arrived at `[x]` in `spec.md`. Each was re-verified against primary evidence —
+source reads, the branch diff, the Cobertura file, and the committed gate artifacts — rather than
+accepted on the check-off. No criterion was found checked-but-unsupported. This audit changed no
+checkbox: none needed setting and none needed contesting.
+
+## Acceptance Criteria Evaluation
+
+| AC | Criterion (abbreviated) | Verdict | Verification performed by this audit |
+|---|---|---|---|
+| AC1 | `MoveToFolderAsync(string,...)` returns `false` instead of propagating when `ArchiveRootPath` throws `InvalidOperationException` | PASS | Source read at `EfcDataModel.cs:327-330`: `if (!TryGetArchiveRoot(out var olAncestor)) { return false; }`. Test `MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing` present at `:46-62` asserting `moved.Should().BeFalse()`. Recorded failing pre-fix and passing post-fix in the paired regression artifacts. |
+| AC2 | `OpenOlFolderAsync` completes without throwing and invokes the seam exactly once | PASS | Source read at `:356-360`: seam invoked then `return`, one call on the path. Test at `:92-110` asserts `reported.Should().ContainSingle()`, which is an exactly-one assertion, not an at-least-one assertion. Absence of a throw is proven by the `await` completing before the assertion. |
+| AC3 | `OpenFsFolderAsync` completes without throwing and invokes the seam exactly once | PASS | Source read at `:380-384`, identical shape. Test at `:117-135`, same `ContainSingle()` assertion. |
+| AC4 | The user-visible diagnostic contains neither a mailbox address nor the archive root path | PASS | The constant at `:264-268` is a fixed two-part string naming the rule; it interpolates nothing. Test `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress` at `:142-162` asserts the captured message contains neither `mailbox@example.com` nor the archive-path literal. The assertion targets the seam's own output, which is the correct target. |
+| AC5 | The archive-root guard sits after the OneDrive `SpecialFolders` read in all three methods | PASS | Source read confirms ordering in all three: `MoveToFolderAsync` `:321-325` then `:327-330`; `OpenOlFolderAsync` `:351-354` then `:356-360`; `OpenFsFolderAsync` `:376-379` then `:380-384`. Pinned from the production side by `MoveToFolderAsync_WhenOneDriveIsMissing_ReturnsFalseWithoutReadingArchiveRoot` plus the two `Open*` equivalents, all `Times.Never()`. Pinned from the untouched side by `EfcHomeControllerLifecycleTests.cs:217` — read directly, still `SpecialFoldersAccessCount.Should().Be(2)`, and the file is absent from the branch diff. |
+| AC6 | The `MailInfo is null` guard remains the first check in `MoveToFolderAsync` | PASS | Source read at `:311-314`: it is the first statement of the method body, before the `attachments` local, the conversation lookup and the OneDrive guard. `MoveToFolderAsync_WhenMailInfoIsNull_ReturnsFalseWithoutReadingArchiveRoot` at `:193-215` asserts `Times.Never()` on the archive-root getter. |
+| AC7 | The success path reads `ArchiveRootPath` exactly once per call | PASS | `TryGetArchiveRoot` contains a single read at `:284`, and each caller invokes it once. `MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce` at `:171-186` asserts `VerifyGet(..., Times.Once())`. See CR-1 in the code review for a non-blocking robustness note about that test's stopping barrier; the `VerifyGet` itself is sound. |
+| AC8 | The catch is narrowed to `InvalidOperationException`; a `COMException` still propagates | PASS | Source read at `:287`: `catch (InvalidOperationException ex)`, the only catch added. Grep of the changed hunks confirms no `catch (Exception)` and no `catch (COMException)`. `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates` at `:248-262` asserts `await act.Should().ThrowAsync<COMException>()`. |
+| AC9 | Both documented throw conditions are covered, not only one | PASS | Two tests inject `InvalidOperationException` carrying, respectively, the unresolvable-root text and the cross-store/renamed text, matching the constants at `ArchiveRootPathGuard.cs:13-17`. Recorded with a note: production dispatches on exception type and never inspects the message, so the two tests drive identical production statements. See CR-2. The criterion as written asks that both conditions be exercised, which they are; the note is about the strength of the evidence, not its existence. |
+| AC10 | Public and internal signatures unchanged | PASS | `git diff` against the merge base shows no alteration to any of `Task<bool> MoveToFolderAsync(string, bool, bool, bool, bool)`, `Task OpenOlFolderAsync(string)` or `Task OpenFsFolderAsync(string)`; the only edits inside those methods are the inserted guard and the changed right-hand side of `OlAncestor`. All six protected test files are absent from `git diff --name-only`, and all compiled and passed in the 6870-test run. |
+| AC11 | The new test file is registered in the legacy `.csproj` and its tests appear in the executed list | PASS | `<Compile Include="Controllers\EfcDataModelArchiveRootTests.cs" />` present in the diff at `QuickFiler.Test.csproj:116`. Registration proven effective, not merely present: `ARCHIVEROOT_TESTS_EXECUTED: 11` in the full-suite TRX derivation, and the total arithmetic 6859 + 11 = 6870 is consistent. |
+| AC12 | Fail-before / pass-after evidence exists under `evidence/regression-testing/` | PASS | `p3-t15-regression-fail-before.md`: exit 1, 11 tests, 5 failed, one `InvalidOperationException` per failure, and the five names are exactly AC1-AC4 plus the redaction test. `p5-t1-regression-pass-after.md`: exit 0, 11 of 11. Both under the canonical sub-path. Recorded with a wording note: the fail-before run executed against code that already carried the Phase-2 seam declaration, which is structurally required for the tests to compile and is behaviourally inert until Phase 4 adds its three invocation sites. The proof of the unguarded read is unaffected. |
+| AC13 | Format gate reports no unformatted files, via `dotnet tool run` | PASS | `evidence/qa-gates/p6-t2-csharpier-check.md`: exit 0, `Checked 1561 files in 4097ms.`, zero `Error <path> - Was not formatted.` lines. The recorded command is `dotnet tool run csharpier check .`, so the manifest-pinned version was used. File count rose by exactly one against the 1560-file baseline, consistent with one new `.cs` file. |
+| AC14 | Analyzer gate: `0 Error(s)` and zero `Skipping target "CoreCompile"` | PASS | `evidence/qa-gates/p6-t3-msbuild-analyzers.md`: exit 0, `0 Error(s)`, `5 Warning(s)` equal to the merge-base baseline, and 0 occurrences of the literal `Skipping target "CoreCompile"` against 86 `CoreCompile` invocations in the tee'd log. The recorded command uses `/t:Rebuild` and carries both analyzer properties. |
+| AC15 | Type-check gate: `0 Error(s)`, zero `CoreCompile` skips, no `/p:Nullable=enable`, no `/t:Build` | PASS | `evidence/qa-gates/p6-t4-msbuild-nullable.md`: exit 0, `0 Error(s)`, `5 Warning(s)`, 0 `Skipping target "CoreCompile"`. The recorded command line contains `/t:Rebuild` and `/p:TreatWarningsAsErrors=true` and contains neither prohibited token, matching `.github/workflows/ci.yml` character for character. |
+| AC16 | Test gate reports zero failures across `QuickFiler.Test` and `TaskMaster.Test`; no `LiveOutlook` category in the change | PASS | `evidence/qa-gates/p6-t5-vstest-coverage.md`: exit 0, 9 assemblies discovered including both named ones, 6870 of 6870 passed, per-namespace TRX join giving `QuickFiler.` = 0 failed and `TaskMaster.` = 0 failed, and 0 executed `LiveOutlook` tests. Independently confirmed by grep that the new test file contains zero `TestCategory` occurrences. The run carried CI's `/InIsolation` and `/TestCaseFilter:"TestCategory!=LiveOutlook"`. |
+| AC17 | Changed lines >= 90% line coverage, no changed-line regression, repo-wide figures captured for both runs and shown not lowered | PASS | Changed-line figure independently recomputed from `coverage/coverage.cobertura.xml` during this audit: 27 covered of 29 valid = **93.10 percent**, uncovered lines 366 and 390 — reproducing `p7-t2-coverage-changed-lines.md` exactly, figure and line identities. Repo-wide figures independently re-read from the Cobertura root: `line-rate=0.853335`, `branch-rate=0.79311`, 9 packages. Baseline captured under `evidence/baseline/` and, after remediation, under `evidence/remediation-baseline/`; post-change under `evidence/qa-gates/`. The `[P7-T3]` mode-mismatch remediation is adjudicated **sound** in the policy audit § 5 on four independent corroborations: mode equality, package-count equality, denominator arithmetic (`64221 - 64195 = 26` = the newly added executable lines) and numerator arithmetic (`+67`, consistent with 11 new tests). The remediation artifact claims only "not lowered", which is what this criterion requires. |
+| AC18 | Change footprint is exactly the three source files plus this feature folder | PASS | `git diff --name-only` against the merge base returns 38 paths: the three source files and 35 feature-folder documents. `EfcFormController.cs`, `AppOlObjects.cs`, `ArchiveRootPathGuard.cs` and `IOlObjects.cs` are all absent. Line deltas match the criterion's premise: `EfcDataModel.cs` 423 to 485, the new test file 389, the `.csproj` +1. `git status --short` in the review worktree is empty, so nothing is staged or untracked outside the diff. |
+| AC19 | `EfcDataModel.cs` remains at or under 500 lines | PASS | `awk END{print NR}` gives 485 at head and 423 at the merge base via `git show`. 15 lines of headroom remain. |
+| AC20 | The three non-goals are each filed as a separate follow-up issue with the numbers recorded in Rollout & Follow-up | PASS | The three numbers #696, #697 and #698 are recorded in `spec.md` § Rollout & Follow-up in two places: the post-fix task list at `:815` and the Links list at `:833-840`, the latter mapping each number to its non-goal letter and URL. `evidence/other/p8-t2-followup-issue-dossier.md` carries exactly three sections, one per non-goal, and they correspond one-to-one to non-goals (a), (b) and (c) in `spec.md` § Scope & Non-Goals — (a) `COMException` from the getter's COM calls, (b) the log-only `async void` boundary sinks, (c) the five archive-root reads in `EfcFormController`. Each section carries a title, body, verified citations and `ProposedLabels:`. The dossier's appended `RESOLVED` section records the filing route and the number-to-non-goal mapping, which agrees with the spec. The remote existence of the three issues was not queried because the reviewing directive prohibits `gh`; see G4/G5 in the policy audit. |
+
+### Verdict distribution
+
+| Verdict | Count |
+|---|---|
+| PASS | 20 |
+| PARTIAL | 0 |
+| FAIL | 0 |
+| UNVERIFIED | 0 |
+
+## Scrutiny of the two orchestrator-closed criteria
+
+The directive singled out AC17 and AC20 as closed after plan execution rather than by the executor.
+Both were examined more closely than the rest.
+
+**AC17 — sound.** The executor was right to refuse the original comparison: a `raw` merge-base figure
+(14 packages, `lines-valid=82363`, every `.Test` assembly in the denominator) against a
+`koverage-processed` post-change figure (9 packages, `lines-valid=64221`) measures the denominator,
+not the change. The `+14.63`-point "improvement" that comparison produced was an artefact and would
+have been a false pass. The remediation removes the defect at its source by re-measuring the merge
+base in the same mode, in an isolated detached worktree, with `packages/` and `.dotnet-sdk/` copied
+from the feature worktree so the analyzer set and SDK cannot contribute to the difference, after a
+`/t:Rebuild`. It exited 0 with 6859 of 6859 passing and reached post-processing, which is precisely
+the step the original baseline run never reached.
+
+Two things raise confidence beyond the artifact's own narrative. First, the arithmetic closes
+independently: the denominator grew by exactly 26 lines, and 26 is the count of newly added
+executable lines in `EfcDataModel.cs` derived separately in this audit from the `git diff -U0` hunks
+intersected with the Cobertura line set. Second, the artifact is appropriately modest — it states
+that line counts drift between runs on a suite this size and claims only "not lowered" rather than
+presenting `+0.07` as a measured improvement. That is the claim AC17's text requires. The original
+`[P7-T3]` artifact was left unedited with a clearly delimited appended `RESOLVED` section, which is
+the correct reconciliation form.
+
+**AC20 — sound within the verification the directive assigns.** Both halves hold. The three numbers
+are recorded in the spec's Rollout & Follow-up section, twice, with each number bound to its
+non-goal letter and URL. The dossier's three sections correspond one-to-one to the spec's three
+non-goals, and each carries the citations a filer would need. One residual is recorded in the policy
+audit as G5: the dossier states the promoted records are retained under
+`docs/features/potential/promoted/`, and no entry for these three is present in the review worktree,
+whose tree is clean. Those records were created in whichever worktree the promotion tooling ran.
+AC20's text requires the numbers to be recorded in the spec, which they are, so this does not affect
+the verdict; it is worth confirming before the feature folder is archived.
+
+## Baseline comparison
+
+Behavior at `ecdb1c84`, from the spec's verified tracing and confirmed by reading the pre-change file
+through `git show`:
+
+`Globals.Ol.ArchiveRootPath` was read unguarded at three sites inside `EmailFilerConfig` object
+initializers. An unresolvable archive root raised `InvalidOperationException`, which unwound through
+four frames with no catch and was absorbed by `EfcFormController`'s log-only `BoundaryErrorSink`.
+Because `ActionOkAsync` hides the form before awaiting the move and disposes it afterwards, the
+observable result was a vanished window, no message, no filed mail, and `Dispose()` and `Cleanup()`
+skipped. With no negative caching on the backing field, the failure recurred on every attempt.
+
+Behavior at `af1b36e2`:
+
+`MoveToFolderAsync` returns `false` before constructing `EmailFiler`; the sole caller of that
+overload routes `false` to `HandleMoveResult` and then to `MoveFailureMessageAction`, so the user is
+told the move failed and `ActionOkAsync` proceeds to `Dispose()` and `Cleanup()`. The two `Open*`
+methods surface a redacted diagnostic through the new seam and return normally. One `logger.Warn`
+entry is written per guarded failure. `COMException` and every other exception type still propagate.
+`OlAncestor` is never assigned an empty or synthesized value, so the #614 store-root-leak failure
+mode is not reintroduced.
+
+The behavior change is confined to the three guarded paths. No other production file is touched, no
+signature changes, no configuration key is added, and rollback is a straight revert with no
+migration.
+
+## Findings
+
+Blocking findings: **0**.
+
+Non-blocking observations are recorded in the policy audit § 8 (G1 through G7) and the code review
+(CR-1 through CR-7). The two that bear on acceptance criteria specifically:
+
+- **AC9's evidence is weaker than its wording suggests** (CR-2). The two throw-condition tests differ
+  only by the message string of the injected exception, and production dispatches on type. They drive
+  identical production statements. The criterion asks that both conditions be exercised, which they
+  are; a stronger test is not constructible at the `IOlObjects` seam, and the guard's own
+  message-level behavior is already pinned upstream in
+  `TaskMaster.Test/AppGlobals/AppOlObjectsArchiveRootValidationTests.cs`, which this change correctly
+  leaves untouched. Verdict remains PASS.
+- **AC12's phrase "unmodified production code" is imprecise** (G3). The fail-before run executed
+  against production code carrying the Phase-2 seam declaration but not the Phase-4 guard. The seam
+  is inert until Phase 4 adds its three invocation sites, which the branch diff confirms, and the
+  tests could not compile without it. The five recorded `InvalidOperationException` failures are
+  genuine proof of the unguarded read. Verdict remains PASS.
+
+## Acceptance Criteria Status
+
+```
+### Acceptance Criteria Status
+- Source: docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md
+- Total AC items: 20
+- Checked off (delivered): 20
+- Remaining (unchecked): 0
+- Items remaining: none
+```
+
+No checkbox was altered by this audit. All 20 were already `[x]` on arrival and all 20 were
+independently verified against evidence.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/issue.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/issue.md
@@ -1,0 +1,96 @@
+# efc-unguarded-archive-root-read-crashes-ui-thread (Issue #638)
+
+
+- Issue: #638
+- Issue URL: https://github.com/drmoisan/TaskMaster/issues/638
+- Last Updated: 2026-08-26
+- Status: Promoted -> docs/features/active/efc-unguarded-archive-root-read-crashes-ui-thread/ (Issue #638)
+- Work Mode: full-bug
+
+## Summary
+`EfcDataModel.MoveToFolderAsync` reads `Globals.Ol.ArchiveRootPath` without a guard, and when the
+archive root cannot be resolved that read throws `InvalidOperationException` all the way out to an
+`async void` WinForms handler, which rethrows it as an unhandled UI-thread exception. The add-in
+tears down instead of degrading.
+
+This was confirmed by static tracing during issue #614 remediation. Every link in the chain was
+verified; no frame between the throw site and the UI boundary catches the exception.
+
+**Throw site.** `TaskMaster/AppGlobals/AppOlObjects.cs:253-267` exposes `ArchiveRootPath`, which
+delegates to `ArchiveRootPathGuard.RequireResolvedArchiveRoot`. That helper throws
+`InvalidOperationException` unconditionally on either of two conditions:
+`TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:44` when the archive folder does not resolve (the
+profile has no `Archive` folder in the default store), and
+`TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:56` when the resolved folder path is not
+case-insensitively equal to `Path.Combine(Root.FolderPath, "Archive")` (archive in a second store,
+renamed, or a delegate mailbox).
+
+**No negative caching.** The backing field `_archiveRootPath` is assigned only when the helper
+returns. On throw it stays null, so every subsequent read throws again. For an affected profile the
+failure is permanent and reproduces on every attempt; there is no throw-once-then-degrade behavior.
+
+**Unguarded read.** `QuickFiler/Controllers/EfcDataModel.cs:289` performs
+`OlAncestor = Globals.Ol.ArchiveRootPath` inside the `string` overload of `MoveToFolderAsync`. The
+method body at `QuickFiler/Controllers/EfcDataModel.cs:259-297` contains no try/catch. The read is
+reached unconditionally once the two early `return false` guards
+(`QuickFiler/Controllers/EfcDataModel.cs:267-270` and `:277-281`) pass. The same unguarded pattern
+appears at `QuickFiler/Controllers/EfcDataModel.cs:310` in `OpenOlFolderAsync` and at `:328` in
+`OpenFsFolderAsync`.
+
+**Propagation chain, no handler.** `QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:86-109`
+has no try. `ExecuteMovesCoreAsync` at `QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:64-84`
+has no try. `ExecuteMovesAsync` at
+`QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:31-46` wraps its core in `try` / `finally`
+with **no catch**; the `finally` resets execution state and the exception continues unchanged. This
+frame is the one most likely to be mistaken for a handler, and it is not one.
+`EfcFormController.ActionOkAsync` has no try/catch around its await.
+
+**Boundary.** `QuickFiler/Controllers/EfcFormController.cs:429-443` is
+`public async void ButtonOK_Click(...)`, wired to a WinForms `Button.Click` at
+`QuickFiler/Controllers/EfcFormController.cs:389`. Its catch logs and then **rethrows** at
+`QuickFiler/Controllers/EfcFormController.cs:441`. A rethrow from `async void` reposts to the
+captured WinForms `SynchronizationContext`, producing an unhandled UI-thread exception. The same
+`async void` + log + rethrow shape appears at `:413-427`, `:445-459`, `:461-519` and `:521`.
+
+**Relationship to other issues.** This is distinct from issue #637, which covers producer-side
+normalization of rooted paths at `BreadcrumbBridgeRouter.SelectRow` and the half-wired D8
+normalizer. This defect is an archive-root *resolution failure*, not a path-rootedness problem, and
+it fires even when the selection is a perfectly well-formed archive-relative stem. It is also
+pre-existing rather than introduced by issue #614: the crash path is present at pre-remediation head
+`02092504`, was neither created nor removed by remediation cycle 1, and is unchanged by the cycle-2
+partial revert.
+
+One nuance worth recording. Remediation cycle 1 added
+`EfcSelectionGuard.ResolveArchiveRootOrEmpty` at `QuickFiler/Controllers/EfcFormController.cs:708`,
+which catches `InvalidOperationException` and degrades to an empty root. That made the OK path look
+protected while leaving the second, unguarded read at
+`QuickFiler/Controllers/EfcDataModel.cs:289` to crash anyway, because
+`EfcSelectionGuard.IsValidFilingSelection` returns true for any non-rooted value regardless of the
+archive root. The cycle-2 partial revert removes that call site, so the misleading appearance of
+handling goes away, but the underlying crash does not.
+
+**Suggested direction.** Route the reads at `QuickFiler/Controllers/EfcDataModel.cs:289`, `:310` and
+`:328` through the same degrade-and-report path used elsewhere, or have the filing entry point
+reject with a user-facing message when the archive root cannot be resolved, rather than allowing an
+`InvalidOperationException` to reach an `async void` boundary. Separately, the rethrow at
+`QuickFiler/Controllers/EfcFormController.cs:441` should be reconsidered: rethrowing from
+`async void` converts every handled-and-logged error into a process-level crash.
+
+## Environment
+- OS/version: Windows 11 Pro 10.0.26200; .NET Framework 4.8.1 VSTO add-in.
+- Command/flags used: Static reachability tracing during issue #614 remediation cycle 2.
+- Data source or fixture: Repository source on the issue #614 branch.
+
+## Steps to Reproduce
+1. Use an Outlook profile whose archive folder does not resolve to the default store's `Archive`
+   folder - for example a profile with no `Archive` folder, or one whose archive lives in a second
+   store such as `\mailbox@example.com\Archive`, or a renamed archive folder.
+2. Open the QuickFiler email-filer form with `InitTypeEnum.Sort`.
+3. Select a valid archive-relative destination stem such as `Clients\North` - a non-rooted value
+   that the OK-path guard accepts.
+4. Press OK.
+5. Observe an unhandled `InvalidOperationException` on the UI thread rather than a message box.
+
+## Expected Behavior
+An unresolvable archive root produces a clear, user-facing diagnostic and leaves the add-in running.
+No archive-root resolution failure reaches an `async void` handler as an unhandled exception.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/plan.2026-08-29T07-41.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/plan.2026-08-29T07-41.md
@@ -4,7 +4,7 @@
 - **Parent (optional):** none
 - **Owner:** drmoisan
 - **Last Updated:** 2026-08-29T11-09
-- **Status:** Ready for Preflight
+- **Status:** Executed
 - **Version:** 1.0
 - **Work Mode:** `full-bug`
 
@@ -248,28 +248,28 @@ Each was re-derived against the working tree of this worktree during plan author
 
 ### Phase 0 — Baseline Capture and Policy Reads
 
-- [ ] [P0-T1] Read `CLAUDE.md` in full and record its four embedded policies (General Code Change,
+- [x] [P0-T1] Read `CLAUDE.md` in full and record its four embedded policies (General Code Change,
   General Unit Test, C# Code Change, C# Unit Test) plus the `## C# Toolchain (run in this exact order)`
   section. Acceptance: the reader can quote the four toolchain commands verbatim from that section.
-- [ ] [P0-T2] Read `.claude/rules/general-code-change.md` in full. Acceptance: the 500-line file-size
+- [x] [P0-T2] Read `.claude/rules/general-code-change.md` in full. Acceptance: the 500-line file-size
   limit and the mandatory toolchain loop are recorded in the reader's notes for [P0-T5].
-- [ ] [P0-T3] Read `.claude/rules/general-unit-test.md` in full. Acceptance: the Coverage Exclusion
+- [x] [P0-T3] Read `.claude/rules/general-unit-test.md` in full. Acceptance: the Coverage Exclusion
   Policy and the Test File Location clause are recorded, together with the note that D1 supersedes the
   `tests/` mirroring clause for C# in this repository because `CLAUDE.md` outranks it.
-- [ ] [P0-T4] Read `.claude/rules/csharp.md` in full. Acceptance: its contents are recorded in the
+- [x] [P0-T4] Read `.claude/rules/csharp.md` in full. Acceptance: its contents are recorded in the
   reader's notes for [P0-T5].
-- [ ] [P0-T5] Write
+- [x] [P0-T5] Write
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/phase0-instructions-read.md`
   containing `Timestamp:`, `Policy Order:` (the four files in the order read), and an explicit list of
   the files read. Acceptance: the file exists and contains all three field labels and four file paths.
-- [ ] [P0-T6] Run `dotnet tool restore` from the worktree root and write
+- [x] [P0-T6] Run `dotnet tool restore` from the worktree root and write
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t6-dotnet-tool-restore.md`
   with `Timestamp:`, `Command:`, `EXIT_CODE:` and `Output Summary:`. Acceptance: the artifact records
   `EXIT_CODE: 0` and `Output Summary:` names CSharpier version `1.2.6`. If `dotnet` cannot resolve an
   SDK because the repo-local `.dotnet-sdk` directory named in `global.json:7` is absent, first run
   `pwsh -NoProfile -File scripts/vscode/Install-RepoDotNetSdk.ps1`, then retry, and record both
   invocations in `Output Summary:`.
-- [ ] [P0-T7] Run
+- [x] [P0-T7] Run
   `pwsh -NoProfile -File scripts/vscode/Invoke-Restore.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform "Any CPU"`
   and write
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t7-solution-restore.md`
@@ -308,14 +308,14 @@ Each was re-derived against the working tree of this worktree during plan author
   `git status --porcelain` output is empty, proving the remediation touched no
   tracked file. If the skew cannot be resolved this way, stop and report; do not proceed to [P0-T10]
   with a CS0006 baseline.
-- [ ] [P0-T8] Probe for the `dotnet-coverage` global tool with
+- [x] [P0-T8] Probe for the `dotnet-coverage` global tool with
   `Get-Command dotnet-coverage -ErrorAction SilentlyContinue`; if it is absent run
   `dotnet tool install --global dotnet-coverage`. Write
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t8-dotnet-coverage-probe.md`
   with the four schema fields and a `Resolution:` line reading either `already present` or
   `installed`. Acceptance: the artifact exists and `Output Summary:` records the resolved
   `dotnet-coverage` version string. Do not halt on absence; install and continue.
-- [ ] [P0-T9] Run `dotnet tool run csharpier check .` from the worktree root and write
+- [x] [P0-T9] Run `dotnet tool run csharpier check .` from the worktree root and write
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t9-csharpier-check.md`
   with the four schema fields. `Output Summary:` must quote the tool's final summary line verbatim and
   record `BASELINE_UNFORMATTED_COUNT:` as the count of `Error <path> - Was not formatted.` lines in the
@@ -325,7 +325,7 @@ Each was re-derived against the working tree of this worktree during plan author
   Acceptance: the artifact exists and carries a numeric `BASELINE_UNFORMATTED_COUNT:` value and a
   `BASELINE_UNFORMATTED_FILES:` line. A non-zero baseline is recorded, not repaired here; the count
   governs the branch chosen in [P6-T1] and the list is the comparison set for [P6-T2].
-- [ ] [P0-T10] Run
+- [x] [P0-T10] Run
   `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
   using the MSBuild resolved by
   `& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" | Select-Object -First 1`
@@ -341,7 +341,7 @@ Each was re-derived against the working tree of this worktree during plan author
   non-zero baseline. Do not invoke
   `scripts/vscode/Invoke-VSBuild.ps1`; it runs `scripts/vscode/Sync-PackageReferences.ps1` over every
   `.csproj` and would rewrite project files outside the change footprint.
-- [ ] [P0-T11] Run
+- [x] [P0-T11] Run
   `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:TreatWarningsAsErrors=true`
   using the same vswhere-resolved MSBuild as [P0-T10], including its `| Select-Object -First 1`
   suffix, teeing console output to `TestResults\msbuild\p0-t11.log` (creating `TestResults\msbuild`
@@ -352,7 +352,7 @@ Each was re-derived against the working tree of this worktree during plan author
   integer. If the recorded integer is non-zero, stop and report before Phase 2; [P6-T3]/[P6-T4] demand
   `0 Error(s)` and cannot be satisfied from a non-zero baseline. The command must not gain
   `/p:Nullable=enable` and must not substitute `/t:Build`.
-- [ ] [P0-T12] Run the baseline test suite in coverage mode with
+- [x] [P0-T12] Run the baseline test suite in coverage mode with
   `pwsh -NoProfile -File scripts/vscode/Invoke-MSTestWithCoverage.ps1 -SearchRoot . -Configuration Debug -CoverageOutput coverage/coverage.cobertura.xml`
   and write
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t12-vstest-coverage.md`
@@ -413,19 +413,19 @@ Each was re-derived against the working tree of this worktree during plan author
 
 ### Phase 1 — Scope Lock and Citation Re-derivation
 
-- [ ] [P1-T1] Re-derive the three unguarded read sites. Run
+- [x] [P1-T1] Re-derive the three unguarded read sites. Run
   `Select-String -Path 'QuickFiler/Controllers/EfcDataModel.cs' -SimpleMatch 'OlAncestor = Globals.Ol.ArchiveRootPath'`
   and record the matched line numbers. Acceptance: exactly three matches are returned and their line
   numbers are 289, 310 and 328.
-- [ ] [P1-T2] Re-derive the ordering sentinel. Run
+- [x] [P1-T2] Re-derive the ordering sentinel. Run
   `Select-String -Path 'QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs' -SimpleMatch 'SpecialFoldersAccessCount.Should().Be(2)'`
   and record the matched line number. Acceptance: exactly one match is returned at line 217.
-- [ ] [P1-T3] Confirm the new test file is not yet registered. Run
+- [x] [P1-T3] Confirm the new test file is not yet registered. Run
   `Select-String -Path 'QuickFiler.Test/QuickFiler.Test.csproj' -SimpleMatch 'EfcDataModelArchiveRootTests.cs'`.
   Acceptance: zero matches are returned, and
   `Select-String -Path 'QuickFiler.Test/QuickFiler.Test.csproj' -SimpleMatch 'Controllers\EfcDataModelTests.cs'`
   returns exactly one match at line 115, which is the insertion anchor for [P3-T2].
-- [ ] [P1-T4] Record the pre-change file size with
+- [x] [P1-T4] Record the pre-change file size with
   `(Get-Content -LiteralPath 'QuickFiler/Controllers/EfcDataModel.cs').Count` and write
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p1-t4-tree-facts.md`
   with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` and the four re-derived facts from
@@ -435,7 +435,7 @@ Each was re-derived against the working tree of this worktree during plan author
 
 ### Phase 2 — Diagnostic Seam Declaration
 
-- [ ] [P2-T1] Add the injectable user-diagnostic seam to `QuickFiler/Controllers/EfcDataModel.cs`,
+- [x] [P2-T1] Add the injectable user-diagnostic seam to `QuickFiler/Controllers/EfcDataModel.cs`,
   inside the `#region Public Properties` block, which spans
   `QuickFiler/Controllers/EfcDataModel.cs:146-255`. Write the declaration as
   `internal Action<string> UserDiagnosticAction { get; set; } = text => MessageBox.Show(text);`,
@@ -448,14 +448,14 @@ Each was re-derived against the working tree of this worktree during plan author
   Acceptance:
   `Select-String -Path 'QuickFiler/Controllers/EfcDataModel.cs' -SimpleMatch 'UserDiagnosticAction'`
   returns exactly one match.
-- [ ] [P2-T2] Confirm the seam is declaration-only across the production tree. Run
+- [x] [P2-T2] Confirm the seam is declaration-only across the production tree. Run
   `Get-ChildItem -Path 'QuickFiler','TaskMaster','UtilitiesCS','ToDoModel' -Recurse -Filter '*.cs' | Where-Object { $_.FullName -notmatch '\\obj\\' -and $_.FullName -notmatch '\\bin\\' } | Select-String -SimpleMatch 'UserDiagnosticAction'`.
   `Select-String` has no `-Recurse` parameter, so the file set is enumerated by `Get-ChildItem` and
   piped in; `obj` and `bin` are excluded because a build leaves generated copies of source files there.
   Acceptance: exactly one match is returned, and it is in `QuickFiler/Controllers/EfcDataModel.cs`.
   This proves the seam changes no behavior yet, so Phase 3's red is caused by the missing guard rather
   than by the seam.
-- [ ] [P2-T3] Rebuild the solution with
+- [x] [P2-T3] Rebuild the solution with
   `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU"` using the
   vswhere-resolved MSBuild from [P0-T10], including its `| Select-Object -First 1` suffix, teeing
   console output to `TestResults\msbuild\p2-t3.log` (creating `TestResults\msbuild` first;
@@ -481,7 +481,7 @@ scenario requires `MailInfo` to be null; that `CancellationTokenSource` is const
 test method with no disposal, matching `QuickFiler.Test/Controllers/EfcDataModelTests.cs:203`.
 Where a task below says "arrange as in [P3-T3]", that includes the `TestableEfcDataModel` construction.
 
-- [ ] [P3-T1] Create `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` with namespace
+- [x] [P3-T1] Create `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` with namespace
   `QuickFiler.Test.Controllers`, a `[TestClass] public class EfcDataModelArchiveRootTests`, two
   private `const string` fields holding verbatim copies of the two rule texts from
   `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:13-14` and `:16-17` (named `UnresolvableRuleText` and
@@ -525,39 +525,39 @@ Where a task below says "arrange as in [P3-T3]", that includes the `TestableEfcD
   constructor. Acceptance: the file exists, contains the literal
   `namespace QuickFiler.Test.Controllers`, contains the literal `class EfcDataModelArchiveRootTests`,
   and contains the literal `class TestableEfcDataModel : EfcDataModel`.
-- [ ] [P3-T2] Register the new file in `QuickFiler.Test/QuickFiler.Test.csproj` by inserting
+- [x] [P3-T2] Register the new file in `QuickFiler.Test/QuickFiler.Test.csproj` by inserting
   `<Compile Include="Controllers\EfcDataModelArchiveRootTests.cs" />` immediately after the existing
   `<Compile Include="Controllers\EfcDataModelTests.cs" />` entry identified in [P1-T3]. Acceptance:
   `Select-String -Path 'QuickFiler.Test/QuickFiler.Test.csproj' -SimpleMatch 'Controllers\EfcDataModelArchiveRootTests.cs'`
   returns exactly one match.
-- [ ] [P3-T3] Add `MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing`.
+- [x] [P3-T3] Add `MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing`.
   Arrange a strict `Mock<IOlObjects>` whose `ArchiveRootPath` getter throws
   `new InvalidOperationException(UnresolvableRuleText)`, a `SpecialFolders` dictionary containing the
   key `OneDrive`, and a `TestableEfcDataModel` built as defined in [P3-T1], whose `MailInfo` is
   therefore non-null. Act with `moveConversation: false`. Assert the awaited result is `false` and that the
   call does not throw. Acceptance: the test method exists with that exact name and its assert block
   contains a FluentAssertions `Should().BeFalse()` call on the awaited result.
-- [ ] [P3-T4] Add
+- [x] [P3-T4] Add
   `MoveToFolderAsync_WhenArchiveRootIsCrossStoreUnresolvable_ReturnsFalseInsteadOfThrowing`, identical
   in shape to [P3-T3] except that the getter throws
   `new InvalidOperationException(CrossStoreRuleText)`. This is the second documented throw condition
   required by AC9. Acceptance: the test method exists with that exact name and references
   `CrossStoreRuleText`.
-- [ ] [P3-T5] Add `OpenOlFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns`. Arrange as in
+- [x] [P3-T5] Add `OpenOlFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns`. Arrange as in
   [P3-T3], additionally assigning `dataModel.UserDiagnosticAction` to a capturing delegate that appends
   to a `List<string>`. Act by awaiting `OpenOlFolderAsync("Clients\\North")`. Assert the call does not
   throw and the captured list has exactly one element. Acceptance: the test method exists with that
   exact name and its assert block contains `Should().ContainSingle()` on the captured list.
-- [ ] [P3-T6] Add `OpenFsFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns`, the same shape
+- [x] [P3-T6] Add `OpenFsFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns`, the same shape
   as [P3-T5] but awaiting `OpenFsFolderAsync("Clients\\North")`. Acceptance: the test method exists
   with that exact name and its assert block contains `Should().ContainSingle()` on the captured list.
-- [ ] [P3-T7] Add `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress`. Arrange
+- [x] [P3-T7] Add `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress`. Arrange
   as in [P3-T5]. Act by awaiting `OpenOlFolderAsync("Clients\\North")`. Assert the single captured
   message contains neither `mailbox@example.com` nor `ArchiveRootLiteral`, using the redaction
   assertion style of `QuickFiler.Test/Controllers/EfcDataModelIssue614Tests.cs:58`. Acceptance: the
   test method exists with that exact name and its assert block contains two
   `Should().NotContain(...)` calls.
-- [ ] [P3-T8] Add `MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce`. Arrange a strict
+- [x] [P3-T8] Add `MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce`. Arrange a strict
   `Mock<IOlObjects>` whose `ArchiveRootPath` getter returns `ArchiveRootLiteral`, a `SpecialFolders`
   dictionary containing `OneDrive`, and an `EfcDataModel` whose `MailInfo` is a `MailItemHelper`
   created through its public parameterless constructor, whose `InitializeSafeDefaults` sets
@@ -584,7 +584,7 @@ Where a task below says "arrange as in [P3-T3]", that includes the `TestableEfcD
   `UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs:106-111` whose materialization reads
   `ArchiveRootPath` a second time and would make `Times.Once()` fail both before and after the fix.
   Acceptance: the test method exists with that exact name and contains the literal `Times.Once()`.
-- [ ] [P3-T9] Add `MoveToFolderAsync_WhenMailInfoIsNull_ReturnsFalseWithoutReadingArchiveRoot`.
+- [x] [P3-T9] Add `MoveToFolderAsync_WhenMailInfoIsNull_ReturnsFalseWithoutReadingArchiveRoot`.
   Arrange a strict `Mock<IOlObjects>` with `ArchiveRootPath` set up to throw and with no `App` setup,
   and construct a plain
   `new EfcDataModel(globals, null, new CancellationTokenSource(), CancellationToken.None)` rather than
@@ -594,12 +594,12 @@ Where a task below says "arrange as in [P3-T3]", that includes the `TestableEfcD
   Act with `moveConversation: false`. Assert the awaited result is `false` and
   `olObjects.VerifyGet(x => x.ArchiveRootPath, Times.Never())`. Acceptance: the test method exists
   with that exact name and contains the literal `Times.Never()`.
-- [ ] [P3-T10] Add `MoveToFolderAsync_WhenOneDriveIsMissing_ReturnsFalseWithoutReadingArchiveRoot`.
+- [x] [P3-T10] Add `MoveToFolderAsync_WhenOneDriveIsMissing_ReturnsFalseWithoutReadingArchiveRoot`.
   Arrange as in [P3-T3] but with an empty `SpecialFolders` dictionary. Assert the awaited result is
   `false` and `olObjects.VerifyGet(x => x.ArchiveRootPath, Times.Never())`. This pins the ordering
   constraint from the production side. Acceptance: the test method exists with that exact name and
   contains the literal `Times.Never()`.
-- [ ] [P3-T11] Add `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates`. Arrange
+- [x] [P3-T11] Add `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates`. Arrange
   exactly as in [P3-T3] — a `SpecialFolders` dictionary containing the key `OneDrive` and a
   `TestableEfcDataModel` with a non-null `MailInfo` — except that the `ArchiveRootPath` getter throws
   `new System.Runtime.InteropServices.COMException("com failure")`. Act with `moveConversation: false`
@@ -607,14 +607,14 @@ Where a task below says "arrange as in [P3-T3]", that includes the `TestableEfcD
   awaited call throws `COMException` rather than returning `false`. Acceptance: the test method exists
   with that exact name, and its assert block contains the literal `ThrowAsync` and the literal
   `COMException`.
-- [ ] [P3-T12] Add `OpenOlFolderAsync_WhenOneDriveIsMissing_ReturnsWithoutReadingArchiveRoot`.
+- [x] [P3-T12] Add `OpenOlFolderAsync_WhenOneDriveIsMissing_ReturnsWithoutReadingArchiveRoot`.
   Arrange an empty `SpecialFolders` dictionary and a throwing `ArchiveRootPath` getter. Assert the
   awaited call does not throw and `olObjects.VerifyGet(x => x.ArchiveRootPath, Times.Never())`.
   Acceptance: the test method exists with that exact name and contains the literal `Times.Never()`.
-- [ ] [P3-T13] Add `OpenFsFolderAsync_WhenOneDriveIsMissing_ReturnsWithoutReadingArchiveRoot`, the
+- [x] [P3-T13] Add `OpenFsFolderAsync_WhenOneDriveIsMissing_ReturnsWithoutReadingArchiveRoot`, the
   same shape as [P3-T12] but awaiting `OpenFsFolderAsync`. Acceptance: the test method exists with
   that exact name and contains the literal `Times.Never()`.
-- [ ] [P3-T14] Rebuild the solution with
+- [x] [P3-T14] Rebuild the solution with
   `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU"` using the
   vswhere-resolved MSBuild from [P0-T10], including its `| Select-Object -First 1` suffix, and write
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p3-t14-tests-compile.md`
@@ -622,7 +622,7 @@ Where a task below says "arrange as in [P3-T3]", that includes the `TestableEfcD
   quotes an MSBuild `Error(s)` summary line reading `0 Error(s)`. A non-zero result here means the new
   tests do not compile and must be corrected before [P3-T15]; the fail-before evidence must be a
   runtime failure, never a build failure.
-- [ ] [P3-T15] `[expect-fail]` Run only the new test class against the built `QuickFiler.Test`
+- [x] [P3-T15] `[expect-fail]` Run only the new test class against the built `QuickFiler.Test`
   assembly with the vswhere-resolved `vstest.console.exe`, resolved with
   `& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -find "Common7\IDE\Extensions\TestPlatform\vstest.console.exe" | Select-Object -First 1`,
   run against `QuickFiler.Test\bin\Debug\QuickFiler.Test.dll` — the Debug|AnyCPU `<OutputPath>` at
@@ -649,7 +649,7 @@ Where a task below says "arrange as in [P3-T3]", that includes the `TestableEfcD
 
 ### Phase 4 — Minimal Fix
 
-- [ ] [P4-T1] Add a private helper to `QuickFiler/Controllers/EfcDataModel.cs` with the signature
+- [x] [P4-T1] Add a private helper to `QuickFiler/Controllers/EfcDataModel.cs` with the signature
   `private bool TryGetArchiveRoot(out string archiveRoot)`. It reads `Globals.Ol.ArchiveRootPath`
   exactly once inside a `try`, returns `true` on success, and in
   `catch (InvalidOperationException ex)` sets `archiveRoot` to `null`, writes one
@@ -661,7 +661,7 @@ Where a task below says "arrange as in [P3-T3]", that includes the `TestableEfcD
   returns exactly one match, and
   `Select-String -Path 'QuickFiler/Controllers/EfcDataModel.cs' -SimpleMatch 'catch (InvalidOperationException'`
   returns exactly one match.
-- [ ] [P4-T2] Route the `MoveToFolderAsync(string, bool, bool, bool, bool)` read through the helper.
+- [x] [P4-T2] Route the `MoveToFolderAsync(string, bool, bool, bool, bool)` read through the helper.
   Insert `if (!TryGetArchiveRoot(out var olAncestor)) { return false; }` immediately after the OneDrive
   guard block — the `Globals.FS.SpecialFolders.TryGetValue("OneDrive", out var folderRoot)` block
   ending at `QuickFiler/Controllers/EfcDataModel.cs:281` before [P2-T1]'s insertion shifted it, since
@@ -672,7 +672,7 @@ Where a task below says "arrange as in [P3-T3]", that includes the `TestableEfcD
   body of `MoveToFolderAsync(string, ...)` the line index of the `SpecialFolders.TryGetValue` call is
   strictly less than the line index of the `TryGetArchiveRoot` call, and the line index of the
   `MailInfo is null` check is strictly less than both.
-- [ ] [P4-T3] Route the `OpenOlFolderAsync(string)` read through the helper. Insert, immediately after
+- [x] [P4-T3] Route the `OpenOlFolderAsync(string)` read through the helper. Insert, immediately after
   the OneDrive guard block — the `Globals.FS.SpecialFolders.TryGetValue("OneDrive", out var oneDrive)`
   block ending at `QuickFiler/Controllers/EfcDataModel.cs:304` before [P2-T1]'s insertion shifted it —
   a guard
@@ -681,14 +681,14 @@ Where a task below says "arrange as in [P3-T3]", that includes the `TestableEfcD
   Acceptance: within the body of `OpenOlFolderAsync` the line index of the `SpecialFolders.TryGetValue`
   call is strictly less than the line index of the `TryGetArchiveRoot` call, and exactly one
   `UserDiagnosticAction` invocation appears in that body.
-- [ ] [P4-T4] Route the `OpenFsFolderAsync(string)` read through the helper, in the same shape as
+- [x] [P4-T4] Route the `OpenFsFolderAsync(string)` read through the helper, in the same shape as
   [P4-T3], after the OneDrive guard block — the
   `Globals.FS.SpecialFolders.TryGetValue("OneDrive", out var oneDrive)` block ending at
   `QuickFiler/Controllers/EfcDataModel.cs:323` before [P2-T1]'s insertion shifted it. Acceptance:
   within the body of `OpenFsFolderAsync` the
   line index of the `SpecialFolders.TryGetValue` call is strictly less than the line index of the
   `TryGetArchiveRoot` call, and exactly one `UserDiagnosticAction` invocation appears in that body.
-- [ ] [P4-T5] Prove no unguarded read remains. Run
+- [x] [P4-T5] Prove no unguarded read remains. Run
   `Select-String -Path 'QuickFiler/Controllers/EfcDataModel.cs' -SimpleMatch 'OlAncestor = Globals.Ol.ArchiveRootPath'`
   and
   `Select-String -Path 'QuickFiler/Controllers/EfcDataModel.cs' -SimpleMatch 'Globals.Ol.ArchiveRootPath'`.
@@ -698,13 +698,13 @@ Where a task below says "arrange as in [P3-T3]", that includes the `TestableEfcD
   comment on `TryGetArchiveRoot`, violates this condition; write the doc comment without naming
   `Globals.Ol.ArchiveRootPath`. Commented-out copies of the old expression are
   prohibited, because they would defeat the first assertion.
-- [ ] [P4-T6] Rebuild the solution with
+- [x] [P4-T6] Rebuild the solution with
   `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU"` using the
   vswhere-resolved MSBuild from [P0-T10], including its `| Select-Object -First 1` suffix, and write
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p4-t6-fix-compile.md`
   with the four schema fields. Acceptance: the artifact records `EXIT_CODE: 0` and `Output Summary:`
   quotes an MSBuild `Error(s)` summary line reading `0 Error(s)`.
-- [ ] [P4-T7] Record the post-fix file size with
+- [x] [P4-T7] Record the post-fix file size with
   `(Get-Content -LiteralPath 'QuickFiler/Controllers/EfcDataModel.cs').Count` and write
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p4-t7-file-size.md`
   with the four schema fields plus `POSTFIX_EFCDATAMODEL_LINE_COUNT:`. Record the line count of
@@ -721,12 +721,12 @@ Where a task below says "arrange as in [P3-T3]", that includes the `TestableEfcD
 
 ### Phase 5 — Regression Pass After the Fix
 
-- [ ] [P5-T1] Re-run the new test class with the same command, executable resolution, assembly and
+- [x] [P5-T1] Re-run the new test class with the same command, executable resolution, assembly and
   filter as [P3-T15] but with `/ResultsDirectory:TestResults\p5-t1`, and write
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p5-t1-regression-pass-after.md`
   with the four schema fields. Acceptance: the artifact records `EXIT_CODE: 0` and `Output Summary:`
   records `Total tests: 11`, `Passed: 11` and `Failed: 0`, with each of the eleven test names listed.
-- [ ] [P5-T2] Run the two ordering-sentinel tests that must keep passing unmodified, using the
+- [x] [P5-T2] Run the two ordering-sentinel tests that must keep passing unmodified, using the
   `vstest.console.exe` resolved exactly as in [P3-T15] against the same
   `QuickFiler.Test\bin\Debug\QuickFiler.Test.dll` assembly, with
   `/InIsolation /Logger:trx /ResultsDirectory:TestResults\p5-t2 /TestCaseFilter:"FullyQualifiedName~OpenFolderMethods_DelegateToDataModelWithoutExternalServices|FullyQualifiedName~HandleMoveResult_WhenMoveFails_RoutesMessageThroughInjectedAction"`,
@@ -734,7 +734,7 @@ Where a task below says "arrange as in [P3-T3]", that includes the `TestableEfcD
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p5-t2-sentinel-tests.md`
   with the four schema fields. Acceptance: the artifact records `EXIT_CODE: 0`, `Total tests: 2`,
   `Passed: 2` and `Failed: 0`.
-- [ ] [P5-T3] Prove the six existing test files named by the spec are unedited. Run
+- [x] [P5-T3] Prove the six existing test files named by the spec are unedited. Run
   `git diff --name-only ecdb1c84ba8541ab67042985919cfed4df768c01 -- QuickFiler.Test TaskMaster.Test`
   and, as the companion required for a name-listing diff,
   `git status --porcelain -uall -- QuickFiler.Test TaskMaster.Test`;
@@ -758,7 +758,7 @@ format step is scoped to this change's two owned files so pre-existing drift is 
 change footprint, and AC13 is then resolved through [P8-T15]'s remediation branch. If any step fails
 or changes a file, restart the loop from [P6-T1].
 
-- [ ] [P6-T1] Record `Get-FileHash -Algorithm SHA256` for `QuickFiler/Controllers/EfcDataModel.cs` and
+- [x] [P6-T1] Record `Get-FileHash -Algorithm SHA256` for `QuickFiler/Controllers/EfcDataModel.cs` and
   `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`, run
   `dotnet tool run csharpier format .`, then record the same two hashes again, and write
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t1-csharpier-format.md`
@@ -770,7 +770,7 @@ or changes a file, restart the loop from [P6-T1].
   `QuickFiler/Controllers/EfcDataModel.cs` and
   `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` so the pre-existing drift is not swept
   into this change footprint, and record that branch and the baseline count in `Output Summary:`.
-- [ ] [P6-T2] Run `dotnet tool run csharpier check .` and write
+- [x] [P6-T2] Run `dotnet tool run csharpier check .` and write
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t2-csharpier-check.md`
   with the four schema fields, quoting the tool's final summary line verbatim in `Output Summary:`.
   Acceptance: the artifact records `EXIT_CODE: 0` when [P0-T9] recorded
@@ -781,7 +781,7 @@ or changes a file, restart the loop from [P6-T1].
   contains neither `QuickFiler/Controllers/EfcDataModel.cs` nor
   `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`; record that set difference in
   `Output Summary:`.
-- [ ] [P6-T3] Run
+- [x] [P6-T3] Run
   `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
   using the vswhere-resolved MSBuild from [P0-T10], including its `| Select-Object -First 1` suffix,
   teeing console output to `TestResults\msbuild\p6-t3.log` (creating `TestResults\msbuild` first;
@@ -791,7 +791,7 @@ or changes a file, restart the loop from [P6-T1].
   quotes an MSBuild `Error(s)` summary line reading `0 Error(s)`; and the tee'd log contains zero
   occurrences of the literal `Skipping target "CoreCompile"`, proving the gate was not vacuous. The
   error count is read from MSBuild's own summary line, not by counting `error CS` occurrences.
-- [ ] [P6-T4] Run
+- [x] [P6-T4] Run
   `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:TreatWarningsAsErrors=true`
   using the vswhere-resolved MSBuild from [P0-T10], including its `| Select-Object -First 1` suffix,
   teeing console output to `TestResults\msbuild\p6-t4.log` (creating `TestResults\msbuild` first;
@@ -801,7 +801,7 @@ or changes a file, restart the loop from [P6-T1].
   quotes an MSBuild `Error(s)` summary line reading `0 Error(s)`; the tee'd log contains zero
   occurrences of the literal `Skipping target "CoreCompile"`; and `Command:` contains neither
   `/p:Nullable=enable` nor `/t:Build`.
-- [ ] [P6-T5] Run the full suite with `vstest.console.exe` and `/EnableCodeCoverage`. Resolve the
+- [x] [P6-T5] Run the full suite with `vstest.console.exe` and `/EnableCodeCoverage`. Resolve the
   executable with
   `& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -find "Common7\IDE\Extensions\TestPlatform\vstest.console.exe" | Select-Object -First 1`.
   The `| Select-Object -First 1` suffix is required for the same reason as in [P0-T10]: `-find` can
@@ -830,7 +830,7 @@ or changes a file, restart the loop from [P6-T1].
   baseline occurrence, and no test in `EfcDataModelArchiveRootTests` may appear among them; and no
   executed test carries `[TestCategory("LiveOutlook")]`. Run this through
   `Start-Process -Wait` or an equivalent detached wrapper.
-- [ ] [P6-T6] Close the toolchain loop. Write
+- [x] [P6-T6] Close the toolchain loop. Write
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t6-loop-closure.md`
   recording, for the final accepted pass, the `Timestamp:` of each of [P6-T1] through [P6-T5] and the
   SHA-256 of `QuickFiler/Controllers/EfcDataModel.cs` and
@@ -841,7 +841,7 @@ or changes a file, restart the loop from [P6-T1].
 
 ### Phase 7 — Coverage Measurement and Delta
 
-- [ ] [P7-T1] Run
+- [x] [P7-T1] Run
   `pwsh -NoProfile -File scripts/vscode/Invoke-MSTestWithCoverage.ps1 -SearchRoot . -Configuration Debug -CoverageOutput coverage/coverage.cobertura.xml`
   and write
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t1-coverage-postchange.md`
@@ -860,7 +860,7 @@ or changes a file, restart the loop from [P6-T1].
   literal is absent from the run output, the non-zero exit came from another cause: record it without
   `ExpectedExitCode:` and treat the task as REMEDIATION-REQUIRED.
   Run through `Start-Process -Wait` or an equivalent detached wrapper.
-- [ ] [P7-T2] Compute coverage for the changed code. From `coverage/coverage.cobertura.xml`, aggregate
+- [x] [P7-T2] Compute coverage for the changed code. From `coverage/coverage.cobertura.xml`, aggregate
   every `class` element whose `filename` attribute resolves to `QuickFiler/Controllers/EfcDataModel.cs`
   — aggregate by `filename`, not by `class`, because a C# async state machine emits its lines under a
   separate generated class and a per-class figure would understate the method.
@@ -884,7 +884,7 @@ or changes a file, restart the loop from [P6-T1].
   re-derive the figure. The lambda body of [P2-T1]'s default seam value is expected to be uncovered:
   every test replaces the seam before invoking the paths that use it, so no test executes the default.
   List it explicitly among the uncovered lines rather than treating it as a gap to close.
-- [ ] [P7-T3] Write the coverage delta report to
+- [x] [P7-T3] Write the coverage delta report to
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t3-coverage-delta.md`
   with the four schema fields plus `BASELINE_REPO_LINE_COVERAGE_PERCENT:` copied from [P0-T12],
   `POSTCHANGE_REPO_LINE_COVERAGE_PERCENT:` copied from [P7-T1], `CHANGED_LINE_COVERAGE_PERCENT:`
@@ -899,7 +899,7 @@ or changes a file, restart the loop from [P6-T1].
   `REMEDIATION-REQUIRED` rather than as a pass. The repo-wide figure is recorded and
   reported per AC17 and is not itself a blocking threshold; the blocking clauses are the change-scoped
   ones in [P7-T2] and the tolerance in this task.
-- [ ] [P7-T4] Decide, and record the decision for, the canonical review coverage artifact. Read
+- [x] [P7-T4] Decide, and record the decision for, the canonical review coverage artifact. Read
   `POSTCHANGE_REPO_LINE_COVERAGE_PERCENT:` and `COVERAGE_XML_MODE:` from [P7-T1]. When
   `COVERAGE_XML_MODE:` reads `raw`, do not create the file and record
   `Decision: NOT WRITTEN — measured figure is a raw denominator that includes test assemblies`,
@@ -939,7 +939,7 @@ per `.claude/skills/acceptance-criteria-tracking/SKILL.md`. Work Mode is `full-b
 the sole AC source. Change only `- [ ]` to `- [x]`; never edit criterion text; never add a criterion.
 Leave any criterion whose evidence is absent unchecked.
 
-- [ ] [P8-T1] Confirm the spec carries no non-canonical evidence path and no absolute host path. Run
+- [x] [P8-T1] Confirm the spec carries no non-canonical evidence path and no absolute host path. Run
   `Select-String -Path 'docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md' -SimpleMatch 'evidence/coverage/'`
   and
   `Select-String -Path 'docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md' -SimpleMatch 'C:\Users'`.
@@ -947,7 +947,7 @@ Leave any criterion whose evidence is absent unchecked.
   naming `.claude/skills/evidence-and-timestamp-conventions/SKILL.md` and the dated entry recording the
   removal of the absolute host path from the Context section. This task edits no criterion text; both
   substitutions were applied by the planner during preflight.
-- [ ] [P8-T2] Write the follow-up-issue dossier for the three non-goals to
+- [x] [P8-T2] Write the follow-up-issue dossier for the three non-goals to
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p8-t2-followup-issue-dossier.md`,
   with one section per non-goal — (a) `COMException` from the live COM calls in the `ArchiveRootPath`
   getter at `TaskMaster/AppGlobals/AppOlObjects.cs:260-261`; (b) the log-only `async void` boundary
@@ -955,48 +955,48 @@ Leave any criterion whose evidence is absent unchecked.
   `QuickFiler/Controllers/EfcFormController.cs` — each carrying a title, a one-paragraph body, its
   verified citations, and a `ProposedLabels:` line. Acceptance: the file exists and contains exactly
   three `## ` sections whose titles name non-goals (a), (b) and (c).
-- [ ] [P8-T3] Check off AC1 in `spec.md` once
+- [x] [P8-T3] Check off AC1 in `spec.md` once
   `MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing` is recorded as
   passing in [P5-T1]. Acceptance: the AC1 line begins `- [x] AC1` and its text is unchanged.
-- [ ] [P8-T4] Check off AC2 once `OpenOlFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns` is
+- [x] [P8-T4] Check off AC2 once `OpenOlFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns` is
   recorded as passing in [P5-T1]. Acceptance: the AC2 line begins `- [x] AC2` and its text is unchanged.
-- [ ] [P8-T5] Check off AC3 once `OpenFsFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns` is
+- [x] [P8-T5] Check off AC3 once `OpenFsFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns` is
   recorded as passing in [P5-T1]. Acceptance: the AC3 line begins `- [x] AC3` and its text is unchanged.
-- [ ] [P8-T6] Check off AC4 once
+- [x] [P8-T6] Check off AC4 once
   `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress` is recorded as passing in
   [P5-T1]. Acceptance: the AC4 line begins `- [x] AC4` and its text is unchanged.
-- [ ] [P8-T7] Check off AC5 once both
+- [x] [P8-T7] Check off AC5 once both
   `MoveToFolderAsync_WhenOneDriveIsMissing_ReturnsFalseWithoutReadingArchiveRoot` (in [P5-T1]) and
   `OpenFolderMethods_DelegateToDataModelWithoutExternalServices` (in [P5-T2]) are recorded as passing
   and [P5-T3] shows `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs` unmodified.
   Acceptance: the AC5 line begins `- [x] AC5` and its text is unchanged.
-- [ ] [P8-T8] Check off AC6 once
+- [x] [P8-T8] Check off AC6 once
   `MoveToFolderAsync_WhenMailInfoIsNull_ReturnsFalseWithoutReadingArchiveRoot` is recorded as passing in
   [P5-T1]. Acceptance: the AC6 line begins `- [x] AC6` and its text is unchanged.
-- [ ] [P8-T9] Check off AC7 once `MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce` is
+- [x] [P8-T9] Check off AC7 once `MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce` is
   recorded as passing in [P5-T1]. Acceptance: the AC7 line begins `- [x] AC7` and its text is unchanged.
-- [ ] [P8-T10] Check off AC8 once `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates`
+- [x] [P8-T10] Check off AC8 once `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates`
   is recorded as passing in [P5-T1]. Acceptance: the AC8 line begins `- [x] AC8` and its text is
   unchanged.
-- [ ] [P8-T11] Check off AC9 once both
+- [x] [P8-T11] Check off AC9 once both
   `MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing` and
   `MoveToFolderAsync_WhenArchiveRootIsCrossStoreUnresolvable_ReturnsFalseInsteadOfThrowing` are recorded
   as passing in [P5-T1]. Acceptance: the AC9 line begins `- [x] AC9` and its text is unchanged.
-- [ ] [P8-T12] Check off AC10 once [P6-T5] records `Failed: 0` for the `QuickFiler.` and `TaskMaster.`
+- [x] [P8-T12] Check off AC10 once [P6-T5] records `Failed: 0` for the `QuickFiler.` and `TaskMaster.`
   test namespaces — the TRX-derived per-namespace figures, not the console all-assembly `Failed:`
   total — and [P5-T3] shows all six named existing test files unmodified. Acceptance: the AC10
   line begins `- [x] AC10` and its text is unchanged.
-- [ ] [P8-T13] Check off AC11 once [P3-T2] recorded the `<Compile Include=... />` entry and [P6-T5]'s
+- [x] [P8-T13] Check off AC11 once [P3-T2] recorded the `<Compile Include=... />` entry and [P6-T5]'s
   TRX under `TestResults\p6-t5` lists at least one test whose fully qualified name contains
   `EfcDataModelArchiveRootTests`. Acceptance: the AC11 line begins `- [x] AC11` and its text is
   unchanged.
-- [ ] [P8-T14] Check off AC12 once both
+- [x] [P8-T14] Check off AC12 once both
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p3-t15-regression-fail-before.md`
   and
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p5-t1-regression-pass-after.md`
   exist and carry all four schema fields. Acceptance: the AC12 line begins `- [x] AC12` and its text is
   unchanged.
-- [ ] [P8-T15] Check off AC13 only when [P6-T2] recorded `EXIT_CODE: 0`. When [P6-T2] was accepted
+- [x] [P8-T15] Check off AC13 only when [P6-T2] recorded `EXIT_CODE: 0`. When [P6-T2] was accepted
   under the subset branch because [P0-T9] recorded a non-zero `BASELINE_UNFORMATTED_COUNT:`, leave AC13
   unchecked and append
   `REMEDIATION-REQUIRED: AC13 unmet — pre-existing format drift outside this change footprint, baseline count <N>, files <list>`
@@ -1006,13 +1006,13 @@ Leave any criterion whose evidence is absent unchecked.
   realized, and the realized branch is verifiable — either the AC13 line begins `- [x] AC13` with its
   text unchanged and [P6-T2] recorded `EXIT_CODE: 0`, or the AC13 line begins `- [ ] AC13` and the
   [P6-T2] artifact contains the `REMEDIATION-REQUIRED:` line.
-- [ ] [P8-T16] Check off AC14 once [P6-T3] records `0 Error(s)` and zero occurrences of
+- [x] [P8-T16] Check off AC14 once [P6-T3] records `0 Error(s)` and zero occurrences of
   `Skipping target "CoreCompile"`. Acceptance: the AC14 line begins `- [x] AC14` and its text is
   unchanged.
-- [ ] [P8-T17] Check off AC15 once [P6-T4] records `0 Error(s)`, zero occurrences of
+- [x] [P8-T17] Check off AC15 once [P6-T4] records `0 Error(s)`, zero occurrences of
   `Skipping target "CoreCompile"`, and a `Command:` free of `/p:Nullable=enable` and `/t:Build`.
   Acceptance: the AC15 line begins `- [x] AC15` and its text is unchanged.
-- [ ] [P8-T18] Check off AC16 only when [P6-T5] recorded `Failed: 0` with an empty baseline-exception
+- [x] [P8-T18] Check off AC16 only when [P6-T5] recorded `Failed: 0` with an empty baseline-exception
   list and no new test carries `[TestCategory("LiveOutlook")]`. When [P6-T5] was accepted with a
   non-empty exception list, leave AC16 unchecked and append
   `REMEDIATION-REQUIRED: AC16 unmet — pre-existing test failures <list> present in the [P0-T12] direct-harness BASELINE_FAILURE_SET`
@@ -1028,7 +1028,7 @@ Leave any criterion whose evidence is absent unchecked.
   and [P7-T3] records all four numeric fields with a delta at or above the stated tolerance and with
   `BASELINE_COVERAGE_XML_MODE:` equal to `POSTCHANGE_COVERAGE_XML_MODE:`.
   Acceptance: the AC17 line begins `- [x] AC17` and its text is unchanged.
-- [ ] [P8-T20] Check off AC18 after verifying the change footprint against the merge base from the
+- [x] [P8-T20] Check off AC18 after verifying the change footprint against the merge base from the
   working tree, before any commit exists. Run
   `git diff --name-only ecdb1c84ba8541ab67042985919cfed4df768c01 -- QuickFiler QuickFiler.Test TaskMaster TaskMaster.Test UtilitiesCS ToDoModel .github docs`
   and, as its companion span,
@@ -1047,14 +1047,14 @@ Leave any criterion whose evidence is absent unchecked.
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/`; and the
   AC18 line then begins `- [x] AC18` with its text unchanged. [P9-T2] repeats this check against the
   commit and is the artifact-bearing record of it.
-- [ ] [P8-T21] Check off AC19 once [P4-T7] records both `POSTFIX_EFCDATAMODEL_LINE_COUNT:` and
+- [x] [P8-T21] Check off AC19 once [P4-T7] records both `POSTFIX_EFCDATAMODEL_LINE_COUNT:` and
   `POSTFIX_ARCHIVEROOTTESTS_LINE_COUNT:` at or below 500 and both counts are re-confirmed after the
   [P6-T1] formatting pass by re-running
   `(Get-Content -LiteralPath 'QuickFiler/Controllers/EfcDataModel.cs').Count` and
   `(Get-Content -LiteralPath 'QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs').Count`.
   Acceptance: both re-run counts are at most 500, the AC19
   line begins `- [x] AC19` and its text is unchanged.
-- [ ] [P8-T22] Resolve AC20. If three follow-up issue numbers for non-goals (a), (b) and (c) are
+- [x] [P8-T22] Resolve AC20. If three follow-up issue numbers for non-goals (a), (b) and (c) are
   already recorded in the spec's Rollout & Follow-up section, check off AC20. Otherwise leave AC20
   unchecked and append to
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p8-t2-followup-issue-dossier.md`
@@ -1064,7 +1064,7 @@ Leave any criterion whose evidence is absent unchecked.
   branches is realized, and the realized branch is verifiable — either the AC20 line begins `- [x] AC20`
   and the spec's Rollout & Follow-up section names three issue numbers, or the AC20 line begins
   `- [ ] AC20` and the dossier contains the `REMEDIATION-REQUIRED:` line.
-- [ ] [P8-T23] Update the `spec.md` header fields `- **Status:**` to `Implemented` and
+- [x] [P8-T23] Update the `spec.md` header fields `- **Status:**` to `Implemented` and
   `- **Last Updated:**` to the current ISO-8601 `yyyy-MM-ddTHH-mm` value, and update this plan file's
   `- **Status:**` to `Executed`. Acceptance:
   `Select-String -Path 'docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md' -SimpleMatch 'Status:** Ready for Planning'`

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/plan.2026-08-29T07-41.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/plan.2026-08-29T07-41.md
@@ -1,0 +1,1128 @@
+# 2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread (Plan)
+
+- **Issue:** #638
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-08-29T11-09
+- **Status:** Ready for Preflight
+- **Version:** 1.0
+- **Work Mode:** `full-bug`
+
+**Acceptance-criteria source.** Work Mode for issue #638 is `full-bug`, so
+`docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md`
+is the sole acceptance-criteria source, per `.claude/skills/acceptance-criteria-tracking/SKILL.md`.
+No `user-story.md` exists for #638 and none is to be created.
+`docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/issue.md`
+is background only; two of its claims are false at this branch head and are corrected in the spec's
+Context section.
+
+**Fail-closed evidence rule.** Every baseline command step, every final-QC command step, and every
+coverage comparison below names its artifact path. A missing or field-incomplete artifact makes the
+corresponding checklist item unchecked and the outcome BLOCKED or INCOMPLETE, never PASS.
+
+**Evidence schema.** Every artifact named below carries `Timestamp:`, `Command:`, `EXIT_CODE:` and
+`Output Summary:` per `.claude/skills/evidence-and-timestamp-conventions/SKILL.md`. Timestamps use
+`yyyy-MM-ddTHH-mm`. Artifact file names are fixed by this plan (no timestamp in the file name) so the
+change footprint is enumerable in advance; the ISO-8601 timestamp lives in the `Timestamp:` field.
+No artifact this plan writes may contain an absolute filesystem path, an account name or a machine
+name, because [P9-T1] commits all of them. This applies in particular to recorded vstest failure
+output, whose Debug stack traces carry absolute source paths, and to [P7-T2] in `raw` mode, where the
+Cobertura `filename` attribute is absolute: record the exception type and the test's fully qualified
+name rather than the stack trace, and record worktree-relative paths computed as
+`$_.FullName.Substring((Get-Location).Path.Length)`. The `Command:` field of every artifact whose
+command runs a vswhere-resolved executable — [P0-T10], [P0-T11], [P0-T12], [P2-T3], [P3-T14],
+[P3-T15], [P4-T6], [P5-T1], [P5-T2], [P6-T3], [P6-T4] and [P6-T5] — records the unresolved
+`& "${env:ProgramFiles(x86)}\...\vswhere.exe" ... | Select-Object -First 1` expression together with
+the arguments passed to the resolved tool, never the resolved MSBuild or `vstest.console.exe` path,
+which is absolute. The clause in [P6-T5] is a specific instance of this rule, not a second rule.
+
+**Evidence location normalization.**
+`EVIDENCE_LOCATION_OVERRIDE_REJECTED: docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/coverage/ replaced with docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/ and docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/`.
+The spec named an `evidence/coverage/` sub-path in its Repro & Evidence section and in AC17 before
+this substitution was applied.
+`evidence/coverage/` is not one of the canonical evidence sub-paths enumerated by
+`.claude/skills/evidence-and-timestamp-conventions/SKILL.md`. Baseline coverage evidence is written
+to `evidence/baseline/` and post-change coverage evidence to `evidence/qa-gates/`. The planner applied
+the two spec substitutions during preflight, so `spec.md` already names the canonical sub-paths and
+AC17 is satisfiable as written. The planner separately replaced the absolute worktree path in the
+spec's Context provenance sentence with a description naming only the branch and the merge-base SHA,
+because [P9-T1] commits this feature folder with the
+`docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638` pathspec, so a
+deferred substitution task ordered after that commit could not prevent the account name from entering
+history. Task [P8-T1] verifies both states; it edits no criterion text.
+
+**Base ref.** All anchored diffs in this plan use the merge base
+`ecdb1c84ba8541ab67042985919cfed4df768c01`, the `origin/main` commit this worktree branched from.
+
+**Scope decisions already settled by the orchestrator; do not reopen.**
+
+- **D1.** New tests live in `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`, not in a
+  `tests/` mirror tree. `.claude/skills/policy-compliance-order/SKILL.md` ranks `CLAUDE.md` above
+  `.claude/rules/general-unit-test.md`; the unit-test policies embedded in `CLAUDE.md` impose no
+  `tests/` mirroring requirement; and the General Code Change Policy requires matching existing
+  repository style, which for every C# test project here is a sibling `<Project>.Test` project. The
+  new file must be registered with an explicit `<Compile Include=... />` entry in
+  `QuickFiler.Test/QuickFiler.Test.csproj`, a legacy non-SDK project.
+- **D2.** Plan against the acceptance criteria as restated in `spec.md`, not against the issue body.
+- **D3.** Scope is the three unguarded reads plus their regression tests. The three non-goals
+  recorded in the spec must not be swept in.
+
+**Out of scope for this plan.** Atomic execution reporting, pull-request authoring, CI monitoring and
+feature review are performed later by a separate orchestrator. This plan contains no task that
+creates a pull request or polls CI.
+
+## Change Footprint
+
+Paths this plan's diff will create or modify:
+
+- `QuickFiler/Controllers/EfcDataModel.cs`
+- `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`
+- `QuickFiler.Test/QuickFiler.Test.csproj`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md`
+  (already edited at plan-authoring time: the planner replaced the two non-canonical coverage evidence
+  sub-path references, replaced the absolute worktree path in the Context section's provenance sentence
+  with a branch-and-merge-base description, and appended a dated Correction Log entry for each of those
+  two substitutions. The executor's remaining edits to
+  this file are the AC check-offs in Phase 8 and the header fields in [P8-T23]. The file therefore
+  appears in the [P9-T2] footprint check whether or not any Phase 8 check-off is applied.)
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/plan.2026-08-29T07-41.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/issue.md`
+  (untracked at plan-authoring time; added to the diff by [P9-T1]'s feature-folder pathspec, unmodified)
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/research/2026-08-29T08-05-archive-root-guard-research.md`
+  (untracked at plan-authoring time; added to the diff by [P9-T1]'s feature-folder pathspec, unmodified)
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/phase0-instructions-read.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t6-dotnet-tool-restore.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t7-solution-restore.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t8-dotnet-coverage-probe.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t9-csharpier-check.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t10-msbuild-analyzers.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t11-msbuild-nullable.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t12-vstest-coverage.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t12-direct-harness-baseline.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p1-t4-tree-facts.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p2-t3-seam-compile.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p3-t14-tests-compile.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p3-t15-regression-fail-before.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p4-t6-fix-compile.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p4-t7-file-size.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p5-t1-regression-pass-after.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p5-t2-sentinel-tests.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p5-t3-untouched-tests.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t1-csharpier-format.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t2-csharpier-check.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t3-msbuild-analyzers.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t4-msbuild-nullable.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t5-vstest-coverage.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t6-loop-closure.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t1-coverage-postchange.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t2-coverage-changed-lines.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t3-coverage-delta.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t4-canonical-coverage-artifact.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p8-t2-followup-issue-dossier.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p9-t2-change-footprint.md`
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p9-t3-clean-tree.md`
+
+Paths written by this plan that are **not** part of the diff because they are gitignored:
+`artifacts/csharp/coverage.xml` (`.gitignore:57` ignores `artifacts/`), `coverage/coverage.cobertura.xml`
+(`.gitignore:144` ignores `coverage/*`), the `TestResults` run directories
+(`.gitignore:39` ignores `[Tt]est[Rr]esult*/`), the MSBuild transcripts written to
+`TestResults\msbuild\*.log` by [P0-T10], [P0-T11], [P2-T3], [P6-T3] and [P6-T4] (same `.gitignore:39`
+rule), and any NuGet package directory materialized under `packages/` by [P0-T7]
+(`.gitignore:191` ignores `**/[Pp]ackages/*`).
+
+No other production file is modified. In particular `QuickFiler/Controllers/EfcFormController.cs`,
+`QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs`, `TaskMaster/AppGlobals/AppOlObjects.cs`,
+`TaskMaster/AppGlobals/ArchiveRootPathGuard.cs`, `QuickFiler/Controllers/EfcSelectionGuard.cs` and
+`UtilitiesCS/Interfaces/IGlobals/IOlObjects.cs` are read-only citations here and must remain
+untouched.
+
+## Verified facts this plan is built on
+
+Each was re-derived against the working tree of this worktree during plan authoring:
+
+- `QuickFiler/Controllers/EfcDataModel.cs:289`, `:310` and `:328` each contain
+  `OlAncestor = Globals.Ol.ArchiveRootPath,` inside an `EmailFilerConfig` object initializer, in
+  `MoveToFolderAsync(string, bool, bool, bool, bool)` (`:259-297`), `OpenOlFolderAsync(string)`
+  (`:299-316`) and `OpenFsFolderAsync(string)` (`:318-334`) respectively.
+- The OneDrive `SpecialFolders` guards sit at `QuickFiler/Controllers/EfcDataModel.cs:277-281`,
+  `:301-304` and `:320-323`, each strictly above the archive-root read in its own method.
+- The `MailInfo is null` guard is the first statement of `MoveToFolderAsync` at
+  `QuickFiler/Controllers/EfcDataModel.cs:267-270`.
+- `QuickFiler/Controllers/EfcDataModel.cs` is 423 lines. The static log4net logger is declared at
+  `:23-25`, `System.Windows.Forms` is imported at `:10`, and `MessageBox.Show` is already used at
+  `:355`.
+- `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs:217` asserts
+  `probe.FileSystem.SpecialFoldersAccessCount.Should().Be(2)` inside
+  `OpenFolderMethods_DelegateToDataModelWithoutExternalServices` (`:207-218`). The counter is
+  incremented by the `SpecialFolders` getter at `:416-423`, declared at `:414`.
+  `FakeApplicationGlobals.Ol` returns `null` at `:388`.
+- `QuickFiler.Test/QuickFiler.Test.csproj:114-115` registers
+  `<Compile Include="Controllers\EfcDataModelIssue614Tests.cs" />` and
+  `<Compile Include="Controllers\EfcDataModelTests.cs" />`.
+- `QuickFiler/Properties/AssemblyInfo.cs:5` is `[assembly: InternalsVisibleTo("QuickFiler.Test")]`.
+- `UtilitiesCS/Interfaces/IGlobals/IOlObjects.cs:15` is `string ArchiveRootPath { get; }`.
+- `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:13-14` declares `UnresolvableRule` and `:16-17`
+  declares `CrossStoreRule`; they are thrown at `:44` and `:56`. The class is `internal` in namespace
+  `TaskMaster`, so `QuickFiler.Test` cannot reference the constants; the new test file declares its
+  own private `const string` copies of both texts.
+- `QuickFiler.Test/Controllers/EfcHomeControllerExecuteMovesTests.cs:160-175` is
+  `HandleMoveResult_WhenMoveFails_RoutesMessageThroughInjectedAction`, asserting the exact string
+  `Cannot move to folderpath Archive/Target` at `:174`.
+- `QuickFiler.Test/Controllers/EfcDataModelTests.cs:220-228` is the private `CreateGlobals()` helper
+  building a strict `Mock<IApplicationGlobals>` over a strict `Mock<IOlObjects>`; it does **not** set
+  up `FS`, so the new test file needs its own globals builder that also stubs
+  `IApplicationGlobals.FS` and `IFileSystemFolderPaths.SpecialFolders`.
+- `QuickFiler/Controllers/EfcDataModel.cs:235-253` is `TryGetFirstInSelection`, whose
+  `catch (System.Exception)` at `:249` returns `null`. A strict `Mock<IOlObjects>` with no `App`
+  setup therefore yields `Mail == null` and `MailInfo == null` from the public constructor, without
+  throwing.
+- `.github/workflows/_mstest-coverage.yml:83` is
+  `& $vstestPath $testAssemblies /EnableCodeCoverage /InIsolation /Logger:trx /TestCaseFilter:"TestCategory!=LiveOutlook"`.
+- `.github/workflows/_format-check.yml:37` runs `dotnet tool restore` and `:41` runs
+  `dotnet csharpier check .`. `dotnet-tools.json:6` pins CSharpier to `1.2.6`.
+- `.csharpierignore:4` excludes `**/evidence/**` and `:12` excludes `*.csproj`, so neither the
+  evidence artifacts nor the `.csproj` edit is subject to the format gate.
+- `scripts/vscode/Invoke-MSTestWithCoverage.ps1:76` appends `/InIsolation` and
+  `/TestCaseFilter:TestCategory!=LiveOutlook` to its inner vstest invocation, and `:341` calls
+  `Assert-CoberturaLineCoverageThreshold` before `:343` writes the post-processed file.
+  `scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1:487-490` throws when the repo-wide line
+  percentage is below 80.
+- `.claude/hooks/validate-feature-review-coverage.ps1:253` reads `artifacts/csharp/coverage.xml`
+  through `Get-JacocoRepoCoverage`, which at `:229` selects `//counter[@type="LINE"]` and sums the
+  `missed` and `covered` attributes; `:313` fails when the repo-wide figure is below `85.0`. The file
+  must therefore be JaCoCo-shaped, not Cobertura-shaped.
+- This worktree has no `packages/` directory, and `QuickFiler.Test/QuickFiler.Test.csproj:499-503`
+  names `Meziantou.Analyzer.3.0.156` and `Roslynator.Analyzers.4.16.0` in `<Analyzer Include>` items
+  while `QuickFiler.Test/packages.config` pins `Meziantou.Analyzer` to `3.0.174` (`:10-15`) and
+  `Roslynator.Analyzers` to `4.16.1` (`:139-144`). Until that skew is resolved, every `/t:Rebuild`
+  fails with `error CS0006`, which would make [P2-T3], [P3-T14], [P4-T6], [P6-T3], [P6-T4], [P6-T5],
+  [P0-T12] and [P7-T1] unsatisfiable. [P0-T7] detects and resolves it. `.gitignore:191` ignores
+  `**/[Pp]ackages/*`, so the remediation adds nothing to the diff.
+- A non-null `MailInfo` is reachable without an Outlook COM fixture only through the harness described
+  in [P3-T1]. `QuickFiler/Controllers/EfcDataModel.cs:233` defines `MailInfo` as
+  `ConversationResolver?.MailHelper`; the two-argument `ConversationResolver` constructor
+  (`QuickFiler/Helper Classes/ConversationResolver.cs:64-68`) does no work; `MailHelper` is publicly
+  settable at `QuickFiler/Helper Classes/ConversationResolver.cs:282-286`; and the parameterless
+  `MailItemHelper` (`UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs:80-84`) runs
+  `InitializeSafeDefaults` (`:167`), which sets `_folderInfo = null` (`:177`), so
+  `MailItemHelper.FolderInfo` (`UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.Properties.cs:78-82`)
+  is `null`. The `ConversationResolver` constructor declared at
+  `QuickFiler/Helper Classes/ConversationResolver.cs:70-84` — five parameters, the fifth defaulted,
+  which production invokes with four arguments at `QuickFiler/Controllers/EfcDataModel.cs:67` — must
+  not be used, because the helper construction inside it at
+  `QuickFiler/Helper Classes/ConversationResolver.cs:82`
+  installs a `_folderInfo` factory (`UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs:106-111`)
+  whose materialization calls `ResolveFolderRoot`
+  (`UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.Loading.cs:122-130`), reading
+  `ArchiveRootPath` a second time at `:124`.
+- `scripts/vscode/Invoke-Restore.ps1:27` resolves MSBuild with
+  `& $vswherePath -latest -requires Microsoft.Component.MSBuild -find 'MSBuild\**\Bin\MSBuild.exe' | Select-Object -First 1`.
+  Every vswhere `-find` invocation in this plan carries the same `| Select-Object -First 1` suffix,
+  because `-find` can emit more than one matching path.
+- `QuickFiler.Test/QuickFiler.Test.csproj:18` is `<TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>`
+  and the project sets no `<LangVersion>`. The absence of that element does not restrict the language
+  version: the tree compiles a C# 12 collection expression at
+  `UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs:133` and a C# 9 `is not null` pattern at
+  `QuickFiler/Controllers/EfcDataModel.cs:61`. No task in this plan depends on a specific C# language
+  version either way.
+
+## Ordering hazards this plan is sequenced around
+
+1. **Compile-red would mask runtime-red.** The regression tests reference
+   `EfcDataModel.UserDiagnosticAction`, which does not exist yet. Written first, they would break the
+   whole `QuickFiler.Test` assembly and the fail-before run would be a build failure rather than a
+   genuine failing test. Phase 2 therefore declares the seam alone, with no call site, so Phase 3's
+   fail-before run is a real runtime `InvalidOperationException`.
+2. **A zero-failure gate must not run while `[expect-fail]` tests are red.** The only zero-failure
+   assertions in this plan are in Phase 5 and Phase 6, both after the fix lands in Phase 4. Phase 3's
+   run asserts an exact failing set, not zero failures.
+3. **Guard placement.** The archive-root guard goes strictly **after** the OneDrive `SpecialFolders`
+   read in all three methods. Placing it first drops
+   `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs:217` from 2 to 0 and additionally
+   raises `NullReferenceException` from the probe's null `Ol` at `:388`, which a
+   `catch (InvalidOperationException)` does not absorb.
+4. **Anchored diffs need a commit.** The change-footprint gate runs in Phase 9 after the commit task,
+   and is paired with a `git status --porcelain` companion so files the plan creates are visible.
+5. **Formatter runs before the size audit.** The 500-line audit in Phase 4 is re-confirmed by [P8-T21]
+   after the Phase 6 formatting pass, because CSharpier can change line counts.
+
+### Phase 0 — Baseline Capture and Policy Reads
+
+- [ ] [P0-T1] Read `CLAUDE.md` in full and record its four embedded policies (General Code Change,
+  General Unit Test, C# Code Change, C# Unit Test) plus the `## C# Toolchain (run in this exact order)`
+  section. Acceptance: the reader can quote the four toolchain commands verbatim from that section.
+- [ ] [P0-T2] Read `.claude/rules/general-code-change.md` in full. Acceptance: the 500-line file-size
+  limit and the mandatory toolchain loop are recorded in the reader's notes for [P0-T5].
+- [ ] [P0-T3] Read `.claude/rules/general-unit-test.md` in full. Acceptance: the Coverage Exclusion
+  Policy and the Test File Location clause are recorded, together with the note that D1 supersedes the
+  `tests/` mirroring clause for C# in this repository because `CLAUDE.md` outranks it.
+- [ ] [P0-T4] Read `.claude/rules/csharp.md` in full. Acceptance: its contents are recorded in the
+  reader's notes for [P0-T5].
+- [ ] [P0-T5] Write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/phase0-instructions-read.md`
+  containing `Timestamp:`, `Policy Order:` (the four files in the order read), and an explicit list of
+  the files read. Acceptance: the file exists and contains all three field labels and four file paths.
+- [ ] [P0-T6] Run `dotnet tool restore` from the worktree root and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t6-dotnet-tool-restore.md`
+  with `Timestamp:`, `Command:`, `EXIT_CODE:` and `Output Summary:`. Acceptance: the artifact records
+  `EXIT_CODE: 0` and `Output Summary:` names CSharpier version `1.2.6`. If `dotnet` cannot resolve an
+  SDK because the repo-local `.dotnet-sdk` directory named in `global.json:7` is absent, first run
+  `pwsh -NoProfile -File scripts/vscode/Install-RepoDotNetSdk.ps1`, then retry, and record both
+  invocations in `Output Summary:`.
+- [ ] [P0-T7] Run
+  `pwsh -NoProfile -File scripts/vscode/Invoke-Restore.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform "Any CPU"`
+  and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t7-solution-restore.md`
+  with the four schema fields. This step exists because a fresh worktree has no `packages/` directory
+  and an unrestored legacy project reports missing-reference errors as CS0006 build errors, not
+  warnings. After the restore returns, confirm the analyzer package wiring resolves.
+  The skew is solution-wide and uniform, and was re-derived at plan-authoring time. Every `.csproj`
+  in the solution names `Meziantou.Analyzer.3.0.156` and `Roslynator.Analyzers.4.16.0` in its
+  `<Analyzer Include>` items, while all sixteen `packages.config` files that carry analyzer entries
+  pin `Meziantou.Analyzer` to `3.0.174` and `Roslynator.Analyzers` to `4.16.1`. The other four
+  analyzer packages — `MSTest.Analyzers 4.3.3`, `SonarAnalyzer.CSharp 10.32.0.713`,
+  `AsyncFixer 2.1.0` and `Microsoft.CodeAnalysis.BannedApiAnalyzers 5.6.0` — already agree between the
+  two files and need no action. Every project resolves its analyzers from the single repository-root
+  `packages/` directory through a `..\packages\` relative path, so installing the two skewed pairs
+  once resolves the whole solution. Run
+  `Select-String -Path 'QuickFiler.Test/QuickFiler.Test.csproj' -SimpleMatch 'Meziantou.Analyzer.','Roslynator.Analyzers.' | ForEach-Object { $_.Line.Trim() }`
+  and compare the version segments against the `Meziantou.Analyzer` and `Roslynator.Analyzers`
+  `version=` values in `QuickFiler.Test/packages.config` (`:10-15` and `:139-144`), then confirm each
+  named `packages\<id>.<version>\` directory exists on disk. Two lines of
+  `QuickFiler.Test/QuickFiler.Test.csproj` other than its `<Analyzer Include>` items also match the
+  first pattern and are excluded from the comparison, which considers `<Analyzer Include>` items
+  only: `:3` is an `<Import Project>` and `:490` is an `<Error Condition>` inside
+  `EnsureNuGetPackageBuildImports`, and both name the packages.config version `3.0.174` rather than the
+  `<Analyzer Include>` version, so a comparison over the raw match list would see both `3.0.174` and
+  `3.0.156` for the same id from the same file. Record `ANALYZER_SKEW:` as either `none`
+  or the explicit list of `<id>.<version>` pairs, drawn from those two ids only, that an
+  `<Analyzer Include>` item names and whose directory is absent. The acceptance below is scoped to
+  those two ids, which are the only ids this command inspects. When the list is non-empty, install
+  exactly those versions into the gitignored `packages/` directory with
+  `nuget install Meziantou.Analyzer -Version 3.0.156 -OutputDirectory packages` and
+  `nuget install Roslynator.Analyzers -Version 4.16.0 -OutputDirectory packages`, re-run the existence
+  check, and record both the before and after lists in `Output Summary:`.
+  Then run `git status --porcelain -- '*.csproj' '*/packages.config' 'packages'` and record its output
+  verbatim. Acceptance: the artifact records `EXIT_CODE: 0`, `ANALYZER_SKEW:` resolves to `none` on the
+  second check for both `Meziantou.Analyzer` and `Roslynator.Analyzers`, and the
+  `git status --porcelain` output is empty, proving the remediation touched no
+  tracked file. If the skew cannot be resolved this way, stop and report; do not proceed to [P0-T10]
+  with a CS0006 baseline.
+- [ ] [P0-T8] Probe for the `dotnet-coverage` global tool with
+  `Get-Command dotnet-coverage -ErrorAction SilentlyContinue`; if it is absent run
+  `dotnet tool install --global dotnet-coverage`. Write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t8-dotnet-coverage-probe.md`
+  with the four schema fields and a `Resolution:` line reading either `already present` or
+  `installed`. Acceptance: the artifact exists and `Output Summary:` records the resolved
+  `dotnet-coverage` version string. Do not halt on absence; install and continue.
+- [ ] [P0-T9] Run `dotnet tool run csharpier check .` from the worktree root and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t9-csharpier-check.md`
+  with the four schema fields. `Output Summary:` must quote the tool's final summary line verbatim and
+  record `BASELINE_UNFORMATTED_COUNT:` as the count of `Error <path> - Was not formatted.` lines in the
+  output. That count is not on the final summary line: `check` ends with `Checked N files in Nms.`,
+  whose N is the number of files processed. Record `BASELINE_UNFORMATTED_FILES:` as the explicit list
+  of the file paths named by those `Error` lines (or the literal `none`).
+  Acceptance: the artifact exists and carries a numeric `BASELINE_UNFORMATTED_COUNT:` value and a
+  `BASELINE_UNFORMATTED_FILES:` line. A non-zero baseline is recorded, not repaired here; the count
+  governs the branch chosen in [P6-T1] and the list is the comparison set for [P6-T2].
+- [ ] [P0-T10] Run
+  `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
+  using the MSBuild resolved by
+  `& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" | Select-Object -First 1`
+  — the `| Select-Object -First 1` suffix is required because `-find` can emit several matching paths,
+  and `scripts/vscode/Invoke-Restore.ps1:27` resolves MSBuild the same way — teeing console output to
+  `TestResults\msbuild\p0-t10.log` (creating `TestResults\msbuild` first; `.gitignore:39` ignores
+  `[Tt]est[Rr]esult*/`, so the log is outside the diff), and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t10-msbuild-analyzers.md`
+  with the four schema fields. `Output Summary:` must quote MSBuild's own `Warning(s)` and `Error(s)`
+  summary lines verbatim and record `BASELINE_ANALYZER_ERRORS:` as the integer from the `Error(s)`
+  line. Acceptance: the artifact exists and carries that integer. If the recorded integer is non-zero,
+  stop and report before Phase 2; [P6-T3]/[P6-T4] demand `0 Error(s)` and cannot be satisfied from a
+  non-zero baseline. Do not invoke
+  `scripts/vscode/Invoke-VSBuild.ps1`; it runs `scripts/vscode/Sync-PackageReferences.ps1` over every
+  `.csproj` and would rewrite project files outside the change footprint.
+- [ ] [P0-T11] Run
+  `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:TreatWarningsAsErrors=true`
+  using the same vswhere-resolved MSBuild as [P0-T10], including its `| Select-Object -First 1`
+  suffix, teeing console output to `TestResults\msbuild\p0-t11.log` (creating `TestResults\msbuild`
+  first; `.gitignore:39` ignores `[Tt]est[Rr]esult*/`, so the log is outside the diff), and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t11-msbuild-nullable.md`
+  with the four schema fields. `Output Summary:` must quote the `Error(s)` summary line verbatim and
+  record `BASELINE_NULLABLE_ERRORS:` as that integer. Acceptance: the artifact exists and carries that
+  integer. If the recorded integer is non-zero, stop and report before Phase 2; [P6-T3]/[P6-T4] demand
+  `0 Error(s)` and cannot be satisfied from a non-zero baseline. The command must not gain
+  `/p:Nullable=enable` and must not substitute `/t:Build`.
+- [ ] [P0-T12] Run the baseline test suite in coverage mode with
+  `pwsh -NoProfile -File scripts/vscode/Invoke-MSTestWithCoverage.ps1 -SearchRoot . -Configuration Debug -CoverageOutput coverage/coverage.cobertura.xml`
+  and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t12-vstest-coverage.md`
+  with the four schema fields plus, in `Output Summary:`, the vstest `Total tests`, `Passed`, `Failed`
+  and `Skipped` counts observed in this coverage-harness run, a `COVERAGE_HARNESS_FAILURE_SET:` line
+  naming every failing test's fully qualified name (or the literal `none`) as observed in this run —
+  `BASELINE_FAILURE_SET:` is set later in this task from the second, direct-harness run — and
+  `BASELINE_REPO_LINE_COVERAGE_PERCENT:` as the repo-wide line
+  percentage. The percentage is read from the `line-rate` attribute of the root `coverage` element of
+  `coverage/coverage.cobertura.xml` multiplied by 100. Also record `COVERAGE_XML_MODE:` as
+  `koverage-processed` when the script exited 0, and as `raw` when it exited non-zero.
+  `scripts/vscode/Invoke-MSTestWithCoverage.ps1:341` asserts the threshold on the post-processed
+  content and `:343` writes that content back only afterwards, so a throw leaves the raw
+  `dotnet-coverage` root attributes on disk. Those two states have different denominators:
+  `scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1:417-421` removes every non-allowlisted
+  `<package>`, including every `.Test` assembly, and `:442-445` recomputes `line-rate`,
+  `lines-covered` and `lines-valid` over what remains. Acceptance: the artifact exists and carries a
+  numeric `BASELINE_REPO_LINE_COVERAGE_PERCENT:` value, a `COVERAGE_XML_MODE:` value that is one of
+  those two literals, and a `COVERAGE_HARNESS_FAILURE_SET:` line. The script
+  is expected to exit non-zero when that percentage is below 80, because
+  `scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1:487-490` throws in that case; the raw Cobertura
+  file is written by `dotnet-coverage` before that throw, so the numeric value is still readable, but
+  it is then a raw figure computed over every instrumented module rather than a post-processed
+  first-party figure, which is what `COVERAGE_XML_MODE:` records. When
+  the run exits non-zero, record the observed `EXIT_CODE:` and set `ExpectedExitCode: 1`. Justify it by
+  quoting, verbatim in `Output Summary:`, the terminating message emitted by
+  `scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1:489`, which reports the measured Cobertura line
+  percentage and ends with the literal `is below the required 80% threshold.`. If that literal is
+  absent from the run output, the non-zero exit came from another cause: record it without
+  `ExpectedExitCode:` and treat the task as REMEDIATION-REQUIRED.
+  Run this command through `Start-Process -Wait` or an equivalent detached wrapper; the full suite takes
+  longer than a single foreground command window is reliable for.
+  Then capture the baseline failure set a second time using exactly the harness [P6-T5] will use, so
+  the carve-out list [P6-T5] consumes is commensurable with the run it gates. Resolve
+  `vstest.console.exe` and build the assembly list by the rules stated in [P6-T5], then run the
+  resolved executable with that list and
+  `/EnableCodeCoverage /InIsolation /Logger:trx /ResultsDirectory:TestResults\p0-t12-direct /TestCaseFilter:"TestCategory!=LiveOutlook"`,
+  again through `Start-Process -Wait` or an equivalent detached wrapper. Record this second run in its
+  own companion artifact
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t12-direct-harness-baseline.md`,
+  not in the artifact above: the evidence schema carries one `EXIT_CODE:` and at most one
+  `ExpectedExitCode:` per file, so two runs with different expected exit codes cannot share one
+  artifact. The companion carries the four schema fields for the direct-harness command, its
+  `Total tests`, `Passed`, `Failed` and `Skipped` counts under `DIRECT_HARNESS_` prefixes, and
+  `BASELINE_FAILURE_SET:` set from **this** run, naming every failing test's fully qualified name or
+  the literal `none`.
+  When this run exits non-zero and every failing test it reports is listed in its own
+  `BASELINE_FAILURE_SET:`, record the observed `EXIT_CODE:` and set `ExpectedExitCode: 1`; when it
+  exits 0 and `BASELINE_FAILURE_SET:` is the literal `none`, omit `ExpectedExitCode:`. Apply the same
+  rule to [P6-T5]'s artifact against the carve-out list it accepts.
+  The coverage-harness run above remains the source of
+  `BASELINE_REPO_LINE_COVERAGE_PERCENT:` only, and its artifact's `Command:`, `EXIT_CODE:` and
+  `ExpectedExitCode:` fields describe that run alone. Also copy `COVERAGE_HARNESS_FAILURE_SET:` into
+  the companion and note there any test that appears in one set and not the other, because
+  a divergence identifies a test whose outcome depends on the instrumentation path rather than on this
+  change. Acceptance additionally requires that the companion artifact exists, carries the four schema
+  fields, and carries a `BASELINE_FAILURE_SET:` line produced by the direct-harness run.
+
+### Phase 1 — Scope Lock and Citation Re-derivation
+
+- [ ] [P1-T1] Re-derive the three unguarded read sites. Run
+  `Select-String -Path 'QuickFiler/Controllers/EfcDataModel.cs' -SimpleMatch 'OlAncestor = Globals.Ol.ArchiveRootPath'`
+  and record the matched line numbers. Acceptance: exactly three matches are returned and their line
+  numbers are 289, 310 and 328.
+- [ ] [P1-T2] Re-derive the ordering sentinel. Run
+  `Select-String -Path 'QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs' -SimpleMatch 'SpecialFoldersAccessCount.Should().Be(2)'`
+  and record the matched line number. Acceptance: exactly one match is returned at line 217.
+- [ ] [P1-T3] Confirm the new test file is not yet registered. Run
+  `Select-String -Path 'QuickFiler.Test/QuickFiler.Test.csproj' -SimpleMatch 'EfcDataModelArchiveRootTests.cs'`.
+  Acceptance: zero matches are returned, and
+  `Select-String -Path 'QuickFiler.Test/QuickFiler.Test.csproj' -SimpleMatch 'Controllers\EfcDataModelTests.cs'`
+  returns exactly one match at line 115, which is the insertion anchor for [P3-T2].
+- [ ] [P1-T4] Record the pre-change file size with
+  `(Get-Content -LiteralPath 'QuickFiler/Controllers/EfcDataModel.cs').Count` and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p1-t4-tree-facts.md`
+  with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` and the four re-derived facts from
+  [P1-T1] through [P1-T4]. Acceptance: the artifact records
+  `PRECHANGE_EFCDATAMODEL_LINE_COUNT: 423` and `HEADROOM_TO_CAP: 77`. Use `(Get-Content ...).Count`,
+  not `Measure-Object -Line`, which reports a different figure for a file with a trailing newline.
+
+### Phase 2 — Diagnostic Seam Declaration
+
+- [ ] [P2-T1] Add the injectable user-diagnostic seam to `QuickFiler/Controllers/EfcDataModel.cs`,
+  inside the `#region Public Properties` block, which spans
+  `QuickFiler/Controllers/EfcDataModel.cs:146-255`. Write the declaration as
+  `internal Action<string> UserDiagnosticAction { get; set; } = text => MessageBox.Show(text);`,
+  matching `QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:23-24`. CSharpier will wrap it
+  across two lines at the `=`; that is expected and is not a deviation. `using System;` is already at
+  `QuickFiler/Controllers/EfcDataModel.cs:1`, so use `Action<string>` rather than
+  `System.Action<string>`. Add an XML doc comment stating that production never assigns it and that
+  tests replace it with a capturing delegate. The XML doc comment must not repeat the identifier
+  `UserDiagnosticAction`; refer to it as 'this seam'. Do not add any call site in this task.
+  Acceptance:
+  `Select-String -Path 'QuickFiler/Controllers/EfcDataModel.cs' -SimpleMatch 'UserDiagnosticAction'`
+  returns exactly one match.
+- [ ] [P2-T2] Confirm the seam is declaration-only across the production tree. Run
+  `Get-ChildItem -Path 'QuickFiler','TaskMaster','UtilitiesCS','ToDoModel' -Recurse -Filter '*.cs' | Where-Object { $_.FullName -notmatch '\\obj\\' -and $_.FullName -notmatch '\\bin\\' } | Select-String -SimpleMatch 'UserDiagnosticAction'`.
+  `Select-String` has no `-Recurse` parameter, so the file set is enumerated by `Get-ChildItem` and
+  piped in; `obj` and `bin` are excluded because a build leaves generated copies of source files there.
+  Acceptance: exactly one match is returned, and it is in `QuickFiler/Controllers/EfcDataModel.cs`.
+  This proves the seam changes no behavior yet, so Phase 3's red is caused by the missing guard rather
+  than by the seam.
+- [ ] [P2-T3] Rebuild the solution with
+  `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU"` using the
+  vswhere-resolved MSBuild from [P0-T10], including its `| Select-Object -First 1` suffix, teeing
+  console output to `TestResults\msbuild\p2-t3.log` (creating `TestResults\msbuild` first;
+  `.gitignore:39` ignores `[Tt]est[Rr]esult*/`, so the log is outside the diff), and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p2-t3-seam-compile.md`
+  with the four schema fields. Acceptance: the artifact records `EXIT_CODE: 0` and `Output Summary:`
+  quotes an MSBuild `Error(s)` summary line reading `0 Error(s)`.
+
+### Phase 3 — Regression Tests, Fail Before the Fix
+
+All eleven tests below live in `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`, use
+MSTest attributes, Moq and FluentAssertions only, and must be independent, deterministic, free of any
+filesystem, network, COM or live-Outlook dependency, free of temporary files, and free of
+`Thread.Sleep` and `Task.Delay`. No test may carry `[TestCategory("LiveOutlook")]`. Each test must be
+laid out in explicit Arrange, Act and Assert sections and must carry a short summary comment stating
+the scenario and the expected outcome, per `spec.md` Test Strategy and `CLAUDE.md` § UT3.
+
+Every test in this phase except [P3-T9] constructs its subject as the `TestableEfcDataModel` defined in
+[P3-T1], which is the only arrangement in this plan that yields a non-null `MailInfo` without an
+Outlook COM fixture. [P3-T9] alone constructs a plain
+`new EfcDataModel(globals, null, new CancellationTokenSource(), CancellationToken.None)`, because its
+scenario requires `MailInfo` to be null; that `CancellationTokenSource` is constructed inline in the
+test method with no disposal, matching `QuickFiler.Test/Controllers/EfcDataModelTests.cs:203`.
+Where a task below says "arrange as in [P3-T3]", that includes the `TestableEfcDataModel` construction.
+
+- [ ] [P3-T1] Create `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` with namespace
+  `QuickFiler.Test.Controllers`, a `[TestClass] public class EfcDataModelArchiveRootTests`, two
+  private `const string` fields holding verbatim copies of the two rule texts from
+  `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:13-14` and `:16-17` (named `UnresolvableRuleText` and
+  `CrossStoreRuleText`, with a comment recording that `ArchiveRootPathGuard` is `internal` to the
+  `TaskMaster` assembly and therefore cannot be referenced), a private `const string ArchiveRootLiteral`
+  of `\\mailbox@example.com\Archive`, and private helpers that build a strict `Mock<IOlObjects>`, a
+  strict `Mock<IApplicationGlobals>` whose `Ol` and `FS` getters are stubbed, and an
+  `IFileSystemFolderPaths` stub whose `SpecialFolders` returns a caller-supplied
+  `ConcurrentDictionary<string, string>`. Also add a
+  `private sealed class TestableEfcDataModel : EfcDataModel` whose constructor takes
+  `IApplicationGlobals globals` and chains to
+  `base(globals, null, new CancellationTokenSource(), CancellationToken.None)`. Construct that
+  `CancellationTokenSource` inline in the `base(...)` argument list and add no disposal for it: no
+  `IDisposable` implementation, no instance field, and no `[TestCleanup]` method. This matches the five
+  existing constructions at `QuickFiler.Test/Controllers/EfcDataModelTests.cs:35`, `:73`, `:139`,
+  `:169` and `:203`, each of which passes `new CancellationTokenSource()` inline with no disposal in
+  the same project that [P6-T4] builds. No disposable-tracking diagnostic can fail either build gate on
+  it. `SonarAnalyzer.CSharp` (`QuickFiler.Test/QuickFiler.Test.csproj:472`) and `Roslynator.Analyzers`
+  (`:500-503`) do ship such rules and may report at suggestion severity; what makes that non-blocking
+  is that the complete
+  `<Analyzer Include>` set for `QuickFiler.Test/QuickFiler.Test.csproj` is at `:470-472` and
+  `:499-506` and contains no `Microsoft.CodeAnalysis.NetAnalyzers` package, and `.editorconfig:27`
+  sets `dotnet_analyzer_diagnostic.severity = suggestion` with no `severity = error` entry anywhere in
+  that file and no `.globalconfig` in the repository. `QuickFiler.Test/QuickFiler.Test.csproj:498`
+  records that intent verbatim. Passing `null` for the
+  mail item makes the base constructor call `TryGetFirstInSelection`, whose `catch (System.Exception)`
+  at `QuickFiler/Controllers/EfcDataModel.cs:249` absorbs the strict mock's failure on the unstubbed
+  `Ol.App`, so `Mail` is null and the base constructor builds no `ConversationResolver`. In the derived
+  constructor body assign the `protected` setter:
+  `ConversationResolver = new ConversationResolver(globals, null) { MailHelper = new MailItemHelper() };`.
+  The two-argument `ConversationResolver` constructor (`QuickFiler/Helper Classes/ConversationResolver.cs:64-68`)
+  stores its two fields and does no work; `MailHelper` is a public settable property
+  (`QuickFiler/Helper Classes/ConversationResolver.cs:282-286`); and the parameterless `MailItemHelper`
+  (`UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs:80-84`) leaves `FolderInfo` null. `MailInfo`
+  (`QuickFiler/Controllers/EfcDataModel.cs:233`, `ConversationResolver?.MailHelper`) is therefore
+  non-null with no Outlook COM mock other than the strict `Mock<IOlObjects>`. The derived class is
+  legal from this assembly because `EfcDataModel` is `internal`
+  (`QuickFiler/Controllers/EfcDataModel.cs:21`) and `QuickFiler/Properties/AssemblyInfo.cs:5` grants
+  `InternalsVisibleTo("QuickFiler.Test")`; the `ConversationResolver` setter is `protected`
+  (`QuickFiler/Controllers/EfcDataModel.cs:216-220`) and is reachable through `this` inside the derived
+  constructor. Acceptance: the file exists, contains the literal
+  `namespace QuickFiler.Test.Controllers`, contains the literal `class EfcDataModelArchiveRootTests`,
+  and contains the literal `class TestableEfcDataModel : EfcDataModel`.
+- [ ] [P3-T2] Register the new file in `QuickFiler.Test/QuickFiler.Test.csproj` by inserting
+  `<Compile Include="Controllers\EfcDataModelArchiveRootTests.cs" />` immediately after the existing
+  `<Compile Include="Controllers\EfcDataModelTests.cs" />` entry identified in [P1-T3]. Acceptance:
+  `Select-String -Path 'QuickFiler.Test/QuickFiler.Test.csproj' -SimpleMatch 'Controllers\EfcDataModelArchiveRootTests.cs'`
+  returns exactly one match.
+- [ ] [P3-T3] Add `MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing`.
+  Arrange a strict `Mock<IOlObjects>` whose `ArchiveRootPath` getter throws
+  `new InvalidOperationException(UnresolvableRuleText)`, a `SpecialFolders` dictionary containing the
+  key `OneDrive`, and a `TestableEfcDataModel` built as defined in [P3-T1], whose `MailInfo` is
+  therefore non-null. Act with `moveConversation: false`. Assert the awaited result is `false` and that the
+  call does not throw. Acceptance: the test method exists with that exact name and its assert block
+  contains a FluentAssertions `Should().BeFalse()` call on the awaited result.
+- [ ] [P3-T4] Add
+  `MoveToFolderAsync_WhenArchiveRootIsCrossStoreUnresolvable_ReturnsFalseInsteadOfThrowing`, identical
+  in shape to [P3-T3] except that the getter throws
+  `new InvalidOperationException(CrossStoreRuleText)`. This is the second documented throw condition
+  required by AC9. Acceptance: the test method exists with that exact name and references
+  `CrossStoreRuleText`.
+- [ ] [P3-T5] Add `OpenOlFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns`. Arrange as in
+  [P3-T3], additionally assigning `dataModel.UserDiagnosticAction` to a capturing delegate that appends
+  to a `List<string>`. Act by awaiting `OpenOlFolderAsync("Clients\\North")`. Assert the call does not
+  throw and the captured list has exactly one element. Acceptance: the test method exists with that
+  exact name and its assert block contains `Should().ContainSingle()` on the captured list.
+- [ ] [P3-T6] Add `OpenFsFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns`, the same shape
+  as [P3-T5] but awaiting `OpenFsFolderAsync("Clients\\North")`. Acceptance: the test method exists
+  with that exact name and its assert block contains `Should().ContainSingle()` on the captured list.
+- [ ] [P3-T7] Add `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress`. Arrange
+  as in [P3-T5]. Act by awaiting `OpenOlFolderAsync("Clients\\North")`. Assert the single captured
+  message contains neither `mailbox@example.com` nor `ArchiveRootLiteral`, using the redaction
+  assertion style of `QuickFiler.Test/Controllers/EfcDataModelIssue614Tests.cs:58`. Acceptance: the
+  test method exists with that exact name and its assert block contains two
+  `Should().NotContain(...)` calls.
+- [ ] [P3-T8] Add `MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce`. Arrange a strict
+  `Mock<IOlObjects>` whose `ArchiveRootPath` getter returns `ArchiveRootLiteral`, a `SpecialFolders`
+  dictionary containing `OneDrive`, and an `EfcDataModel` whose `MailInfo` is a `MailItemHelper`
+  created through its public parameterless constructor, whose `InitializeSafeDefaults` sets
+  `_folderInfo = null` (`UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs:167`, `:177`), so
+  `MailItemHelper.FolderInfo` (`UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.Properties.cs:78-82`)
+  returns `null` and no lazy `FolderWrapper` factory runs. `EmailFiler.SortAsync` therefore
+  dereferences `FolderInfo!.OlFolder` at
+  `UtilitiesCS/EmailIntelligence/EmailParsingSorting/EmailFiler.cs:133` and raises
+  `NullReferenceException` before `MailItemHelper.Loading.cs:124` can perform a second
+  `ArchiveRootPath` read. Act with `moveConversation: false`, awaiting the call inside
+  `await act.Should().ThrowAsync<NullReferenceException>()`. The `moveConversation` value is
+  load-bearing: with `true`, `QuickFiler/Controllers/EfcDataModel.cs:274` dereferences
+  `ConversationResolver.ConversationInfo`, which the two-argument `ConversationResolver` used by
+  [P3-T1] leaves null, so a `NullReferenceException` is raised at `:274` before the read at `:289` —
+  `ThrowAsync<NullReferenceException>()` would still pass while `Times.Once()` would fail. Assert
+  `olObjects.VerifyGet(x => x.ArchiveRootPath, Times.Once())`. The `Times.Once()` assertion and the
+  asserted exception type are both fixed and must not be weakened or substituted. The
+  `TestableEfcDataModel` of [P3-T1] already supplies exactly this mail helper, so this test uses it
+  unchanged; the `ConversationResolver` constructor declared at
+  `QuickFiler/Helper Classes/ConversationResolver.cs:70-84` — five parameters, the fifth defaulted,
+  which production invokes with four arguments at `QuickFiler/Controllers/EfcDataModel.cs:67` — must
+  not be used here, because the helper construction inside it at
+  `QuickFiler/Helper Classes/ConversationResolver.cs:82` installs a `_folderInfo` factory at
+  `UtilitiesCS/OutlookObjects/MailItem/MailItemHelper.cs:106-111` whose materialization reads
+  `ArchiveRootPath` a second time and would make `Times.Once()` fail both before and after the fix.
+  Acceptance: the test method exists with that exact name and contains the literal `Times.Once()`.
+- [ ] [P3-T9] Add `MoveToFolderAsync_WhenMailInfoIsNull_ReturnsFalseWithoutReadingArchiveRoot`.
+  Arrange a strict `Mock<IOlObjects>` with `ArchiveRootPath` set up to throw and with no `App` setup,
+  and construct a plain
+  `new EfcDataModel(globals, null, new CancellationTokenSource(), CancellationToken.None)` rather than
+  a `TestableEfcDataModel`, so the public constructor's `TryGetFirstInSelection` catch at
+  `QuickFiler/Controllers/EfcDataModel.cs:249` yields a null `Mail`, no `ConversationResolver` is
+  built, and `MailInfo` is null.
+  Act with `moveConversation: false`. Assert the awaited result is `false` and
+  `olObjects.VerifyGet(x => x.ArchiveRootPath, Times.Never())`. Acceptance: the test method exists
+  with that exact name and contains the literal `Times.Never()`.
+- [ ] [P3-T10] Add `MoveToFolderAsync_WhenOneDriveIsMissing_ReturnsFalseWithoutReadingArchiveRoot`.
+  Arrange as in [P3-T3] but with an empty `SpecialFolders` dictionary. Assert the awaited result is
+  `false` and `olObjects.VerifyGet(x => x.ArchiveRootPath, Times.Never())`. This pins the ordering
+  constraint from the production side. Acceptance: the test method exists with that exact name and
+  contains the literal `Times.Never()`.
+- [ ] [P3-T11] Add `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates`. Arrange
+  exactly as in [P3-T3] — a `SpecialFolders` dictionary containing the key `OneDrive` and a
+  `TestableEfcDataModel` with a non-null `MailInfo` — except that the `ArchiveRootPath` getter throws
+  `new System.Runtime.InteropServices.COMException("com failure")`. Act with `moveConversation: false`
+  and assert the
+  awaited call throws `COMException` rather than returning `false`. Acceptance: the test method exists
+  with that exact name, and its assert block contains the literal `ThrowAsync` and the literal
+  `COMException`.
+- [ ] [P3-T12] Add `OpenOlFolderAsync_WhenOneDriveIsMissing_ReturnsWithoutReadingArchiveRoot`.
+  Arrange an empty `SpecialFolders` dictionary and a throwing `ArchiveRootPath` getter. Assert the
+  awaited call does not throw and `olObjects.VerifyGet(x => x.ArchiveRootPath, Times.Never())`.
+  Acceptance: the test method exists with that exact name and contains the literal `Times.Never()`.
+- [ ] [P3-T13] Add `OpenFsFolderAsync_WhenOneDriveIsMissing_ReturnsWithoutReadingArchiveRoot`, the
+  same shape as [P3-T12] but awaiting `OpenFsFolderAsync`. Acceptance: the test method exists with
+  that exact name and contains the literal `Times.Never()`.
+- [ ] [P3-T14] Rebuild the solution with
+  `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU"` using the
+  vswhere-resolved MSBuild from [P0-T10], including its `| Select-Object -First 1` suffix, and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p3-t14-tests-compile.md`
+  with the four schema fields. Acceptance: the artifact records `EXIT_CODE: 0` and `Output Summary:`
+  quotes an MSBuild `Error(s)` summary line reading `0 Error(s)`. A non-zero result here means the new
+  tests do not compile and must be corrected before [P3-T15]; the fail-before evidence must be a
+  runtime failure, never a build failure.
+- [ ] [P3-T15] `[expect-fail]` Run only the new test class against the built `QuickFiler.Test`
+  assembly with the vswhere-resolved `vstest.console.exe`, resolved with
+  `& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -find "Common7\IDE\Extensions\TestPlatform\vstest.console.exe" | Select-Object -First 1`,
+  run against `QuickFiler.Test\bin\Debug\QuickFiler.Test.dll` — the Debug|AnyCPU `<OutputPath>` at
+  `QuickFiler.Test/QuickFiler.Test.csproj:36` — and the arguments
+  `/InIsolation /Logger:trx /ResultsDirectory:TestResults\p3-t15 /TestCaseFilter:"FullyQualifiedName~EfcDataModelArchiveRootTests"`,
+  then write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p3-t15-regression-fail-before.md`
+  with `Timestamp:`, `Command:`, `EXIT_CODE:`, `ExpectedExitCode: 1` and `Output Summary:`. Acceptance:
+  the run reports `Total tests: 11`, `Failed: 5` and `Passed: 6`; the five failing tests are exactly
+  `MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing`,
+  `MoveToFolderAsync_WhenArchiveRootIsCrossStoreUnresolvable_ReturnsFalseInsteadOfThrowing`,
+  `OpenOlFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns`,
+  `OpenFsFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns` and
+  `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress`; and each of those five
+  failure messages names `InvalidOperationException`. The other six tests
+  (`MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce`,
+  `MoveToFolderAsync_WhenMailInfoIsNull_ReturnsFalseWithoutReadingArchiveRoot`,
+  `MoveToFolderAsync_WhenOneDriveIsMissing_ReturnsFalseWithoutReadingArchiveRoot`,
+  `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates`,
+  `OpenOlFolderAsync_WhenOneDriveIsMissing_ReturnsWithoutReadingArchiveRoot`,
+  `OpenFsFolderAsync_WhenOneDriveIsMissing_ReturnsWithoutReadingArchiveRoot`) pin behavior that is
+  already correct before the fix and are expected to pass in this run. Give the run its own
+  `/ResultsDirectory` so its TRX does not collide with the Phase 5 and Phase 6 runs.
+
+### Phase 4 — Minimal Fix
+
+- [ ] [P4-T1] Add a private helper to `QuickFiler/Controllers/EfcDataModel.cs` with the signature
+  `private bool TryGetArchiveRoot(out string archiveRoot)`. It reads `Globals.Ol.ArchiveRootPath`
+  exactly once inside a `try`, returns `true` on success, and in
+  `catch (InvalidOperationException ex)` sets `archiveRoot` to `null`, writes one
+  `logger.Warn(...)` entry through the existing static logger at
+  `QuickFiler/Controllers/EfcDataModel.cs:23-25` with a message that interpolates no path and no
+  mailbox address, and returns `false`. The catch must name `InvalidOperationException` only.
+  Acceptance:
+  `Select-String -Path 'QuickFiler/Controllers/EfcDataModel.cs' -SimpleMatch 'private bool TryGetArchiveRoot(out string archiveRoot)'`
+  returns exactly one match, and
+  `Select-String -Path 'QuickFiler/Controllers/EfcDataModel.cs' -SimpleMatch 'catch (InvalidOperationException'`
+  returns exactly one match.
+- [ ] [P4-T2] Route the `MoveToFolderAsync(string, bool, bool, bool, bool)` read through the helper.
+  Insert `if (!TryGetArchiveRoot(out var olAncestor)) { return false; }` immediately after the OneDrive
+  guard block — the `Globals.FS.SpecialFolders.TryGetValue("OneDrive", out var folderRoot)` block
+  ending at `QuickFiler/Controllers/EfcDataModel.cs:281` before [P2-T1]'s insertion shifted it, since
+  [P2-T1] adds the seam and its doc comment inside `#region Public Properties` (`:146-255`), above this
+  method — and change the
+  initializer member to `OlAncestor = olAncestor,`. The `MailInfo is null` guard remains the first
+  statement of the method and the OneDrive guard remains above the new guard. Acceptance: within the
+  body of `MoveToFolderAsync(string, ...)` the line index of the `SpecialFolders.TryGetValue` call is
+  strictly less than the line index of the `TryGetArchiveRoot` call, and the line index of the
+  `MailInfo is null` check is strictly less than both.
+- [ ] [P4-T3] Route the `OpenOlFolderAsync(string)` read through the helper. Insert, immediately after
+  the OneDrive guard block — the `Globals.FS.SpecialFolders.TryGetValue("OneDrive", out var oneDrive)`
+  block ending at `QuickFiler/Controllers/EfcDataModel.cs:304` before [P2-T1]'s insertion shifted it —
+  a guard
+  that calls `TryGetArchiveRoot`, invokes `UserDiagnosticAction` exactly once with a redacted message
+  on failure, and returns; and change the initializer member to `OlAncestor = olAncestor,`.
+  Acceptance: within the body of `OpenOlFolderAsync` the line index of the `SpecialFolders.TryGetValue`
+  call is strictly less than the line index of the `TryGetArchiveRoot` call, and exactly one
+  `UserDiagnosticAction` invocation appears in that body.
+- [ ] [P4-T4] Route the `OpenFsFolderAsync(string)` read through the helper, in the same shape as
+  [P4-T3], after the OneDrive guard block — the
+  `Globals.FS.SpecialFolders.TryGetValue("OneDrive", out var oneDrive)` block ending at
+  `QuickFiler/Controllers/EfcDataModel.cs:323` before [P2-T1]'s insertion shifted it. Acceptance:
+  within the body of `OpenFsFolderAsync` the
+  line index of the `SpecialFolders.TryGetValue` call is strictly less than the line index of the
+  `TryGetArchiveRoot` call, and exactly one `UserDiagnosticAction` invocation appears in that body.
+- [ ] [P4-T5] Prove no unguarded read remains. Run
+  `Select-String -Path 'QuickFiler/Controllers/EfcDataModel.cs' -SimpleMatch 'OlAncestor = Globals.Ol.ArchiveRootPath'`
+  and
+  `Select-String -Path 'QuickFiler/Controllers/EfcDataModel.cs' -SimpleMatch 'Globals.Ol.ArchiveRootPath'`.
+  Acceptance: the first returns zero matches; the second returns exactly one match, and that match is
+  inside the `TryGetArchiveRoot` body added by [P4-T1]. The single match must be an executable
+  statement inside the `TryGetArchiveRoot` body. Any occurrence in a comment, including an XML doc
+  comment on `TryGetArchiveRoot`, violates this condition; write the doc comment without naming
+  `Globals.Ol.ArchiveRootPath`. Commented-out copies of the old expression are
+  prohibited, because they would defeat the first assertion.
+- [ ] [P4-T6] Rebuild the solution with
+  `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU"` using the
+  vswhere-resolved MSBuild from [P0-T10], including its `| Select-Object -First 1` suffix, and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p4-t6-fix-compile.md`
+  with the four schema fields. Acceptance: the artifact records `EXIT_CODE: 0` and `Output Summary:`
+  quotes an MSBuild `Error(s)` summary line reading `0 Error(s)`.
+- [ ] [P4-T7] Record the post-fix file size with
+  `(Get-Content -LiteralPath 'QuickFiler/Controllers/EfcDataModel.cs').Count` and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p4-t7-file-size.md`
+  with the four schema fields plus `POSTFIX_EFCDATAMODEL_LINE_COUNT:`. Record the line count of
+  `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` with
+  `(Get-Content -LiteralPath 'QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs').Count`
+  alongside the production count, and record it as `POSTFIX_ARCHIVEROOTTESTS_LINE_COUNT:`. Acceptance:
+  both recorded counts are at most 500. If either exceeds 500, the corresponding file must be tightened
+  rather than the cap waived; no other file may absorb the overflow, because that would leave the
+  change footprint. Budget guidance: at roughly 25 lines per test and roughly 110 lines of shared
+  fixtures, `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` lands near 385 lines. If
+  tightening cannot bring it under 500, stop and report rather than splitting, because a second test
+  file would require an AC18 amendment in `spec.md` and a corresponding change to [P8-T20] and
+  [P9-T2].
+
+### Phase 5 — Regression Pass After the Fix
+
+- [ ] [P5-T1] Re-run the new test class with the same command, executable resolution, assembly and
+  filter as [P3-T15] but with `/ResultsDirectory:TestResults\p5-t1`, and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p5-t1-regression-pass-after.md`
+  with the four schema fields. Acceptance: the artifact records `EXIT_CODE: 0` and `Output Summary:`
+  records `Total tests: 11`, `Passed: 11` and `Failed: 0`, with each of the eleven test names listed.
+- [ ] [P5-T2] Run the two ordering-sentinel tests that must keep passing unmodified, using the
+  `vstest.console.exe` resolved exactly as in [P3-T15] against the same
+  `QuickFiler.Test\bin\Debug\QuickFiler.Test.dll` assembly, with
+  `/InIsolation /Logger:trx /ResultsDirectory:TestResults\p5-t2 /TestCaseFilter:"FullyQualifiedName~OpenFolderMethods_DelegateToDataModelWithoutExternalServices|FullyQualifiedName~HandleMoveResult_WhenMoveFails_RoutesMessageThroughInjectedAction"`,
+  and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p5-t2-sentinel-tests.md`
+  with the four schema fields. Acceptance: the artifact records `EXIT_CODE: 0`, `Total tests: 2`,
+  `Passed: 2` and `Failed: 0`.
+- [ ] [P5-T3] Prove the six existing test files named by the spec are unedited. Run
+  `git diff --name-only ecdb1c84ba8541ab67042985919cfed4df768c01 -- QuickFiler.Test TaskMaster.Test`
+  and, as the companion required for a name-listing diff,
+  `git status --porcelain -uall -- QuickFiler.Test TaskMaster.Test`;
+  write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p5-t3-untouched-tests.md`
+  with the four schema fields and both outputs verbatim. Acceptance: neither output names
+  `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs`,
+  `QuickFiler.Test/Controllers/EfcHomeControllerExecuteMovesTests.cs`,
+  `QuickFiler.Test/Controllers/EfcDataModelTests.cs`,
+  `QuickFiler.Test/Controllers/EfcDataModelIssue614Tests.cs`,
+  `QuickFiler.Test/Controllers/EfcFormControllerTests.cs` or
+  `TaskMaster.Test/AppGlobals/AppOlObjectsArchiveRootValidationTests.cs`; and the union of the two
+  outputs names exactly `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` and
+  `QuickFiler.Test/QuickFiler.Test.csproj` under those two pathspecs.
+
+### Phase 6 — Final QC Toolchain Loop
+
+The four commands below are the `CLAUDE.md` § "C# Toolchain (run in this exact order)" commands, run
+in order. [P6-T1] carries one documented deviation: when [P0-T9] recorded a non-zero baseline, the
+format step is scoped to this change's two owned files so pre-existing drift is not swept into the
+change footprint, and AC13 is then resolved through [P8-T15]'s remediation branch. If any step fails
+or changes a file, restart the loop from [P6-T1].
+
+- [ ] [P6-T1] Record `Get-FileHash -Algorithm SHA256` for `QuickFiler/Controllers/EfcDataModel.cs` and
+  `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`, run
+  `dotnet tool run csharpier format .`, then record the same two hashes again, and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t1-csharpier-format.md`
+  with the four schema fields plus the four hash values under `BeforeHashes:` and `AfterHashes:`.
+  Acceptance: the artifact records `EXIT_CODE: 0` and both before-and-after hash pairs, so the
+  write-mode command is judged on a tree observation rather than on its exit code, which is 0 whether
+  or not it rewrote anything. If [P0-T9] recorded `BASELINE_UNFORMATTED_COUNT: 0`, run the command
+  against `.` as written; if [P0-T9] recorded a non-zero count, run it against only
+  `QuickFiler/Controllers/EfcDataModel.cs` and
+  `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` so the pre-existing drift is not swept
+  into this change footprint, and record that branch and the baseline count in `Output Summary:`.
+- [ ] [P6-T2] Run `dotnet tool run csharpier check .` and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t2-csharpier-check.md`
+  with the four schema fields, quoting the tool's final summary line verbatim in `Output Summary:`.
+  Acceptance: the artifact records `EXIT_CODE: 0` when [P0-T9] recorded
+  `BASELINE_UNFORMATTED_COUNT: 0`. When [P0-T9] recorded a non-zero count, the acceptance is instead
+  that the set of files the check reports — derived as in [P0-T9] from the
+  `Error <path> - Was not formatted.` lines, not from the `Checked N files in Nms.` summary line —
+  is a subset of the baseline set recorded in [P0-T9] and
+  contains neither `QuickFiler/Controllers/EfcDataModel.cs` nor
+  `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`; record that set difference in
+  `Output Summary:`.
+- [ ] [P6-T3] Run
+  `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
+  using the vswhere-resolved MSBuild from [P0-T10], including its `| Select-Object -First 1` suffix,
+  teeing console output to `TestResults\msbuild\p6-t3.log` (creating `TestResults\msbuild` first;
+  `.gitignore:39` ignores `[Tt]est[Rr]esult*/`, so the log is outside the diff), and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t3-msbuild-analyzers.md`
+  with the four schema fields. Acceptance: the artifact records `EXIT_CODE: 0`; `Output Summary:`
+  quotes an MSBuild `Error(s)` summary line reading `0 Error(s)`; and the tee'd log contains zero
+  occurrences of the literal `Skipping target "CoreCompile"`, proving the gate was not vacuous. The
+  error count is read from MSBuild's own summary line, not by counting `error CS` occurrences.
+- [ ] [P6-T4] Run
+  `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:TreatWarningsAsErrors=true`
+  using the vswhere-resolved MSBuild from [P0-T10], including its `| Select-Object -First 1` suffix,
+  teeing console output to `TestResults\msbuild\p6-t4.log` (creating `TestResults\msbuild` first;
+  `.gitignore:39` ignores `[Tt]est[Rr]esult*/`, so the log is outside the diff), and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t4-msbuild-nullable.md`
+  with the four schema fields. Acceptance: the artifact records `EXIT_CODE: 0`; `Output Summary:`
+  quotes an MSBuild `Error(s)` summary line reading `0 Error(s)`; the tee'd log contains zero
+  occurrences of the literal `Skipping target "CoreCompile"`; and `Command:` contains neither
+  `/p:Nullable=enable` nor `/t:Build`.
+- [ ] [P6-T5] Run the full suite with `vstest.console.exe` and `/EnableCodeCoverage`. Resolve the
+  executable with
+  `& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -find "Common7\IDE\Extensions\TestPlatform\vstest.console.exe" | Select-Object -First 1`.
+  The `| Select-Object -First 1` suffix is required for the same reason as in [P0-T10]: `-find` can
+  emit several matching paths, and `scripts/vscode/Invoke-Restore.ps1:27` resolves its tool the same way.
+  Build the assembly list from `Get-ChildItem -Path . -Recurse -Filter '*.Test.dll'` keeping only paths
+  matching `\bin\Debug\` and rejecting paths matching `\obj\` or `\ref\`. Apply the `.claude` worktree
+  exclusion to the path **relative to the current worktree root**, computed as
+  `$_.FullName.Substring((Get-Location).Path.Length)`, and reject only relative paths matching
+  `\.claude\`. Do not test the absolute path for `\.claude\`: this worktree's own root sits under
+  `.claude\worktrees`, so an absolute-path filter matches every candidate and yields an empty assembly
+  list, which vstest reports as a run with zero failures. Then run the resolved executable with the
+  assembly list and `/EnableCodeCoverage /InIsolation /Logger:trx /ResultsDirectory:TestResults\p6-t5 /TestCaseFilter:"TestCategory!=LiveOutlook"`,
+  and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t5-vstest-coverage.md`
+  with the four schema fields plus `DISCOVERED_ASSEMBLY_COUNT:` and the assembly list recorded as
+  worktree-relative paths, computed as `$_.FullName.Substring((Get-Location).Path.Length)`; no
+  absolute path and no account or machine name may appear in the artifact, which [P9-T1] commits.
+  Acceptance: `DISCOVERED_ASSEMBLY_COUNT:` is at least 4 and the list contains a path ending
+  `QuickFiler.Test.dll` and a path ending `TaskMaster.Test.dll`; the run reports `Failed: 0` for tests
+  whose fully qualified name begins `QuickFiler.` and for tests whose fully qualified name begins
+  `TaskMaster.` — both figures derived from the TRX under `TestResults\p6-t5`, not from the console
+  `Failed:` total, which is an all-assembly aggregate — except any such test already named in the
+  direct-harness `BASELINE_FAILURE_SET:` recorded by [P0-T12] in
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/p0-t12-direct-harness-baseline.md`
+  — each such exception must be listed by name in `Output Summary:` together with its
+  baseline occurrence, and no test in `EfcDataModelArchiveRootTests` may appear among them; and no
+  executed test carries `[TestCategory("LiveOutlook")]`. Run this through
+  `Start-Process -Wait` or an equivalent detached wrapper.
+- [ ] [P6-T6] Close the toolchain loop. Write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t6-loop-closure.md`
+  recording, for the final accepted pass, the `Timestamp:` of each of [P6-T1] through [P6-T5] and the
+  SHA-256 of `QuickFiler/Controllers/EfcDataModel.cs` and
+  `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` taken immediately after [P6-T5].
+  Acceptance: those two hashes equal the `AfterHashes:` values recorded in [P6-T1], proving no file in
+  the change footprint changed between the formatting step and the test step, and the five timestamps
+  are non-decreasing.
+
+### Phase 7 — Coverage Measurement and Delta
+
+- [ ] [P7-T1] Run
+  `pwsh -NoProfile -File scripts/vscode/Invoke-MSTestWithCoverage.ps1 -SearchRoot . -Configuration Debug -CoverageOutput coverage/coverage.cobertura.xml`
+  and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t1-coverage-postchange.md`
+  with the four schema fields plus `POSTCHANGE_REPO_LINE_COVERAGE_PERCENT:` read from the `line-rate`
+  attribute of the root `coverage` element of `coverage/coverage.cobertura.xml` multiplied by 100, and
+  `POSTCHANGE_REPO_BRANCH_COVERAGE_PERCENT:` read from the `branch-rate` attribute the same way, and
+  `COVERAGE_XML_MODE:` recorded by the same rule as [P0-T12] — `koverage-processed` on exit 0, `raw`
+  on a non-zero exit. Acceptance: the artifact carries numeric values for both percentage fields and a
+  `COVERAGE_XML_MODE:` value that is one of those two literals. As in [P0-T12], the Cobertura file is
+  written before the script's built-in 80 percent assert runs, so a non-zero exit does not
+  invalidate the artifact, but it does mean the file carries raw rather than post-processed root
+  attributes. When the run exits non-zero, record the observed `EXIT_CODE:` and set
+  `ExpectedExitCode: 1`. Justify it by quoting, verbatim in `Output Summary:`, the terminating message
+  emitted by `scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1:489`, which reports the measured
+  Cobertura line percentage and ends with the literal `is below the required 80% threshold.`. If that
+  literal is absent from the run output, the non-zero exit came from another cause: record it without
+  `ExpectedExitCode:` and treat the task as REMEDIATION-REQUIRED.
+  Run through `Start-Process -Wait` or an equivalent detached wrapper.
+- [ ] [P7-T2] Compute coverage for the changed code. From `coverage/coverage.cobertura.xml`, aggregate
+  every `class` element whose `filename` attribute resolves to `QuickFiler/Controllers/EfcDataModel.cs`
+  — aggregate by `filename`, not by `class`, because a C# async state machine emits its lines under a
+  separate generated class and a per-class figure would understate the method.
+  In `koverage-processed` mode `Merge-CoberturaClassesByFilename`
+  (`scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1:428`) has already merged them and
+  `filename` is repo-relative; in `raw` mode neither is true and `filename` is an absolute path, so
+  match on the `QuickFiler/Controllers/EfcDataModel.cs` suffix with the separator normalized. Record
+  `COVERAGE_XML_MODE:` copied from [P7-T1]. Derive the changed-line
+  set mechanically rather than by judgment: run
+  `git diff -U0 ecdb1c84ba8541ab67042985919cfed4df768c01 -- QuickFiler/Controllers/EfcDataModel.cs`,
+  take every post-image line number named by a `+` hunk, and intersect that set with the line numbers
+  that appear as `<line number=...>` entries under the aggregated `QuickFiler/Controllers/EfcDataModel.cs`
+  filename. The intersection is the denominator; a changed line that emits no `<line>` entry is
+  non-executable and is excluded. Record the `git diff -U0` hunk headers verbatim in `Output Summary:`
+  so the set is re-derivable. Report the covered and valid line counts and the percentage over that
+  intersection, and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t2-coverage-changed-lines.md`
+  with the four schema fields plus `CHANGED_LINE_COVERAGE_PERCENT:`, `CHANGED_LINES_COVERED:`,
+  `CHANGED_LINES_VALID:` and `COVERAGE_XML_MODE:`. Acceptance: `CHANGED_LINE_COVERAGE_PERCENT:` is at least 90.0, and the
+  artifact lists each changed line number with a covered or uncovered marker so a third party can
+  re-derive the figure. The lambda body of [P2-T1]'s default seam value is expected to be uncovered:
+  every test replaces the seam before invoking the paths that use it, so no test executes the default.
+  List it explicitly among the uncovered lines rather than treating it as a gap to close.
+- [ ] [P7-T3] Write the coverage delta report to
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t3-coverage-delta.md`
+  with the four schema fields plus `BASELINE_REPO_LINE_COVERAGE_PERCENT:` copied from [P0-T12],
+  `POSTCHANGE_REPO_LINE_COVERAGE_PERCENT:` copied from [P7-T1], `CHANGED_LINE_COVERAGE_PERCENT:`
+  copied from [P7-T2], and `DELTA_REPO_LINE_COVERAGE_POINTS:` as the post-change value minus the
+  baseline value. Also copy `COVERAGE_XML_MODE:` from each of [P0-T12] and [P7-T1] as
+  `BASELINE_COVERAGE_XML_MODE:` and `POSTCHANGE_COVERAGE_XML_MODE:`. Acceptance: all four numeric
+  fields are present and none reads `UNVERIFIED`; the two recorded modes are equal, because a raw
+  figure and a post-processed figure are computed over different denominators and their difference
+  measures the denominator rather than the change; and `DELTA_REPO_LINE_COVERAGE_POINTS:` is at least
+  `-0.50`, the tolerance that absorbs measurement noise from run-to-run instrumentation differences on
+  a suite this size. A delta below that tolerance, or a pair of unequal modes, is recorded as
+  `REMEDIATION-REQUIRED` rather than as a pass. The repo-wide figure is recorded and
+  reported per AC17 and is not itself a blocking threshold; the blocking clauses are the change-scoped
+  ones in [P7-T2] and the tolerance in this task.
+- [ ] [P7-T4] Decide, and record the decision for, the canonical review coverage artifact. Read
+  `POSTCHANGE_REPO_LINE_COVERAGE_PERCENT:` and `COVERAGE_XML_MODE:` from [P7-T1]. When
+  `COVERAGE_XML_MODE:` reads `raw`, do not create the file and record
+  `Decision: NOT WRITTEN — measured figure is a raw denominator that includes test assemblies`,
+  because the raw root attributes are computed over every instrumented module and overstate the
+  first-party repo-wide figure the downstream hook reads. When it reads `koverage-processed`, write
+  `artifacts/csharp/coverage.xml` **only if** the measured value is greater than or equal to 85.0;
+  otherwise do not create the file. Write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p7-t4-canonical-coverage-artifact.md`
+  with the four schema fields plus `MEASURED_REPO_LINE_COVERAGE_PERCENT:`, `COVERAGE_XML_MODE:` and a
+  `Decision:` line reading exactly one of `WRITTEN`, `NOT WRITTEN — measured figure below 85.0`, or
+  `NOT WRITTEN — measured figure is a raw denominator that includes test assemblies`. When the file is
+  written — reachable only in `koverage-processed` mode, so the source attributes named below are the
+  recomputed first-party ones from
+  `scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1:442-445` — it
+  must be JaCoCo-shaped, carrying a root `<report>` element with a
+  `<counter type="LINE" missed="…" covered="…"/>` child whose two values are derived from the
+  `lines-covered` and `lines-valid` attributes of the root `coverage` element of
+  `coverage/coverage.cobertura.xml`. The hook reads the file with `Get-JacocoRepoCoverage` at
+  `.claude/hooks/validate-feature-review-coverage.ps1:253`, which selects `//counter[@type="LINE"]` at
+  `:229` and sums the `missed` and `covered` attributes, so a Cobertura-shaped file yields no counters
+  and the hook reads nothing. Record the derivation, both source attribute values, and both emitted
+  counter values in `Output Summary:`, so a third party can re-derive the figure. Acceptance: the
+  artifact exists, carries a numeric measured figure, its `Decision:` line is one of the three defined
+  values and agrees with the presence or absence of `artifacts/csharp/coverage.xml` on disk, and
+  `([xml](Get-Content artifacts/csharp/coverage.xml)).report.counter` returns a node when `Decision:`
+  reads `WRITTEN`. This condition exists because
+  `.claude/hooks/validate-feature-review-coverage.ps1:313` applies a hard-coded 85.0 floor whenever
+  that file exists, while this repository's policy floor is 80 percent on the testable denominator;
+  emitting the file while the measured figure sits between those two values would force a false
+  failure downstream.
+
+### Phase 8 — Acceptance Criteria and Spec Updates
+
+Acceptance criteria are checked off in
+`docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md`
+per `.claude/skills/acceptance-criteria-tracking/SKILL.md`. Work Mode is `full-bug`, so `spec.md` is
+the sole AC source. Change only `- [ ]` to `- [x]`; never edit criterion text; never add a criterion.
+Leave any criterion whose evidence is absent unchecked.
+
+- [ ] [P8-T1] Confirm the spec carries no non-canonical evidence path and no absolute host path. Run
+  `Select-String -Path 'docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md' -SimpleMatch 'evidence/coverage/'`
+  and
+  `Select-String -Path 'docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md' -SimpleMatch 'C:\Users'`.
+  Acceptance: both commands return zero matches, and the spec's Correction Log contains the dated entry
+  naming `.claude/skills/evidence-and-timestamp-conventions/SKILL.md` and the dated entry recording the
+  removal of the absolute host path from the Context section. This task edits no criterion text; both
+  substitutions were applied by the planner during preflight.
+- [ ] [P8-T2] Write the follow-up-issue dossier for the three non-goals to
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p8-t2-followup-issue-dossier.md`,
+  with one section per non-goal — (a) `COMException` from the live COM calls in the `ArchiveRootPath`
+  getter at `TaskMaster/AppGlobals/AppOlObjects.cs:260-261`; (b) the log-only `async void` boundary
+  sinks in `QuickFiler/Controllers/EfcFormController.cs`; (c) the five archive-root reads inside
+  `QuickFiler/Controllers/EfcFormController.cs` — each carrying a title, a one-paragraph body, its
+  verified citations, and a `ProposedLabels:` line. Acceptance: the file exists and contains exactly
+  three `## ` sections whose titles name non-goals (a), (b) and (c).
+- [ ] [P8-T3] Check off AC1 in `spec.md` once
+  `MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing` is recorded as
+  passing in [P5-T1]. Acceptance: the AC1 line begins `- [x] AC1` and its text is unchanged.
+- [ ] [P8-T4] Check off AC2 once `OpenOlFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns` is
+  recorded as passing in [P5-T1]. Acceptance: the AC2 line begins `- [x] AC2` and its text is unchanged.
+- [ ] [P8-T5] Check off AC3 once `OpenFsFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns` is
+  recorded as passing in [P5-T1]. Acceptance: the AC3 line begins `- [x] AC3` and its text is unchanged.
+- [ ] [P8-T6] Check off AC4 once
+  `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress` is recorded as passing in
+  [P5-T1]. Acceptance: the AC4 line begins `- [x] AC4` and its text is unchanged.
+- [ ] [P8-T7] Check off AC5 once both
+  `MoveToFolderAsync_WhenOneDriveIsMissing_ReturnsFalseWithoutReadingArchiveRoot` (in [P5-T1]) and
+  `OpenFolderMethods_DelegateToDataModelWithoutExternalServices` (in [P5-T2]) are recorded as passing
+  and [P5-T3] shows `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs` unmodified.
+  Acceptance: the AC5 line begins `- [x] AC5` and its text is unchanged.
+- [ ] [P8-T8] Check off AC6 once
+  `MoveToFolderAsync_WhenMailInfoIsNull_ReturnsFalseWithoutReadingArchiveRoot` is recorded as passing in
+  [P5-T1]. Acceptance: the AC6 line begins `- [x] AC6` and its text is unchanged.
+- [ ] [P8-T9] Check off AC7 once `MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce` is
+  recorded as passing in [P5-T1]. Acceptance: the AC7 line begins `- [x] AC7` and its text is unchanged.
+- [ ] [P8-T10] Check off AC8 once `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates`
+  is recorded as passing in [P5-T1]. Acceptance: the AC8 line begins `- [x] AC8` and its text is
+  unchanged.
+- [ ] [P8-T11] Check off AC9 once both
+  `MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing` and
+  `MoveToFolderAsync_WhenArchiveRootIsCrossStoreUnresolvable_ReturnsFalseInsteadOfThrowing` are recorded
+  as passing in [P5-T1]. Acceptance: the AC9 line begins `- [x] AC9` and its text is unchanged.
+- [ ] [P8-T12] Check off AC10 once [P6-T5] records `Failed: 0` for the `QuickFiler.` and `TaskMaster.`
+  test namespaces — the TRX-derived per-namespace figures, not the console all-assembly `Failed:`
+  total — and [P5-T3] shows all six named existing test files unmodified. Acceptance: the AC10
+  line begins `- [x] AC10` and its text is unchanged.
+- [ ] [P8-T13] Check off AC11 once [P3-T2] recorded the `<Compile Include=... />` entry and [P6-T5]'s
+  TRX under `TestResults\p6-t5` lists at least one test whose fully qualified name contains
+  `EfcDataModelArchiveRootTests`. Acceptance: the AC11 line begins `- [x] AC11` and its text is
+  unchanged.
+- [ ] [P8-T14] Check off AC12 once both
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p3-t15-regression-fail-before.md`
+  and
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/p5-t1-regression-pass-after.md`
+  exist and carry all four schema fields. Acceptance: the AC12 line begins `- [x] AC12` and its text is
+  unchanged.
+- [ ] [P8-T15] Check off AC13 only when [P6-T2] recorded `EXIT_CODE: 0`. When [P6-T2] was accepted
+  under the subset branch because [P0-T9] recorded a non-zero `BASELINE_UNFORMATTED_COUNT:`, leave AC13
+  unchecked and append
+  `REMEDIATION-REQUIRED: AC13 unmet — pre-existing format drift outside this change footprint, baseline count <N>, files <list>`
+  to
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t2-csharpier-check.md`,
+  substituting the recorded count and file list. Acceptance: exactly one of the two branches is
+  realized, and the realized branch is verifiable — either the AC13 line begins `- [x] AC13` with its
+  text unchanged and [P6-T2] recorded `EXIT_CODE: 0`, or the AC13 line begins `- [ ] AC13` and the
+  [P6-T2] artifact contains the `REMEDIATION-REQUIRED:` line.
+- [ ] [P8-T16] Check off AC14 once [P6-T3] records `0 Error(s)` and zero occurrences of
+  `Skipping target "CoreCompile"`. Acceptance: the AC14 line begins `- [x] AC14` and its text is
+  unchanged.
+- [ ] [P8-T17] Check off AC15 once [P6-T4] records `0 Error(s)`, zero occurrences of
+  `Skipping target "CoreCompile"`, and a `Command:` free of `/p:Nullable=enable` and `/t:Build`.
+  Acceptance: the AC15 line begins `- [x] AC15` and its text is unchanged.
+- [ ] [P8-T18] Check off AC16 only when [P6-T5] recorded `Failed: 0` with an empty baseline-exception
+  list and no new test carries `[TestCategory("LiveOutlook")]`. When [P6-T5] was accepted with a
+  non-empty exception list, leave AC16 unchecked and append
+  `REMEDIATION-REQUIRED: AC16 unmet — pre-existing test failures <list> present in the [P0-T12] direct-harness BASELINE_FAILURE_SET`
+  to
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p6-t5-vstest-coverage.md`,
+  substituting the recorded names. AC16 as written at `spec.md:733-736` demands zero failed tests
+  across `QuickFiler.Test` and `TaskMaster.Test` with no baseline carve-out, so the exception branch
+  [P6-T5] permits does not satisfy it. Acceptance: exactly one of the two branches is realized, and
+  the realized branch is verifiable — either the AC16 line begins `- [x] AC16` with its text unchanged
+  and [P6-T5] recorded `Failed: 0` with an empty exception list, or the AC16 line begins `- [ ] AC16`
+  and the [P6-T5] artifact contains the `REMEDIATION-REQUIRED:` line.
+- [ ] [P8-T19] Check off AC17 once [P7-T2] records `CHANGED_LINE_COVERAGE_PERCENT:` at or above 90.0
+  and [P7-T3] records all four numeric fields with a delta at or above the stated tolerance and with
+  `BASELINE_COVERAGE_XML_MODE:` equal to `POSTCHANGE_COVERAGE_XML_MODE:`.
+  Acceptance: the AC17 line begins `- [x] AC17` and its text is unchanged.
+- [ ] [P8-T20] Check off AC18 after verifying the change footprint against the merge base from the
+  working tree, before any commit exists. Run
+  `git diff --name-only ecdb1c84ba8541ab67042985919cfed4df768c01 -- QuickFiler QuickFiler.Test TaskMaster TaskMaster.Test UtilitiesCS ToDoModel .github docs`
+  and, as its companion span,
+  `git status --porcelain -uall -- QuickFiler QuickFiler.Test docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638`;
+  the anchored diff enumerates tracked modifications and the porcelain span enumerates the files this
+  plan created, so neither alone is sufficient. The `-uall` flag is required: without it
+  `git status --porcelain` collapses a wholly untracked directory to a single directory entry, so the
+  feature folder's untracked evidence tree would be reported as one path and the per-file clause below
+  would be evaluated against a directory rather than against files. Acceptance: the union of the two
+  outputs names
+  `QuickFiler/Controllers/EfcDataModel.cs`,
+  `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` and
+  `QuickFiler.Test/QuickFiler.Test.csproj`; names no path under `QuickFiler/` other than
+  `QuickFiler/Controllers/EfcDataModel.cs`; names no path under `TaskMaster/`, `UtilitiesCS/`,
+  `ToDoModel/` or `.github/`; every remaining named path lies under
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/`; and the
+  AC18 line then begins `- [x] AC18` with its text unchanged. [P9-T2] repeats this check against the
+  commit and is the artifact-bearing record of it.
+- [ ] [P8-T21] Check off AC19 once [P4-T7] records both `POSTFIX_EFCDATAMODEL_LINE_COUNT:` and
+  `POSTFIX_ARCHIVEROOTTESTS_LINE_COUNT:` at or below 500 and both counts are re-confirmed after the
+  [P6-T1] formatting pass by re-running
+  `(Get-Content -LiteralPath 'QuickFiler/Controllers/EfcDataModel.cs').Count` and
+  `(Get-Content -LiteralPath 'QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs').Count`.
+  Acceptance: both re-run counts are at most 500, the AC19
+  line begins `- [x] AC19` and its text is unchanged.
+- [ ] [P8-T22] Resolve AC20. If three follow-up issue numbers for non-goals (a), (b) and (c) are
+  already recorded in the spec's Rollout & Follow-up section, check off AC20. Otherwise leave AC20
+  unchecked and append to
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/other/p8-t2-followup-issue-dossier.md`
+  a line reading `REMEDIATION-REQUIRED: AC20 unmet — three follow-up issues not yet filed`, naming the
+  dossier as the ready-to-file input and the promotion lifecycle as the filing route. Issue filing is
+  an orchestrator responsibility and is not performed by this plan. Acceptance: exactly one of the two
+  branches is realized, and the realized branch is verifiable — either the AC20 line begins `- [x] AC20`
+  and the spec's Rollout & Follow-up section names three issue numbers, or the AC20 line begins
+  `- [ ] AC20` and the dossier contains the `REMEDIATION-REQUIRED:` line.
+- [ ] [P8-T23] Update the `spec.md` header fields `- **Status:**` to `Implemented` and
+  `- **Last Updated:**` to the current ISO-8601 `yyyy-MM-ddTHH-mm` value, and update this plan file's
+  `- **Status:**` to `Executed`. Acceptance:
+  `Select-String -Path 'docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md' -SimpleMatch 'Status:** Ready for Planning'`
+  returns zero matches.
+
+### Phase 9 — Commit, Footprint Verification, and Clean Tree
+
+- [ ] [P9-T1] Stage and commit all work with pathspecs scoped to this change:
+  `git add -A -- QuickFiler QuickFiler.Test docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638`
+  followed by a commit whose subject references issue 638. The pathspecs are mandatory: `git add -A`
+  without them would sweep unrelated tracked paths, including `.claude/agent-memory`, onto this branch.
+  Acceptance: `git log -1 --name-only` lists
+  `QuickFiler/Controllers/EfcDataModel.cs`,
+  `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` and
+  `QuickFiler.Test/QuickFiler.Test.csproj`, and lists no path outside the three pathspecs above; and
+  `git log -1 --format=%s` contains the literal `638`.
+- [ ] [P9-T2] Verify the change footprint against the merge base. Run
+  `git diff --name-only ecdb1c84ba8541ab67042985919cfed4df768c01..HEAD` and, as its companion span,
+  `git status --porcelain -uall -- QuickFiler QuickFiler.Test docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638`,
+  and write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p9-t2-change-footprint.md`
+  with the four schema fields and both outputs verbatim. Acceptance: the diff output names
+  `QuickFiler/Controllers/EfcDataModel.cs`,
+  `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` and
+  `QuickFiler.Test/QuickFiler.Test.csproj`; it names no path under `QuickFiler/` other than
+  `QuickFiler/Controllers/EfcDataModel.cs`; it names no path under `TaskMaster/`, `UtilitiesCS/`,
+  `ToDoModel/` or `.github/`; and every remaining named path lies under
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/`. In
+  particular it must not name `QuickFiler/Controllers/EfcFormController.cs`,
+  `TaskMaster/AppGlobals/AppOlObjects.cs`, `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs` or
+  `UtilitiesCS/Interfaces/IGlobals/IOlObjects.cs`.
+- [ ] [P9-T3] Write
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p9-t3-clean-tree.md`
+  with the four schema fields, summarizing the outcome of every phase and listing every evidence
+  artifact this plan produced with its `EXIT_CODE:`, then stage and commit both it and the [P9-T2]
+  artifact using the same three pathspecs as [P9-T1]. Acceptance: the file exists, lists at least 25
+  artifact paths, and `git log -1 --name-only` names both
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p9-t2-change-footprint.md`
+  and
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p9-t3-clean-tree.md`.
+- [ ] [P9-T4] Close the plan and confirm the working tree is clean within this change's scope. First
+  mark every remaining unchecked box in
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/plan.2026-08-29T07-41.md`,
+  including [P9-T3] and this task. Then run
+  `git add -- docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638`
+  followed by `git commit -m "docs(638): close plan checklist"`. Then run
+  `git status --porcelain -uall -- QuickFiler QuickFiler.Test docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638`.
+  Acceptance: the command prints nothing. The check-off precedes the commit so the tree is clean when
+  the status runs. The pathspecs are required because
+  `.claude/agent-memory` is tracked in this repository and an unscoped status would report unrelated
+  agent-memory edits as uncommitted work for this change.
+
+## Notes for the executor
+
+- Every acceptance condition above is written to be falsifiable at the moment its task runs. If any
+  condition cannot be satisfied because the tree differs from the facts recorded in the "Verified
+  facts" section, stop and report the divergence rather than weakening the condition.
+- No task in this plan requires a live Outlook profile, a live COM object, network access, the
+  filesystem for test fixtures, or a temporary file.
+- The four toolchain commands in Phase 6 are quoted from `CLAUDE.md`. Do not add `/p:Nullable=enable`
+  and do not substitute `/t:Build` for `/t:Rebuild`.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/plan.2026-08-29T07-41.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/plan.2026-08-29T07-41.md
@@ -1024,7 +1024,7 @@ Leave any criterion whose evidence is absent unchecked.
   the realized branch is verifiable — either the AC16 line begins `- [x] AC16` with its text unchanged
   and [P6-T5] recorded `Failed: 0` with an empty exception list, or the AC16 line begins `- [ ] AC16`
   and the [P6-T5] artifact contains the `REMEDIATION-REQUIRED:` line.
-- [ ] [P8-T19] Check off AC17 once [P7-T2] records `CHANGED_LINE_COVERAGE_PERCENT:` at or above 90.0
+- [x] [P8-T19] Check off AC17 once [P7-T2] records `CHANGED_LINE_COVERAGE_PERCENT:` at or above 90.0
   and [P7-T3] records all four numeric fields with a delta at or above the stated tolerance and with
   `BASELINE_COVERAGE_XML_MODE:` equal to `POSTCHANGE_COVERAGE_XML_MODE:`.
   Acceptance: the AC17 line begins `- [x] AC17` and its text is unchanged.
@@ -1072,7 +1072,7 @@ Leave any criterion whose evidence is absent unchecked.
 
 ### Phase 9 — Commit, Footprint Verification, and Clean Tree
 
-- [ ] [P9-T1] Stage and commit all work with pathspecs scoped to this change:
+- [x] [P9-T1] Stage and commit all work with pathspecs scoped to this change:
   `git add -A -- QuickFiler QuickFiler.Test docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638`
   followed by a commit whose subject references issue 638. The pathspecs are mandatory: `git add -A`
   without them would sweep unrelated tracked paths, including `.claude/agent-memory`, onto this branch.
@@ -1081,7 +1081,7 @@ Leave any criterion whose evidence is absent unchecked.
   `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` and
   `QuickFiler.Test/QuickFiler.Test.csproj`, and lists no path outside the three pathspecs above; and
   `git log -1 --format=%s` contains the literal `638`.
-- [ ] [P9-T2] Verify the change footprint against the merge base. Run
+- [x] [P9-T2] Verify the change footprint against the merge base. Run
   `git diff --name-only ecdb1c84ba8541ab67042985919cfed4df768c01..HEAD` and, as its companion span,
   `git status --porcelain -uall -- QuickFiler QuickFiler.Test docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638`,
   and write
@@ -1096,7 +1096,7 @@ Leave any criterion whose evidence is absent unchecked.
   particular it must not name `QuickFiler/Controllers/EfcFormController.cs`,
   `TaskMaster/AppGlobals/AppOlObjects.cs`, `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs` or
   `UtilitiesCS/Interfaces/IGlobals/IOlObjects.cs`.
-- [ ] [P9-T3] Write
+- [x] [P9-T3] Write
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p9-t3-clean-tree.md`
   with the four schema fields, summarizing the outcome of every phase and listing every evidence
   artifact this plan produced with its `EXIT_CODE:`, then stage and commit both it and the [P9-T2]
@@ -1105,7 +1105,7 @@ Leave any criterion whose evidence is absent unchecked.
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p9-t2-change-footprint.md`
   and
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/p9-t3-clean-tree.md`.
-- [ ] [P9-T4] Close the plan and confirm the working tree is clean within this change's scope. First
+- [x] [P9-T4] Close the plan and confirm the working tree is clean within this change's scope. First
   mark every remaining unchecked box in
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/plan.2026-08-29T07-41.md`,
   including [P9-T3] and this task. Then run

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/policy-audit.2026-08-29T13-06.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/policy-audit.2026-08-29T13-06.md
@@ -1,0 +1,426 @@
+# Policy Audit — Issue #638 (EFC unguarded archive-root read)
+
+- **Component:** `QuickFiler` / `QuickFiler.Test`
+- **Feature folder:** `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638`
+- **Branch:** `bug/efc-unguarded-archive-root-read-crashes-ui-thread-638`
+- **Base / merge base:** `ecdb1c84ba8541ab67042985919cfed4df768c01` (re-derived with `git merge-base`; matches the caller-supplied ref)
+- **Head:** `af1b36e2d93c6beeeb98bbe4998d752e1ebfd732`
+- **Commits under review:** `f07b6299`, `254fd56d`, `0b063741`, `a8cb1499`, `af1b36e2`
+- **Work mode:** `full-bug` (marker read from `issue.md:8`) — sole AC source is `spec.md`
+- **Audit date:** 2026-08-29T13-06
+- **Reviewer:** feature-review agent
+
+Assumptions recorded because evidence was not directly obtainable:
+
+1. The MCP policy-audit template asset could not be resolved: no `mcp__drm-copilot__*` tool is
+   exposed to this agent session. The canonical major headings required by
+   `.claude/skills/policy-audit-template-usage/SKILL.md` are reproduced verbatim below and the
+   artifact is authored to that structure. The same limitation prevents running
+   `mcp__drm-copilot__validate_orchestration_artifacts`.
+2. The reviewing directive prohibits `gh`, so the existence of GitHub issues #696, #697 and #698 on
+   the remote is asserted from the branch's own recorded evidence rather than from the GitHub API.
+
+## Executive Summary
+
+**Overall verdict: PASS. Blocking findings: 0.**
+
+The change is a minimal, well-bounded bug fix. Three unguarded reads of
+`Globals.Ol.ArchiveRootPath` inside `EmailFilerConfig` object initializers in
+`QuickFiler/Controllers/EfcDataModel.cs` are routed through a new private
+`TryGetArchiveRoot(out string)` helper whose `catch` is narrowed to `InvalidOperationException`.
+`MoveToFolderAsync` degrades to `return false`; the two `Open*` methods report through a new
+injectable `Action<string>` diagnostic seam and return. Eleven MSTest regression tests were added in
+a new file registered in the legacy non-SDK test project.
+
+Every gate mandated by `CLAUDE.md` § "C# Toolchain" is evidenced and independently corroborated:
+CSharpier check exit 0 with zero `Was not formatted.` lines; both `msbuild /t:Rebuild` gates at
+`0 Error(s)` with zero `Skipping target "CoreCompile"` occurrences; a full nine-assembly vstest run
+with 6870 of 6870 passing and zero executed `LiveOutlook` tests. The SHA-256 hashes recorded after
+the accepted toolchain pass match the two footprint files at `HEAD` byte-for-byte, so the gated tree
+state is the reviewed tree state.
+
+Repository-wide C# line coverage is 85.33 percent and branch coverage is 79.31 percent, both
+independently re-read from `coverage/coverage.cobertura.xml` root attributes. Changed-line coverage
+was independently recomputed from the same Cobertura file and reproduces the recorded 93.10 percent
+exactly, including the identity of the two uncovered lines. One coverage row is recorded FAIL: the
+modified production file `QuickFiler/Controllers/EfcDataModel.cs` sits at 66.20 percent line
+coverage against the 85 percent modified-file floor. That row is dispositioned non-blocking on
+evidence set out in section 5.
+
+## Rejected Scope Narrowing
+
+None detected. The caller directive anchors the audit to the full branch diff against
+`ecdb1c84ba8541ab67042985919cfed4df768c01`, names every changed file category, and explicitly
+requires coverage, toolchain and hygiene verification rather than excluding any of them. The
+directive's statement that no `user-story.md` exists is a correct consequence of the `full-bug`
+work mode and is not a narrowing of audit scope. No instruction was received that limits the audit
+to a plan, task, phase, or file subset, or that marks any language as out of scope.
+
+The audit scope used is the full two-dot-equivalent diff
+`git diff ecdb1c84ba8541ab67042985919cfed4df768c01...HEAD`: 38 files, 3 of them source
+(`QuickFiler/Controllers/EfcDataModel.cs`, `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`,
+`QuickFiler.Test/QuickFiler.Test.csproj`), the remaining 35 feature-folder documents and evidence.
+
+## Evidence Location Compliance
+
+PASS. No file in the branch diff is written under `artifacts/baselines/`, `artifacts/qa/`,
+`artifacts/evidence/` or `artifacts/coverage/`. All 33 evidence artifacts on the branch live under
+`<FEATURE>/evidence/<kind>/` with `<kind>` drawn from the canonical set
+(`baseline`, `qa-gates`, `regression-testing`, `remediation-baseline`, `other`), as required by
+`.claude/skills/evidence-and-timestamp-conventions/SKILL.md`.
+
+`validate_evidence_locations.py` is not present in this repository, so the scan was performed
+directly over `git diff --name-only` output against the merge base. `artifacts/csharp/coverage.xml`
+exists on disk but is gitignored (`.gitignore:57`) and therefore contributes no branch-diff entry.
+
+No `EVIDENCE_LOCATION_OVERRIDE_REJECTED` condition arose: this agent wrote its three artifacts to
+the feature folder root in the review worktree, as directed, and wrote no evidence elsewhere.
+
+The branch also cured one earlier non-canonical path itself: the spec's Correction Log entry at
+2026-08-29T10-05 records replacing a non-canonical coverage sub-directory reference with the
+canonical `evidence/baseline/` and `evidence/qa-gates/` locations. No helper script
+(`.ps1`, `.py`, `.sh`) exists anywhere under the feature folder's `evidence/` tree; verified by a
+recursive extension search returning zero matches.
+
+## 1. General Unit Test Policy Compliance
+
+| Requirement | Verdict | Evidence |
+|---|---|---|
+| Independence — tests run in any order | PASS | Every test constructs its own `Mock<IOlObjects>`, `Mock<IApplicationGlobals>`, `ConcurrentDictionary` and `EfcDataModel`. No static or shared mutable state; no `[ClassInitialize]`/`[AssemblyInitialize]`. |
+| Isolation — one unit of behavior per test | PASS | Each of the 11 tests exercises exactly one method-and-condition pair; names encode both. |
+| Fast execution | PASS | No I/O, no COM, no waits. The whole 11-test filter run is a sub-second segment of the 44.9-second nine-assembly suite. |
+| Determinism | PASS | No wall-clock assertion, no RNG, no ambient environment read. Grep for `Thread.Sleep`, `Task.Delay`, `Path.GetTemp`, `File.Create` over the new test file returns zero matches. |
+| Readability and maintainability | PASS | Every test carries a Scenario/Expected-outcome XML summary and explicit `// Arrange`, `// Act`, `// Assert` markers. Shared arrangement is factored into six named private helpers. |
+| Arrange-Act-Assert structure | PASS | All 11 tests. |
+| Clear failure messages | PASS | FluentAssertions throughout (`Should().BeFalse()`, `Should().ContainSingle()`, `Should().NotContain(...)`, `Should().ThrowAsync<T>()`). |
+| No external dependencies | PASS | Strict Moq seams over `IApplicationGlobals`, `IOlObjects` and `IFileSystemFolderPaths`. No network, database, filesystem, live Outlook or external process. |
+| No temporary files | PASS | Zero filesystem writes in the new test file. |
+| Scenario completeness (positive, negative, edge, error) | PASS | Positive: `MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce`. Negative: both `InvalidOperationException` throw conditions. Edge: two `MoveToFolderAsync` early-guard orderings plus two `Open*` OneDrive-missing paths. Error: `COMException` propagation. |
+| Test file location | PASS (with recorded deviation) | Tests are placed at `QuickFiler.Test/Controllers/`, not in a `tests/` mirror tree. `.claude/rules/general-unit-test.md` § "Test File Location" mandates a `tests/` mirror; `spec.md` records decision D1 resolving the conflict in favour of `CLAUDE.md` § C#, which ranks above `.claude/rules/` per `.claude/skills/policy-compliance-order/SKILL.md`, and in favour of the General Code Change Policy § 7.1 "match existing style". Every C# test in this repository lives in a `<Project>.Test` sibling; the `tests/` tree holds only PowerShell Pester files. The deviation is pre-existing, repository-wide, and documented rather than silent. |
+| Coverage thresholds | See section 5 | Repo-wide C# line coverage PASS; modified-file line coverage FAIL, dispositioned non-blocking. |
+
+## 2. General Code Change Policy Compliance
+
+| Requirement | Verdict | Evidence |
+|---|---|---|
+| Bugfix Workflow — failing regression test first | PASS | `evidence/regression-testing/p3-t15-regression-fail-before.md`: exit 1, 11 tests, 5 failed, each failure message naming `InvalidOperationException`, run before the Phase 4 fix. `evidence/regression-testing/p5-t1-regression-pass-after.md`: exit 0, 11 of 11 pass. |
+| Bugfix Workflow — minimal targeted fix | PASS | One production file, +65/-3 lines, one new private helper and one new internal seam. No opportunistic refactor. Deeper design problems were routed to follow-up issues rather than widening scope. |
+| Bugfix Workflow — verify locally before review | PASS | Section 7 records the four-step toolchain, run twice with the second pass clean end to end. |
+| Simplicity first | PASS | A `try`/`catch` extracted into a `bool`-returning helper with an `out` parameter — the simplest shape that lets a `try` guard a read that syntactically sits inside an object initializer. |
+| Reusability | PASS | The single helper serves all three call sites; no copy-pasted `try`. |
+| Extensibility | PASS | `UserDiagnosticAction` is a settable delegate seam, matching `EfcHomeController.MoveFailureMessageAction`. |
+| Separation of concerns | PASS | The helper isolates the COM-backed read and its documented failure mode from the filing workflow. |
+| Fail fast and explicitly | PASS | The catch is exactly `InvalidOperationException`. `COMException` propagates, pinned by `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates`. No broad `catch (Exception)` was introduced. |
+| Logging via the project pattern | PASS | `logger.Warn(message, ex)` on the existing static log4net logger, mirroring the adjacent OneDrive guard's `logger.Warn`. No `Console.WriteLine`. |
+| No silent error swallowing | PASS | Each guarded failure emits one `Warn` entry, and the `Open*` paths additionally surface a user-facing message. The pre-fix behavior — a hidden form, no message, and one log entry several frames away — is what the change removes. |
+| File size <= 500 lines | PASS | `QuickFiler/Controllers/EfcDataModel.cs` is 485 lines at head (423 at the merge base), measured with `awk END{print NR}`. `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` is 389 lines. |
+| Module cohesion | PASS | The helper and its message constant belong to the class that performs the reads. |
+| Comment why, not what | PASS | The helper's XML doc explains why `InvalidOperationException` is absorbed and why other failures are not. The `TestableEfcDataModel` doc explains why the two-argument `ConversationResolver` constructor is required and why the five-argument one would break the single-read invariant. |
+| No breaking public API change | PASS | `git diff` shows no signature line altered. `EfcDataModel` is `internal`; the new member is `internal`. |
+| Approved dependencies only | PASS | No package reference added. `QuickFiler.Test.csproj` gains exactly one `<Compile Include>` line. |
+| I/O boundaries | PASS | Domain logic is testable without network or filesystem; the 11 tests prove it. |
+| Existing tests treated as spec | PASS | `evidence/other/p5-t3-untouched-tests.md` shows the union of `git diff --name-only` and `git status --porcelain -uall` over both test projects is exactly the new file plus the one-line `.csproj` edit. All six protected test files are unmodified; independently re-verified against the branch diff. |
+| Docs updated | PASS | `spec.md` status set to Implemented, AC check-off recorded, Rollout & Follow-up carries the three follow-up issue numbers, and a Correction Log documents three amendments. |
+
+## 3. Language-Specific Code Change Policy Compliance (C#)
+
+| Requirement | Verdict | Evidence |
+|---|---|---|
+| CSharpier formatting via `dotnet tool run` | PASS | `evidence/qa-gates/p6-t2-csharpier-check.md`: `dotnet tool run csharpier check .`, exit 0, `Checked 1561 files in 4097ms.`, zero `Error <path> - Was not formatted.` lines. Baseline was 1560 files with zero unformatted. |
+| `dotnet format` not used | PASS | No evidence artifact or command record references `dotnet format`. |
+| Analyzer gate with `/t:Rebuild` | PASS | `evidence/qa-gates/p6-t3-msbuild-analyzers.md`: exit 0, `0 Error(s)`, `5 Warning(s)` (unchanged from the `[P0-T10]` baseline), zero occurrences of `Skipping target "CoreCompile"` in the tee'd log against 86 `CoreCompile` invocations. |
+| Type-check gate with `/t:Rebuild`, no `/p:Nullable=enable` | PASS | `evidence/qa-gates/p6-t4-msbuild-nullable.md`: exit 0, `0 Error(s)`, `5 Warning(s)`, zero `Skipping target "CoreCompile"`. The recorded command contains neither `/p:Nullable=enable` nor `/t:Build`, matching `CLAUDE.md` § C#1.3 and `.github/workflows/ci.yml`. |
+| Toolchain order and restart-on-change | PASS | `evidence/qa-gates/p6-t6-loop-closure.md`: the loop ran twice; pass 1's format step rewrote the new test file (line-ending normalization) and forced a restart; pass 2 was a fixpoint and steps 2-5 all ran after it, with non-decreasing timestamps. |
+| Gated tree equals reviewed tree | PASS | SHA-256 hashes recorded immediately after the test step — `995BB645...B2A5E2A` for `EfcDataModel.cs` and `A20BCF32...987794EB` for the new test file — reproduce exactly against the working tree at `HEAD` (independently recomputed during this review). |
+| Strong contracts, explicit APIs | PASS | `TryGetArchiveRoot(out string)` documents its contract, its absorbed exception and its non-absorbed exceptions in XML doc comments. |
+| Null-safety | PASS | The helper assigns `archiveRoot = null` on the failure branch and every caller checks the `bool` before use, so no null flows into `EmailFilerConfig.OlAncestor`. Neither changed file opts into `#nullable enable`, consistent with the repository's per-file opt-in model. |
+| Resource safety / async | PASS | No new disposable, no new `async` method, no `async void` added. |
+| Public surface minimal | PASS | The seam is `internal`, the helper and the message constant are `private`. |
+| Naming conventions | PASS | `PascalCase` members, `camelCase` locals, descriptive names. |
+| XML documentation on non-obvious behavior | PASS | Both new members and the message constant carry XML doc comments. |
+| No new suppressions | PASS | No `#pragma warning disable`, no `[SuppressMessage]`, no `[ExcludeFromCodeCoverage]` added. |
+
+## 4. Language-Specific Unit Test Policy Compliance (C#)
+
+| Requirement | Verdict | Evidence |
+|---|---|---|
+| MSTest framework | PASS | `[TestClass]` / `[TestMethod]` from `Microsoft.VisualStudio.TestTools.UnitTesting`. No xUnit or NUnit reference. |
+| Moq for mocking | PASS | `Mock<IOlObjects>`, `Mock<IApplicationGlobals>`, `Mock<IFileSystemFolderPaths>`, all `MockBehavior.Strict`. |
+| FluentAssertions for assertions | PASS | Every assertion is FluentAssertions; `Moq.VerifyGet` is used for call-count pinning, which FluentAssertions does not express. |
+| No new test dependency | PASS | `QuickFiler.Test.csproj` diff is one `<Compile Include>` line; no `PackageReference` or `Reference` added. |
+| New test file registered in the legacy project | PASS | `<Compile Include="Controllers\EfcDataModelArchiveRootTests.cs" />` added at `QuickFiler.Test/QuickFiler.Test.csproj:116`. Confirmed effective, not merely present: 11 tests named `EfcDataModelArchiveRootTests` appear in the full-suite TRX. |
+| No `[TestCategory("LiveOutlook")]` in the change | PASS | Grep over the new test file returns zero `TestCategory` occurrences. The suite run executed zero `LiveOutlook` tests. |
+| Strict mocks fail loudly on unexpected reads | PASS | `MockBehavior.Strict` on all three seams, so an unconfigured member access throws rather than returning a default. |
+
+## 5. Test Coverage Detail
+
+Coverage source: `coverage/coverage.cobertura.xml` (post-processed by
+`scripts/vscode/Invoke-MSTestWithCoverage.Helpers.ps1`), plus the canonical review artifact
+`artifacts/csharp/coverage.xml`. Both were read directly during this review, not taken on trust.
+
+Root attributes independently re-read: `line-rate="0.853335"`, `branch-rate="0.79311"`,
+`lines-covered="54802"`, `lines-valid="64221"`, 9 `<package>` elements. The canonical JaCoCo-shaped
+artifact carries `<counter type="LINE" missed="9419" covered="54802"/>`, which recomputes to
+85.33 percent and agrees with the Cobertura root.
+
+| Language | Artifact | Scope | Figure | Floor | Verdict |
+|---|---|---|---|---|---|
+| C# | `artifacts/csharp/coverage.xml` (present) | repo-wide line coverage | 85.33% | 85% | PASS |
+| C# | `coverage/coverage.cobertura.xml` | repo-wide branch coverage | 79.31% | 75% | PASS |
+| C# | `coverage/coverage.cobertura.xml` | changed-line coverage on `EfcDataModel.cs` | 93.10% (27 of 29) | 90% | PASS |
+| C# | `coverage/coverage.cobertura.xml` | modified-file line coverage, `QuickFiler/Controllers/EfcDataModel.cs` | 66.20% (188 of 284) | 85% | FAIL, dispositioned non-blocking below |
+| C# | branch-diff scan | new production source files added by this change | none exist; the one added file is a test file | 85% | PASS |
+| TypeScript | branch-diff scan | zero changed files on this branch | no measurement required | 85% | PASS |
+| Python | branch-diff scan | zero changed files on this branch | no measurement required | 85% | PASS |
+| PowerShell | branch-diff scan | zero changed files on this branch | no measurement required | 85% | PASS |
+
+C# is the only language with changed files in the branch diff. The diff contains three source files,
+all `.cs` or `.csproj`, and 35 Markdown documents. No `.ts`, `.tsx`, `.py`, `.ps1` or `.psm1` file
+appears anywhere in the diff, which is why the three non-C# rows above record no measurement
+obligation rather than a waived one.
+
+### Independent recomputation of the changed-line figure
+
+The recorded 93.10 percent was reproduced from scratch during this review. Parsing
+`coverage/coverage.cobertura.xml` for every `<class>` whose `filename` resolves to
+`QuickFiler/Controllers/EfcDataModel.cs` yields exactly one merged class element carrying 284
+`<line>` entries. Intersecting the 65 post-image line numbers named by the `+` hunks of
+`git diff -U0` against the merge base with that line set leaves 29 executable lines, 27 of them with
+`hits > 0`: **93.10 percent**, uncovered lines **366** and **390**. Every figure and both line
+numbers match `evidence/qa-gates/p7-t2-coverage-changed-lines.md` exactly.
+
+Lines 366 and 390 are `OlAncestor = olAncestor,` on the success branch of `OpenOlFolderAsync` and
+`OpenFsFolderAsync`. Reaching them requires constructing a real `EmailFiler` against a live Outlook
+folder, which `.claude/rules/general-unit-test.md` prohibits. The equivalent line on the move path,
+339, is covered.
+
+### AC17 remediation adjudication
+
+The plan's `[P7-T3]` correctly refused to compare a `raw` merge-base figure against a
+`koverage-processed` post-change figure: the raw file carried 14 packages and `lines-valid=82363`
+including every `.Test` assembly, versus 9 packages and `lines-valid=64221` post-processed. That is
+a denominator difference, not a change effect, and the resulting `+14.63` delta was an artefact.
+
+The remediation is sound. `evidence/remediation-baseline/ac17-commensurable-baseline.md` records a
+fresh merge-base run in a separate detached worktree at `ecdb1c84`, with `packages/` and
+`.dotnet-sdk/` copied from the feature worktree so the analyzer set and SDK are identical, a
+`/t:Rebuild` before the harness, exit 0, 6859 of 6859 passing, and post-processing reached. It
+yields `line-rate=0.852636`, `branch-rate=0.792376`, `lines-covered=54735`, `lines-valid=64195`
+across 9 packages. Four independent corroborations were checked:
+
+1. **Mode equality.** Both figures are `koverage-processed`; the clause `[P7-T3]` could not satisfy
+   is now satisfied on its own terms.
+2. **Package-count equality.** 9 packages in both runs, so the assembly allowlist selected the same
+   set and the denominators are constructed identically.
+3. **Denominator arithmetic.** `64221 - 64195 = 26`, which equals the count of newly added
+   executable lines in `EfcDataModel.cs` derived independently above (29 changed executable lines
+   minus the 3 pre-existing lines that were only re-pointed at the local). The denominator grew by
+   exactly what the change adds and by nothing else.
+4. **Numerator arithmetic.** `54802 - 54735 = +67`. Of that, 26 are the new lines; the remaining 41
+   are lines that were executable and uncovered at the merge base and are now reached by the 11 new
+   tests through `EfcDataModel`'s guard and early-return paths. The sign and magnitude are consistent
+   with 11 added tests that drive previously unexercised branches.
+
+The `+0.07`-point movement on both line and branch rates is inside the run-to-run noise band this
+repository has previously measured for C# repo-wide figures, and the remediation artifact says so
+explicitly, claiming only "not lowered" rather than a measured improvement. That is the claim AC17
+requires and the claim the evidence supports. The original `[P7-T3]` artifact was left unedited with
+an appended, clearly delimited `RESOLVED` section, which conforms to the remediation-reconciliation
+rule in `.claude/skills/evidence-and-timestamp-conventions/SKILL.md`. **AC17's closure is sound.**
+
+### Disposition of the modified-file FAIL row
+
+`QuickFiler/Controllers/EfcDataModel.cs` reads 66.20 percent line coverage (188 of 284), below the
+85 percent modified-file floor. Recorded FAIL. Dispositioned **non-blocking**, on five grounds:
+
+1. **The shortfall is pre-existing and the change improves it.** The change adds 26 executable lines,
+   all covered. Baseline denominator was therefore 258 and baseline numerator 161 or 162 (161 if the
+   pre-change line 289 was uncovered, 162 if covered), giving a merge-base figure of 62.40 to 62.79
+   percent. Head is 66.20 percent, an improvement of 3.4 to 3.8 points. The exact baseline numerator
+   cannot be pinned because the merge-base Cobertura file was produced in a detached worktree that
+   was not retained; the bound above is derived arithmetically and holds either way.
+2. **Zero regression on changed lines.** All 26 newly added executable lines are covered, and of the
+   three pre-existing lines the change touched, one is covered and two (366, 390) sit on a
+   COM-dependent success branch that no test could reach before or after.
+3. **The residual uncovered mass is COM-bound and outside the defect.** The 96 uncovered lines fall
+   in eight ranges: 181-185 and 189-221 (`FolderHelper` / `InitFolderHandlerAsync`, driven by
+   `FolderPredictor`), 248-254 (`TryGetFirstInSelection`), 345-346, 362-371 and 386-395
+   (`EmailFiler` construction and its `SortAsync` / `OpenOlFolderAsync` /
+   `OpenFileSystemFolderAsync` calls), 406-419 (the `MAPIFolder` overload of `MoveToFolderAsync`)
+   and 451-481 (`PackageItems`, `FindMatches`, `RefreshSuggestions`, which dereference
+   `MailItem` and `FolderPredictor`). Every one of these requires a live Outlook object.
+4. **Raising the file to 85 percent would violate the Bugfix Workflow.** `CLAUDE.md` § Bugfix
+   Workflow step 2 requires changing only what is needed and directs deeper design problems to new
+   issues. Covering the ranges above needs new injectable seams across `EmailFiler`, `FolderPredictor`
+   and the `MAPIFolder` overload — a refactor several times the size of the fix.
+5. **The governing acceptance criterion is change-scoped and it passes.** `spec.md` AC17 sets the
+   blocking clause at >= 90 percent on changed lines with no regression, and demotes the repo-wide
+   figure to record-and-report. Changed-line coverage is 93.10 percent and repo-wide is 85.33 percent,
+   which clears both the 80 percent floor in `CLAUDE.md` § UT2 and the 85 percent floor in
+   `.claude/rules/general-unit-test.md`.
+
+No remediation-inputs artifact is produced, because no finding in this audit blocks.
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Source |
+|---|---|---|
+| Test assemblies discovered | 9 | `evidence/qa-gates/p6-t5-vstest-coverage.md` |
+| Total tests executed | 6870 | same |
+| Passed | 6870 | same |
+| Failed | 0 | same; corroborated per-namespace from the TRX (`QuickFiler.` = 0, `TaskMaster.` = 0, all others = 0) |
+| Skipped | 0 | no `Skipped:` summary line emitted |
+| `LiveOutlook` tests executed | 0 | TRX `TestDefinitions` intersected with the executed `testId` set |
+| Baseline failure carve-outs consumed | 0 | `BASELINE_FAILURE_SET: none` in `evidence/baseline/p0-t12-direct-harness-baseline.md` |
+| New tests added | 11 | all 11 present in the TRX |
+| Merge-base test total | 6859 | `evidence/remediation-baseline/ac17-commensurable-baseline.md` |
+| Arithmetic check | 6859 + 11 = 6870 | consistent |
+| Fail-before run | exit 1; 11 tests, 6 passed, 5 failed, each naming `InvalidOperationException` | `evidence/regression-testing/p3-t15-regression-fail-before.md` |
+| Pass-after run | exit 0; 11 of 11 passed | `evidence/regression-testing/p5-t1-regression-pass-after.md` |
+| Test filter parity with CI | `/InIsolation` and `/TestCaseFilter:"TestCategory!=LiveOutlook"`, matching `.github/workflows/_mstest-coverage.yml:83` | `evidence/qa-gates/p6-t5-vstest-coverage.md` |
+
+The assembly-discovery rule recorded in the evidence rejects `\.claude\` only in the
+worktree-relative path, not the absolute path. That is the correct form: an absolute-path test would
+match every candidate when the review worktree itself sits under a `.claude` directory and would
+silently produce an empty assembly list that vstest reports as zero failures. Nine assemblies were
+in fact discovered, so the filter did not over-reject.
+
+## 7. Code Quality Checks
+
+| Check | Command | Result | Verdict |
+|---|---|---|---|
+| Format | `dotnet tool run csharpier check .` | exit 0, 1561 files checked, 0 unformatted | PASS |
+| Analyzers | `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true` | exit 0, `0 Error(s)`, `5 Warning(s)` (baseline-equal), 0 `Skipping target "CoreCompile"` | PASS |
+| Type check | `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:TreatWarningsAsErrors=true` | exit 0, `0 Error(s)`, `5 Warning(s)` (baseline-equal), 0 `Skipping target "CoreCompile"` | PASS |
+| Test | `vstest.console.exe <9 assemblies> /EnableCodeCoverage /InIsolation /Logger:trx /TestCaseFilter:"TestCategory!=LiveOutlook"` | exit 0, 6870 of 6870 passed | PASS |
+| Loop closure | SHA-256 of both footprint files before and after | equal; and equal to the working tree at `HEAD` | PASS |
+| File-size cap | `awk END{print NR}` | 485 and 389, both <= 500 | PASS |
+| Redaction discipline | source read plus `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress` | the constant names the rule only; no path, no mailbox address, no exception message interpolated | PASS |
+| Host-identity hygiene of branch content | recursive case-insensitive grep for user-profile roots, the account name and worktree names over the feature folder and both source files | zero matches | PASS |
+| Guard ordering | direct source read at `EfcDataModel.cs:311-330`, `:349-360`, `:374-384` | `MailInfo is null` first; OneDrive `SpecialFolders` second; archive-root guard third in `MoveToFolderAsync`, and after the OneDrive guard in both `Open*` methods | PASS |
+| Ordering pinned from the untouched side | `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs:217` | `probe.FileSystem.SpecialFoldersAccessCount.Should().Be(2)` still present and the file unmodified in the diff | PASS |
+| Catch breadth | `EfcDataModel.cs:287` | `catch (InvalidOperationException ex)` only; no `catch (Exception)`, no `catch (COMException)` | PASS |
+
+The 5 analyzer/compiler warnings are pre-existing and equal in count to the `[P0-T10]` and
+`[P0-T11]` merge-base baselines, so the change introduces no new diagnostic.
+
+## 8. Gaps and Exceptions
+
+All items below are non-blocking. Each is recorded so it is not lost.
+
+- **G1 — Modified-file line coverage below the 85 percent floor.** Recorded FAIL in section 5 with a
+  five-part non-blocking disposition. Severity: Minor. Pre-existing debt, improved by this change.
+- **G2 — `tests/` mirror-tree deviation.** `.claude/rules/general-unit-test.md` requires test files
+  in a `tests/` mirror. This repository places all C# tests in `<Project>.Test` siblings. The
+  deviation is repository-wide and pre-existing; `spec.md` decision D1 records the resolution and its
+  authority chain. Severity: Informational. Not introduced by this change.
+- **G3 — AC12's phrase "unmodified production code" is imprecise.** The fail-before run at
+  `[P3-T15]` executed against production code that already carried the Phase-2 diagnostic seam
+  declaration; only the Phase-4 guard was absent. This is structurally necessary — the tests assign
+  `dataModel.UserDiagnosticAction`, so they cannot compile without the seam — and the seam is
+  behaviourally inert until Phase 4 adds its three invocation sites, which the branch diff confirms.
+  The five recorded failures are therefore genuine proof of the unguarded read. Severity:
+  Informational, wording only.
+- **G4 — Remote existence of issues #696, #697 and #698 was not queried.** The directive prohibits
+  `gh`. Verification was limited to what the directive assigns: the three numbers are recorded in
+  `spec.md` § Rollout & Follow-up (two places: the post-fix task list and the Links list), and the
+  three sections of `evidence/other/p8-t2-followup-issue-dossier.md` correspond one-to-one to the
+  three non-goals (a), (b) and (c) in `spec.md` § Scope & Non-Goals. Both hold. Severity:
+  Informational.
+- **G5 — The promotion records for #696-#698 are not on this branch.** The dossier's `RESOLVED`
+  appendix states the promoted records are retained under `docs/features/potential/promoted/`; that
+  directory in the review worktree contains no entry for these three, and the working tree is clean.
+  The records were created in whichever worktree the orchestrator ran the promotion tools. This does
+  not affect AC20, whose text requires the issue numbers to be recorded in the spec, which they are.
+  Severity: Informational. Worth confirming before the feature folder is archived.
+- **G6 — Spec-internal tension on the redaction invariant.** `spec.md` § Boundaries states that no
+  user-visible message may interpolate the destination folder path, while § Error handling
+  deliberately preserves the pre-existing `EfcHomeController` message "Cannot move to folderpath
+  {selectedFolder}", which does interpolate it. That message is pre-existing, unmodified by this
+  change, pinned by an untouched test, and carries an archive-relative stem rather than a mailbox
+  address. AC4 is scoped to the new seam's diagnostic, which is clean. Severity: Informational.
+- **G7 — Region placement.** `TryGetArchiveRoot` and `ArchiveRootUnavailableMessage` are declared
+  inside the `#region Public Properties` block, although both are private and one is a method.
+  Severity: Trivial. Detailed in the code review.
+
+No policy document under `.claude/rules/` or `.github/instructions/` was modified by this change or
+by this review. No secret or `.env` file was created.
+
+## 9. Summary of Changes
+
+| File | Change | Lines |
+|---|---|---|
+| `QuickFiler/Controllers/EfcDataModel.cs` | Added `internal Action<string> UserDiagnosticAction` seam defaulting to `MessageBox.Show`; added `private const string ArchiveRootUnavailableMessage`; added `private bool TryGetArchiveRoot(out string)` with a narrow `catch (InvalidOperationException)` and a `logger.Warn`; routed the three `OlAncestor` assignments through it, returning `false` in `MoveToFolderAsync` and reporting-then-returning in both `Open*` methods | +65 / -3 (423 to 485) |
+| `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` | New file: 11 MSTest tests, 6 private arrangement helpers, one `TestableEfcDataModel` fixture subclass | +389 (new) |
+| `QuickFiler.Test/QuickFiler.Test.csproj` | One `<Compile Include>` registration | +1 |
+| Feature folder documents and evidence | `issue.md`, `spec.md`, `plan.2026-08-29T07-41.md`, one research artifact, 33 evidence artifacts | +3969 |
+
+Change footprint matches AC18 exactly. `QuickFiler/Controllers/EfcFormController.cs`,
+`TaskMaster/AppGlobals/AppOlObjects.cs`, `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs` and
+`UtilitiesCS/Interfaces/IGlobals/IOlObjects.cs` are all absent from the branch diff, confirmed by
+`git diff --name-only` against the merge base.
+
+## 10. Compliance Verdict
+
+**PASS.**
+
+| Section | Verdict |
+|---|---|
+| 1. General Unit Test Policy | PASS |
+| 2. General Code Change Policy | PASS |
+| 3. C# Code Change Policy | PASS |
+| 4. C# Unit Test Policy | PASS |
+| 5. Test Coverage Detail | PASS overall; one FAIL row (modified-file line coverage) dispositioned non-blocking |
+| 6. Test Execution Metrics | PASS |
+| 7. Code Quality Checks | PASS |
+| 8. Gaps and Exceptions | 7 non-blocking items recorded |
+| Evidence Location Compliance | PASS |
+| Rejected Scope Narrowing | none detected |
+
+Blocking findings: **0**. No remediation-inputs artifact is required or produced.
+
+## Appendix A: Test Inventory
+
+New tests, all in `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`, namespace
+`QuickFiler.Test.Controllers`:
+
+| # | Test | Category | Pre-fix | Post-fix |
+|---|---|---|---|---|
+| 1 | `MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing` | Regression | FAIL | PASS |
+| 2 | `MoveToFolderAsync_WhenArchiveRootIsCrossStoreUnresolvable_ReturnsFalseInsteadOfThrowing` | Regression | FAIL | PASS |
+| 3 | `OpenOlFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns` | Regression | FAIL | PASS |
+| 4 | `OpenFsFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns` | Regression | FAIL | PASS |
+| 5 | `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress` | Redaction | FAIL | PASS |
+| 6 | `MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce` | Invariant | PASS | PASS |
+| 7 | `MoveToFolderAsync_WhenMailInfoIsNull_ReturnsFalseWithoutReadingArchiveRoot` | Ordering | PASS | PASS |
+| 8 | `MoveToFolderAsync_WhenOneDriveIsMissing_ReturnsFalseWithoutReadingArchiveRoot` | Ordering | PASS | PASS |
+| 9 | `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates` | Catch breadth | PASS | PASS |
+| 10 | `OpenOlFolderAsync_WhenOneDriveIsMissing_ReturnsWithoutReadingArchiveRoot` | Ordering | PASS | PASS |
+| 11 | `OpenFsFolderAsync_WhenOneDriveIsMissing_ReturnsWithoutReadingArchiveRoot` | Ordering | PASS | PASS |
+
+Protected existing tests, verified unmodified in the branch diff:
+`QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs`,
+`QuickFiler.Test/Controllers/EfcHomeControllerExecuteMovesTests.cs`,
+`QuickFiler.Test/Controllers/EfcDataModelTests.cs`,
+`QuickFiler.Test/Controllers/EfcDataModelIssue614Tests.cs`,
+`QuickFiler.Test/Controllers/EfcFormControllerTests.cs`,
+`TaskMaster.Test/AppGlobals/AppOlObjectsArchiveRootValidationTests.cs`.
+
+## Appendix B: Toolchain Commands Reference
+
+Commands mandated by `CLAUDE.md` § "C# Toolchain (run in this exact order)", all evidenced on this
+branch. Executable paths are recorded in the evidence as unresolved `vswhere` expressions because the
+resolved paths are absolute.
+
+1. `dotnet tool restore` (once per worktree) — `evidence/baseline/p0-t6-dotnet-tool-restore.md`
+2. `dotnet tool run csharpier format .` — `evidence/qa-gates/p6-t1-csharpier-format.md`
+3. `dotnet tool run csharpier check .` — `evidence/qa-gates/p6-t2-csharpier-check.md`
+4. `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true` — `evidence/qa-gates/p6-t3-msbuild-analyzers.md`
+5. `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:TreatWarningsAsErrors=true` — `evidence/qa-gates/p6-t4-msbuild-nullable.md`
+6. `vstest.console.exe <assembly list> /EnableCodeCoverage /InIsolation /Logger:trx /TestCaseFilter:"TestCategory!=LiveOutlook"` — `evidence/qa-gates/p6-t5-vstest-coverage.md`
+
+Read-only commands run by this review, all non-mutating: `git rev-parse`, `git merge-base`,
+`git status --short`, `git diff --numstat`, `git diff -U0`, `git diff --name-only`, `git show`,
+`git check-ignore`, `awk END{print NR}`, `sha256sum`, `grep`, and a read-only Python parse of
+`coverage/coverage.cobertura.xml`. No source file, policy document or acceptance criterion was
+modified.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/research/2026-08-29T08-05-archive-root-guard-research.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/research/2026-08-29T08-05-archive-root-guard-research.md
@@ -1,0 +1,677 @@
+# Research — Issue #638: EFC unguarded archive-root read
+
+- **Issue:** #638
+- **Feature folder:** `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638`
+- **Branch:** `bug/efc-unguarded-archive-root-read-crashes-ui-thread-638` (worktree branched from `origin/main` at `ecdb1c84ba8541ab67042985919cfed4df768c01`)
+- **Timestamp:** 2026-08-29T08-05
+- **Type:** Research only. No production source file was modified.
+
+## 0. Method and tool limitations
+
+All line citations below were read from the working tree of this worktree during this session and are
+current as of the branch head named above.
+
+Two limitations must be recorded because they bound the confidence of specific claims:
+
+1. **No shell was available in this session.** The delegation prompt directed `gh issue view 638`.
+   This agent had only `Read`, `Grep`, `Glob`, `Write`, `Edit`, and `WebFetch`; no `Bash` tool was
+   present, so neither `gh` nor `git` could be executed. The issue text used here is the local
+   mirror at `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/issue.md`,
+   which the orchestrator stated carries the same verified trace, cross-checked against the
+   identical text at `docs/features/potential/promoted/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread.md`
+   and `.../spec.md`. Any claim about the *remote* issue body is therefore unverified.
+2. **The artifact timestamp was not read from a system clock.** It is derived from the session date
+   (2026-08-29) and sequenced after the existing `plan.2026-08-29T07-41.md` in the same folder. The
+   format follows `.claude/skills/evidence-and-timestamp-conventions/SKILL.md` (`yyyy-MM-ddTHH-mm`).
+
+## 1. Ground-truth verification of the trace (research question 1)
+
+### 1.1 Confirmed unchanged
+
+| Element | Current location | Issue body claim | Status |
+|---|---|---|---|
+| `AppOlObjects.ArchiveRootPath` property | `TaskMaster/AppGlobals/AppOlObjects.cs:253-267` | `:253-267` | Confirmed |
+| Guard call from the property | `TaskMaster/AppGlobals/AppOlObjects.cs:259-263` | — | Confirmed |
+| Backing field `_archiveRootPath` | `TaskMaster/AppGlobals/AppOlObjects.cs:237` | — | Confirmed |
+| `RequireResolvedArchiveRoot` throw #1 (unresolvable) | `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:44` | `:44` | Confirmed |
+| `RequireResolvedArchiveRoot` throw #2 (cross-store / renamed) | `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:56` | `:56` | Confirmed |
+| Unguarded read in `MoveToFolderAsync(string, …)` | `QuickFiler/Controllers/EfcDataModel.cs:289` | `:289` | Confirmed |
+| Unguarded read in `OpenOlFolderAsync` | `QuickFiler/Controllers/EfcDataModel.cs:310` | `:310` | Confirmed |
+| Unguarded read in `OpenFsFolderAsync` | `QuickFiler/Controllers/EfcDataModel.cs:328` | `:328` | Confirmed |
+| `MoveToFolderAsync(string, …)` body | `QuickFiler/Controllers/EfcDataModel.cs:259-297`, no try/catch | `:259-297` | Confirmed |
+| Early guard 1 (`MailInfo is null`) | `QuickFiler/Controllers/EfcDataModel.cs:267-270` | `:267-270` | Confirmed |
+| Early guard 2 (OneDrive special folder) | `QuickFiler/Controllers/EfcDataModel.cs:277-281` | `:277-281` | Confirmed |
+
+Method signature of the guard: `ArchiveRootPathGuard.RequireResolvedArchiveRoot(string composedArchiveRootPath, string resolvedArchiveFolderPath, Action<string> logDiagnostic)` at
+`TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:32-60`.
+
+Throw condition 1 (`:38-45`) fires when *either* `composedArchiveRootPath` or
+`resolvedArchiveFolderPath` is null, empty, or whitespace. Throw condition 2 (`:47-57`) fires when
+the two are not `OrdinalIgnoreCase`-equal.
+
+**No negative caching — confirmed.** `AppOlObjects.cs:257-264` assigns `_archiveRootPath` only from
+the helper's return value inside `if (_archiveRootPath is null)`. On throw the field stays null, so
+every subsequent read re-enters the helper and throws again.
+
+### 1.2 Line-number drift (issue body is stale)
+
+| Element | Issue body claim | Verified current location | Drift |
+|---|---|---|---|
+| `EfcHomeController.ExecuteMovesAsync` | `EfcHomeController.ExecuteMoves.cs:31-46` | `:32-47` | +1 |
+| `EfcHomeController.ExecuteMovesCoreAsync` | `:64-84` | `:67-87` | +3 |
+| `EfcHomeController.MoveToFolderAsync` | `:86-109` | `:89-112` | +3 |
+| `ButtonOK_Click` | `EfcFormController.cs:429-443` | `:460` (one-line expression body) | +31, shape changed |
+| `Button.Click` wiring for OK | `EfcFormController.cs:389` | `:418` (`_formViewer.Ok.Click += ButtonOK_Click;`) | +29 |
+| "rethrow" | `EfcFormController.cs:441` | **does not exist** | see §1.4 |
+| `EfcSelectionGuard.ResolveArchiveRootOrEmpty` | `EfcFormController.cs:708` | **does not exist** | see §2.3 |
+
+### 1.3 Propagation chain, verified frame by frame
+
+1. `QuickFiler/Controllers/EfcDataModel.cs:289` — throw site (property read). No try/catch in the
+   enclosing method (`:259-297`).
+2. `QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:98` — `_dataModel.MoveToFolderAsync(...)`
+   inside `EfcHomeController.MoveToFolderAsync` (`:89-112`). **No try.**
+3. `QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:78` — the awaited call inside
+   `ExecuteMovesCoreAsync` (`:67-87`). **No try.**
+4. `QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:41` — inside `ExecuteMovesAsync`
+   (`:32-47`), which is `try { … } finally { ResetExecuteMovesState(); }` at `:39-46`. **No catch.**
+   The `finally` releases the `Interlocked` single-move guard (`:62-65`) and the exception continues
+   unchanged. Grep for `catch` across the whole file returns zero matches. This frame is the one most
+   likely to be mistaken for a handler, and the issue body's warning about it is correct.
+5. `QuickFiler/Controllers/EfcFormController.cs:759` — `await _homeController.ExecuteMovesAsync();`
+   inside `ActionOkAsync` (`:738-772`). **No try/catch.**
+6. `QuickFiler/Controllers/EfcFormController.cs:469` — `await ActionOkAsync();` inside
+   `ButtonOkClickAsync` (`:462-475`). **This frame catches.** `catch (System.Exception ex)` at
+   `:471-474` calls `BoundaryErrorSink(ex.Message, ex)` at `:473`.
+
+**Explicit answer to the question asked:** no frame between the throw site at `EfcDataModel.cs:289`
+and `EfcFormController.ButtonOkClickAsync` catches the exception. The first and only handler is
+`EfcFormController.cs:471-474`.
+
+### 1.4 Material correction: the rethrow no longer exists on this branch head
+
+The issue body states that the boundary catch "logs and then **rethrows** at
+`QuickFiler/Controllers/EfcFormController.cs:441`". That is **not true of this branch head.**
+
+- `BoundaryErrorSink` is declared at `EfcFormController.cs:128-129` as
+  `internal System.Action<string, System.Exception> BoundaryErrorSink { get; set; } = (message, exception) => logger.Error(message, exception);`
+  — an injectable seam over the static log4net logger, with no rethrow.
+- A repo-wide grep for `throw` inside `QuickFiler/Controllers/EfcFormController.cs` returns exactly
+  one executable throw: `throw new NotImplementedException();` at `:767`, in the `ActionOkAsync`
+  else-branch for an `_initType` that is neither `Sort` nor `Find`. There is no bare `throw;` and no
+  `throw ex;` anywhere in the file.
+
+Consequence for scoping: **the symptom described in the issue's step 5 ("Observe an unhandled
+`InvalidOperationException` on the UI thread") is not reproducible at this head.** The exception is
+caught and logged. The residual defect is different and is described in §1.5.
+
+### 1.5 The residual defect that *is* present
+
+`ActionOkAsync` (`EfcFormController.cs:738-772`) executes in this order on the Sort path:
+
+- `:756` `_formViewer.Hide();`
+- `:759` `await _homeController.ExecuteMovesAsync();`  ← throws here
+- `:769` `_formViewer.Dispose();`  ← **skipped**
+- `:770` `Cleanup();`  ← **skipped**
+
+So on an unresolvable archive root the user sees the EFC form vanish, the mail is not filed, no
+message box appears, the only record is a log4net `Error` entry, and the viewer is left hidden and
+undisposed with `Cleanup()` never run. The add-in keeps running (satisfying half of the issue's
+Expected Behavior) but produces no user-facing diagnostic (failing the other half) and leaks the
+form/session state.
+
+This is a real, user-visible defect and is a sufficient basis for the fix. The acceptance criteria
+should be restated against this observed behavior rather than against the stale crash symptom.
+
+### 1.6 Other archive-root reads reachable from the EFC surface
+
+Recorded for completeness; none is in the recommended minimal scope.
+
+| Read | Enclosing method | Handler status |
+|---|---|---|
+| `EfcFormController.cs:529` | `ButtonCreateClickAsync` (`:498-555`) | caught at `:551-554` → `BoundaryErrorSink` |
+| `EfcFormController.cs:539` | `ButtonCreateClickAsync` | same |
+| `EfcFormController.cs:836` | `CreateFolderAsync` (`:815-858`) | **no local try/catch**; reached from keyboard `'N'` at `:630` and `:698` via `KbdExecuteAsync` (`:894-898`, no try/catch) → `KeyboardHandler.KeyboardHandler_KeyDownAsync` (`QuickFiler/Controllers/KeyboardHandler.cs:133-148`), whose `catch` at `:141-147` logs only |
+| `EfcFormController.cs:846` | `CreateFolderAsync` | same |
+| `EfcFormController.cs:987` | `BindBreadcrumbRowsAsync` (`:980-997`) | caught at `:993-996`, logs only |
+
+Every EFC entry point therefore terminates in a log-only sink. There is no remaining unhandled
+UI-thread path for this exception on this head.
+
+## 2. Existing degrade-and-report patterns (research question 2)
+
+### 2.1 (a) User-facing diagnostic from a filing operation
+
+Three shapes exist. In descending order of testability:
+
+1. **Injectable action seam — `EfcHomeController.MoveFailureMessageAction`.**
+   `QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:23-24`:
+   `internal Action<string> MoveFailureMessageAction { get; set; } = text => MessageBox.Show(text);`
+   Consumed by `HandleMoveResult` (`:125-145`): `if (!result) { MoveFailureMessageAction($"Cannot move to folderpath {selectedFolder}"); return; }` (`:132-136`).
+   Already unit-tested at `QuickFiler.Test/Controllers/EfcHomeControllerExecuteMovesTests.cs:160-175`
+   (`HandleMoveResult_WhenMoveFails_RoutesMessageThroughInjectedAction`).
+2. **Direct `MessageBox.Show`** — `EfcDataModel.cs:353-356`, in the `MAPIFolder` overload of
+   `MoveToFolderAsync`: `if (!result) { MessageBox.Show($"Cannot move to folderpath {folderpath}"); }`.
+   Not injectable, therefore not assertable without a UI.
+3. **Log plus message box inside a catch** — `UtilitiesCS/EmailIntelligence/EmailParsingSorting/EmailFiler.cs:95-107`
+   (`TryOpenOlFolder`): `catch (System.Exception ex) { logger.Error(ex); MessageBox.Show($"Error opening folder \n{ex.Message}"); }`.
+
+### 2.2 (b) Logging pattern
+
+log4net, obtained per type. The canonical declaration is repeated verbatim across the repo:
+
+- `QuickFiler/Controllers/EfcDataModel.cs:23-25`
+- `QuickFiler/Controllers/EfcFormController.cs:123-125`
+- `UtilitiesCS/EmailIntelligence/EmailParsingSorting/EmailFiler.cs:38-40`
+
+`ArchiveRootPathGuard` deliberately does not take a logger; it takes
+`Action<string> logDiagnostic` (`ArchiveRootPathGuard.cs:35`) and is wired to `logger.Error` at the
+call site (`AppOlObjects.cs:262`). `EfcFormController` layers `BoundaryErrorSink` (`:128-129`) over
+the static logger for the same reason.
+
+There is no ad-hoc `Console.WriteLine` in any of these files.
+
+### 2.3 (c) Degrading on an unresolvable required root
+
+**`EfcSelectionGuard.ResolveArchiveRootOrEmpty` does not exist on this branch head.** A repo-wide
+`Grep` over `*.cs` for `ResolveArchiveRootOrEmpty` returns zero matches. `EfcSelectionGuard`
+(`QuickFiler/Controllers/EfcSelectionGuard.cs`, 79 lines) contains exactly two members:
+`IsValidFilingSelection` (`:41-51`) and `IsValidCreationSelection` (`:66-77`). The issue body's
+statement that "the cycle-2 partial revert removes that call site" is confirmed, and the revert went
+further: the method itself is gone, so there are zero call sites and no dead helper to clean up.
+
+The pattern that *does* exist, and that is the closest possible precedent, is the **adjacent
+OneDrive miss in the same method**:
+
+```
+// QuickFiler/Controllers/EfcDataModel.cs:277-281
+if (!Globals.FS.SpecialFolders.TryGetValue("OneDrive", out var folderRoot))
+{
+    logger.Warn($"Cannot sort without OneDrive location");
+    return false;
+}
+```
+
+and its two siblings in the Open* methods, which degrade silently:
+
+- `EfcDataModel.cs:301-304` — `OpenOlFolderAsync`, bare `return;`, no log.
+- `EfcDataModel.cs:320-323` — `OpenFsFolderAsync`, bare `return;`, no log.
+
+### 2.4 Recommendation for pattern reuse
+
+Reuse §2.3's OneDrive shape for the guarded read, and §2.1 item 1's injectable-action shape for the
+user message on the two `Open*` paths. Do not invent a new abstraction.
+
+Rationale: the OneDrive guard is in the same method, guards the same class of condition (a required
+filing root that could not be resolved), returns the same `false`, and its `false` already reaches
+the user through `HandleMoveResult` → `MoveFailureMessageAction`. Matching it satisfies the
+"match existing style" requirement of the General Code Change Policy §7.1 with the smallest diff.
+
+## 3. Return-contract impact (research question 3)
+
+### 3.1 `EfcDataModel.MoveToFolderAsync(string, bool, bool, bool, bool)` → `Task<bool>` (`:259-297`)
+
+| Caller | Location | What it does with the result |
+|---|---|---|
+| `EfcHomeController.MoveToFolderAsync` | `EfcHomeController.ExecuteMoves.cs:98` | returns the `Task<bool>` unchanged to `:78` |
+| `EfcDataModel.MoveToFolderAsync(MAPIFolder, …)` | `EfcDataModel.cs:346` | `if (!result) MessageBox.Show($"Cannot move to folderpath {folderpath}")` at `:353-356` |
+
+The first path continues: `ExecuteMovesCoreAsync:78` assigns `result`, then `:86` calls
+`HandleMoveResult(result, …)`, which at `:132-136` routes a false result to
+`MoveFailureMessageAction`.
+
+**Assessment:** returning `false` instead of throwing is already fully supported. Both callers
+surface a message to the user. **No caller silently swallows the bool.** Returning `false` is
+strictly better than the current behavior because it additionally allows `ActionOkAsync:769-770`
+(`Dispose()` / `Cleanup()`) to run, which the throw currently skips.
+
+One accuracy caveat: the existing message text, "Cannot move to folderpath {selectedFolder}",
+attributes the failure to the destination folder rather than to the archive root. It is not wrong
+(the move did not happen) but it is not cause-specific. Changing it is optional; see §5.3.
+
+### 3.2 `EfcDataModel.OpenOlFolderAsync(string)` → `Task` (`:299-316`)
+
+| Caller | Location | What it does |
+|---|---|---|
+| `EfcHomeController.OpenOlFolderAsync` | `EfcHomeController.cs:429` (method `:427-430`) | `await`s; returns `Task` |
+| `EfcFormController.ActionOkAsync` | `EfcFormController.cs:763` | `await`s in the `InitTypeEnum.Find` branch; no result to inspect |
+
+### 3.3 `EfcDataModel.OpenFsFolderAsync(string)` → `Task` (`:318-334`)
+
+| Caller | Location | What it does |
+|---|---|---|
+| `EfcHomeController.OpenFsFolderAsync` | `EfcHomeController.cs:434` (method `:432-435`) | `await`s; returns `Task` |
+| `EfcFormController.ButtonCreateClickAsync` | `EfcFormController.cs:513` | `await`s in the `Find` branch |
+| `EfcFormController.CreateFolderAsync` | `EfcFormController.cs:823` | `await`s in the `Find` branch |
+
+Test-only caller of both: `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs:214-215`.
+
+**Assessment:** these two return `Task`, so a failure result is unobservable today. Widening them to
+`Task<bool>` would require changing the two `internal` `EfcHomeController` wrappers and would leave
+**all five** production call sites discarding the value — that is, it would *manufacture* the
+silent-swallow problem the question asks about, in five places at once. Reject the signature change.
+
+Because `Open*` failures cannot be reported through a return value, the diagnostic must be emitted at
+the point of failure. Note that unlike the Sort path, a silent `return` from `Open*` still lets
+`ActionOkAsync:769-770` run, so nothing leaks; the only defect is the absent user feedback.
+
+## 4. Testability seam (research question 4)
+
+### 4.1 `Globals` in `EfcDataModel` is not the static COM accessor
+
+The delegation prompt's premise that "`Globals.Ol` is a static COM-bound accessor" does not hold for
+this class. In `EfcDataModel`, `Globals` resolves to the **instance property** declared at
+`EfcDataModel.cs:148-153`:
+
+```
+private IApplicationGlobals _globals;
+public IApplicationGlobals Globals { get => _globals; protected set => _globals = value; }
+```
+
+It is assigned from the constructor parameter at `:57` (public ctor) and `:85` (private ctor). The
+read chain is therefore `IApplicationGlobals.Ol` → `IOlObjects.ArchiveRootPath`, and
+`IOlObjects.ArchiveRootPath` is an interface member at
+`UtilitiesCS/Interfaces/IGlobals/IOlObjects.cs:15`.
+
+**Conclusion: no new seam is required.** Moq can already make the getter throw:
+`olObjects.SetupGet(x => x.ArchiveRootPath).Throws(new InvalidOperationException(...))`. This is the
+same technique already used to make it *return* in
+`TaskMaster.Test/AppGlobals/AppOlObjectsArchiveRootValidationTests.cs:118-130`.
+
+### 4.2 `EfcDataModel` is already unit-testable today
+
+Verified facts:
+
+- `QuickFiler/Properties/AssemblyInfo.cs:5` — `[assembly: InternalsVisibleTo("QuickFiler.Test")]`,
+  so the `internal` class and its `internal` members are reachable.
+- `QuickFiler.Test/Controllers/EfcDataModelTests.cs:220-228` builds
+  `Mock<IApplicationGlobals>(MockBehavior.Strict)` with `Mock<IOlObjects>(MockBehavior.Strict)`.
+- `EfcDataModelTests.cs:166-171` and `:200-205` construct the real object via the public constructor
+  `new EfcDataModel(globals.Object, mailItem.Object, new CancellationTokenSource(), CancellationToken.None)`
+  and drive it to a loaded `ConversationResolver` with only Moq'd interop objects.
+- `EfcDataModel.cs:233` — `MailInfo => ConversationResolver?.MailHelper`. The public ctor path sets
+  `ConversationResolver` at `:67`, and `QuickFiler/Helper Classes/ConversationResolver.cs:82` assigns
+  `MailHelper = new MailItemHelper(mailItem, _globals)`. So `MailInfo` is non-null after that ctor,
+  which is what the `:267-270` guard requires in order to reach the archive-root read.
+- `IFileSystemFolderPaths.SpecialFolders` is a concrete `ConcurrentDictionary<string, string>`
+  (`UtilitiesCS/Interfaces/IGlobals/IFileSystemFolderPaths.cs:7`), so seeding `"OneDrive"` to let the
+  `:277-281` guard pass is trivial.
+- With `moveConversation: false`, `:273-275` takes the `new List<MailItemHelper> { MailInfo }` branch
+  and never touches `ConversationResolver.ConversationInfo`.
+
+The RED test therefore reaches `:289` and observes the throw, without a live Outlook process and
+without constructing `EmailFiler` (`:293`), which is only reached after the guarded read.
+
+### 4.3 Comparable harness already in the repo
+
+`QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs` contains a purpose-built probe worth
+copying rather than reinventing:
+
+- `LifecycleProbe` (`:220-372`)
+- `FakeApplicationGlobals` (`:374-403`) — hand-written `IApplicationGlobals` stub
+- `FakeFileSystemFolderPaths` (`:405-433`) — counts `SpecialFolders` reads
+- `LifecycleProbe.CreateDataModelWithGlobals` (`:350-358`) — real `EfcDataModel` over fake globals
+- `CreateUninitialized<T>` (`:367-371`) — `FormatterServices.GetUninitializedObject`, the repo's
+  established ctor-free construction technique
+- `OpenFolderMethods_DelegateToDataModelWithoutExternalServices` (`:207-218`) — already exercises
+  `OpenOlFolderAsync` and `OpenFsFolderAsync` end-to-end with no external services
+
+Caveat: `FakeApplicationGlobals.Ol` returns `null` (`:388`). To use this probe for the archive-root
+tests it must either gain a fake `IOlObjects` or be replaced by the Moq-based globals from
+`EfcDataModelTests.CreateGlobals` (`:220-228`). Prefer the Moq route for the new tests, because
+`SetupGet(...).Throws(...)` expresses the failure directly and `Times`-verification is available.
+
+### 4.4 Test project and directory
+
+**Recommended location:** `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`
+
+Verified basis:
+- `EfcDataModel` tests already live at `QuickFiler.Test/Controllers/EfcDataModelTests.cs` and
+  `QuickFiler.Test/Controllers/EfcDataModelIssue614Tests.cs`.
+- Both are registered explicitly in `QuickFiler.Test/QuickFiler.Test.csproj` at lines 114 and 115.
+- `QuickFiler.csproj:2` shows the legacy non-SDK project format
+  (`ToolsVersion="15.0"`, `Microsoft.Common.props` import, `TargetFrameworkVersion v4.8.1`); the test
+  project enumerates every `.cs` the same way. **A new test file will not compile until an explicit
+  `<Compile Include="Controllers\EfcDataModelArchiveRootTests.cs" />` is added to
+  `QuickFiler.Test.csproj`.** This is a frequent omission and should be an explicit plan task.
+- Namespace precedent is inconsistent between the two existing files
+  (`QuickFiler.Controllers.Tests` in `EfcDataModelTests.cs:13`, `QuickFiler.Test.Controllers` in
+  `EfcDataModelIssue614Tests.cs:8`). Prefer `QuickFiler.Test.Controllers`, matching the newer file.
+
+**Policy conflict that must be surfaced, not silently resolved.**
+`.claude/rules/general-unit-test.md` § "Test File Location" states that test files must live in a
+`tests/` tree mirroring production source and that colocation is "not permitted". Verified against
+the tree: `tests/` contains only five PowerShell Pester files under `tests/scripts/vscode/`. Every
+C# test in this repository lives in a sibling `<Project>.Test/` project
+(`QuickFiler.Test`, `TaskMaster.Test`, `UtilitiesCS.Test`, `SVGControl.Test`). The C# Unit Test
+Policy embedded in `CLAUDE.md` — which the "Policy Compliance Order" section ranks above the rules
+files — imposes no `tests/` layout requirement.
+
+Recommendation: follow the repository's actual C# convention (`QuickFiler.Test/Controllers/`), and
+record the deviation from `.claude/rules/general-unit-test.md` explicitly in the plan and PR. Per
+`CLAUDE.md` ("If you encounter **any** conflicting instructions, halt and notify the user"), the
+orchestrator should surface this conflict rather than have an executor decide it silently.
+
+## 5. Recommended approach
+
+### 5.1 Design
+
+Add one private helper to `EfcDataModel` and route the three reads through it.
+
+```
+private bool TryGetArchiveRoot(out string archiveRoot)
+{
+    try
+    {
+        archiveRoot = Globals.Ol.ArchiveRootPath;
+        return true;
+    }
+    catch (InvalidOperationException ex)
+    {
+        archiveRoot = null;
+        logger.Warn("Cannot file without a resolvable Outlook archive root.", ex);
+        return false;
+    }
+}
+```
+
+Call-site changes:
+
+- `EfcDataModel.cs:289` — hoist to a guard beside the OneDrive guard:
+  `if (!TryGetArchiveRoot(out var olAncestor)) { return false; }`, then `OlAncestor = olAncestor`.
+- `EfcDataModel.cs:310` — `if (!TryGetArchiveRoot(out var olAncestor)) { UserDiagnosticAction(...); return; }`
+- `EfcDataModel.cs:328` — same shape.
+
+Plus one injectable report seam, mirroring `EfcHomeController.MoveFailureMessageAction`
+(`EfcHomeController.ExecuteMoves.cs:23-24`) exactly:
+
+```
+internal System.Action<string> UserDiagnosticAction { get; set; } = text => MessageBox.Show(text);
+```
+
+`System.Windows.Forms` is already imported at `EfcDataModel.cs:10` and `MessageBox.Show` is already
+used at `:355`, so this adds no new dependency.
+
+### 5.2 Ordering constraint (verified, load-bearing)
+
+The archive-root guard must be placed **after** the existing OneDrive guard in all three methods, not
+before it. `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs:217` asserts
+`probe.FileSystem.SpecialFoldersAccessCount.Should().Be(2)` after calling `OpenOlFolderAsync` and
+`OpenFsFolderAsync` once each. Inserting an earlier-returning guard ahead of the `SpecialFolders`
+read would drop that count and break an existing test that is part of the spec.
+
+### 5.3 Exception breadth
+
+Catch `InvalidOperationException` only. That is precisely the documented contract of the property
+(`AppOlObjects.cs:250-252`) and of the guard (`ArchiveRootPathGuard.cs:30-31`), and it keeps the
+change minimal per the Bugfix Workflow.
+
+Recorded residual, **not** in scope: the getter also evaluates `Root.FolderPath` (`AppOlObjects.cs:260`)
+and `ArchiveRoot?.FolderPath` (`:261`), where `ArchiveRoot` (`:270`) lazily runs `LoadArchiveRoot`
+(`:272-276`) → `FolderPredictor.GetFolder`. Those are live COM calls and can raise
+`System.Runtime.InteropServices.COMException`, which the narrow catch will not absorb. Recommend
+promoting this to a separate issue rather than widening the catch here.
+
+### 5.4 Message text
+
+Leave `HandleMoveResult`'s existing "Cannot move to folderpath {selectedFolder}" unchanged for the
+Sort path (it already fires and requires no edit), and let `UserDiagnosticAction` carry a
+cause-specific, non-identifying message on the two `Open*` paths. Any user-visible message must reuse
+the redaction discipline already established for this failure class: `ArchiveRootPathGuard`'s two
+constants (`ArchiveRootPathGuard.cs:13-17`) deliberately name the rule and withhold the path because
+it carries a mailbox address (#602). Do not interpolate the archive root or the folder path into a
+new message.
+
+### 5.5 File-size headroom
+
+`QuickFiler/Controllers/EfcDataModel.cs` is currently 423 lines. The General Code Change Policy caps
+any file at 500 lines. The proposed change adds roughly 30-45 lines, landing near 455-470. It fits,
+but with limited headroom; any further growth of this file should trigger a split.
+
+### 5.6 Rejected alternatives (brief)
+
+- **Make `AppOlObjects.ArchiveRootPath` return empty instead of throwing.** Rejected: it reverses the
+  deliberate #614 D6 decision, changes the contract for every consumer of `IOlObjects.ArchiveRootPath`
+  (production reads exist in `ToDoModel/Email Utilities/SortItemsToExistingFolder.cs:67,95,107,109,228`,
+  `UtilitiesCS/OutlookObjects/Folder/FolderPredictor.cs:304,375,686,748,852,910`,
+  `FolderConverter.cs:334,339`, `FolderNavigator.cs:48`, `MailItemHelper.Loading.cs:124`,
+  `MeetingItemHelper.cs:262`, `SortEmail.cs:1337`), reintroduces the unverified-root bug class, and is
+  pinned by `TaskMaster.Test/AppGlobals/AppOlObjectsArchiveRootValidationTests.cs:64-111`.
+- **Reinstate an `EfcSelectionGuard.ResolveArchiveRootOrEmpty`-style empty-root degrade.** Rejected: an
+  empty `OlAncestor` flows into `EmailFilerConfig` (`EfcDataModel.cs:282-291`) and downstream stem
+  composition, which is the #614 store-root-leak failure mode. Cycle-2 already deleted this helper.
+- **Catch at `EfcFormController.ActionOkAsync`.** Rejected: the form is already hidden at `:756`
+  before the failure, so the catch cannot restore a clean state without extra work; and it covers
+  neither the `Find` path nor the two `Open*` reads.
+- **Widen `OpenOlFolderAsync` / `OpenFsFolderAsync` to `Task<bool>`.** Rejected: see §3.2 — all five
+  production call sites discard, so the change creates silent swallow rather than removing it.
+
+## 6. `async void` rethrow scope decision (research question 5)
+
+### 6.1 Complete inventory in `EfcFormController.cs`
+
+| `async void` handler | Line | Delegates to | `catch` | Sink call | Rethrow? |
+|---|---|---|---|---|---|
+| `ButtonCancel_Click` | `:442-443` | `ButtonCancelClickAsync` `:445-458` | `:454-457` | `:456` | No |
+| `ButtonOK_Click` | `:460` | `ButtonOkClickAsync` `:462-475` | `:471-474` | `:473` | No |
+| `ButtonRefresh_Click` | `:477-478` | `ButtonRefreshClickAsync` `:480-493` | `:489-492` | `:491` | No |
+| `ButtonCreate_Click` | `:495-496` | `ButtonCreateClickAsync` `:498-555` | `:551-554` | `:553` | No |
+| `ButtonDelete_Click` | `:557-558` | `ButtonDeleteClickAsync` `:560-570` | `:566-569` | `:568` | No |
+
+Related non-`async void` boundaries in the same file, for completeness:
+`PopulateFolderCombobox` `:1119-1140` (catch `:1136-1139`, sink `:1138`) and
+`BindBreadcrumbRowsAsync` `:980-997` (catches `:989-992` and `:993-996`, `logger` directly).
+
+### 6.2 Decision
+
+**No work item. The requested change is already present on this branch head.** Every one of the five
+`async void` boundaries logs through `BoundaryErrorSink` and returns; none rethrows. The issue's
+suggestion to reconsider the rethrow at `EfcFormController.cs:441` refers to code that does not
+exist here. Neither an in-scope change nor a separate issue for "remove the rethrow" is warranted.
+
+Record the correction in the issue rather than acting on it.
+
+### 6.3 Blast radius, had a change been needed
+
+For completeness: `BoundaryErrorSink` is `internal` with a settable default, and it is already
+asserted in three tests (`QuickFiler.Test/Controllers/EfcFormControllerTests.cs:261`, `:283-290`,
+`:310`). Any change to the five catch bodies would be confined to `EfcFormController.cs` plus those
+three assertions. The wider `async void` surface in the QuickFiler assembly (13 further sites, listed
+by grep in `QfcFormController.EventHandlers.cs`, `QfcItemController.EventHandlers.cs`,
+`QfcItemController.EventWiring.cs`, `QfcDatamodel.cs:173`, `KeyboardHandler.cs:133/238/266`,
+`BreadcrumbBridgeRouter.cs:291`, `ConversationResolver.Loading.cs:304`) is not reached by this issue
+and must not be swept in.
+
+**Separately promotable observation (report only, do not fix here).** All five EFC boundary sinks are
+log-only, so *any* unexpected exception on the OK path now produces a silently vanished form with no
+user feedback and with `Dispose()`/`Cleanup()` skipped. That is a generic boundary-behavior gap
+distinct from #638's archive-root cause and should be promoted to its own issue.
+
+## 7. Coverage and toolchain (research question 6)
+
+### 7.1 Projects touched
+
+| Project | File | Role |
+|---|---|---|
+| `QuickFiler` | `QuickFiler/Controllers/EfcDataModel.cs` | production change |
+| `QuickFiler.Test` | `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` (new) + `QuickFiler.Test.csproj` | tests |
+
+`TaskMaster` (`AppOlObjects.cs`, `ArchiveRootPathGuard.cs`) and `UtilitiesCS` are **not** modified by
+the recommended approach.
+
+### 7.2 Tier classification
+
+`quality-tiers.yml` **does not exist** anywhere in this repository. A `Glob` for `quality-tiers.yml`
+across the whole tree returns zero matches, and a `Grep` for `tier-classification` / `quality-tiers`
+under `.github/` returns zero matches, so the CI stage that `.claude/rules/quality-tiers.md`
+describes is not present either. The T1–T4 tier system therefore has no source of truth in this repo
+and no tier can be cited for `QuickFiler`. Record this as an unmet documented precondition; it is not
+a blocker for this change, and this agent recommends **not** creating the file as part of #638.
+
+### 7.3 Coverage exemption interaction
+
+- `coverage.config` (repo root) excludes only third-party modules: `Deedle`, `FSharp`, `Castle.Core`,
+  `FluentAssertions`, `Moq`, `Microsoft.Testing`, `MSTest` (`coverage.config:12-22`). No first-party
+  assembly is excluded, and `QuickFiler` is not excluded.
+- `QuickFiler/Controllers/EfcDataModel.cs` carries **no** `[ExcludeFromCodeCoverage]` attribute; the
+  file was read end to end.
+- The COM/VSTO/WinForms exemption in `CLAUDE.md` § UT2 does not apply: `EfcDataModel` is not
+  form-derived, is not Designer-generated, is not a VSTO lifecycle class, and takes its Outlook
+  dependency through the injectable `IApplicationGlobals` seam — which `CLAUDE.md` explicitly names
+  as the disqualifier ("without an injectable seam").
+
+Consequence: the changed lines are in the measured denominator and must be covered. All of them are
+coverable by the tests in §8.
+
+Note on evidence interpretation, from prior work in this repo: an exempt member emits no `<method>`
+element in the Cobertura output at all, so absence is the exemption signal, not a zero rate.
+
+### 7.4 Toolchain commands (verbatim from `CLAUDE.md` § "C# Toolchain (run in this exact order)")
+
+1. `dotnet tool run csharpier format .` (verify with `dotnet tool run csharpier check .`)
+2. `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
+3. `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:TreatWarningsAsErrors=true`
+4. `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage`
+
+Run `dotnet tool restore` once per worktree before the first csharpier invocation. Do not add
+`/p:Nullable=enable` to step 3 and do not substitute `/t:Build` for `/t:Rebuild`; `CLAUDE.md`
+documents both as load-bearing.
+
+CI parity notes verified in this tree:
+- `.github/workflows/_format-check.yml:41` runs `dotnet csharpier check .`
+- `.github/workflows/_build-nullable.yml:54-59` runs the `TreatWarningsAsErrors` rebuild
+- `.github/workflows/_mstest-coverage.yml:70-83` discovers `*.Test.dll` recursively and runs
+  `vstest.console.exe $testAssemblies /EnableCodeCoverage /InIsolation /Logger:trx /TestCaseFilter:"TestCategory!=LiveOutlook"`
+
+Two consequences of that last line: (a) local runs should add `/InIsolation` and exclude
+`.claude/worktrees` assemblies to match CI, and (b) **CI already excludes any test marked
+`[TestCategory("LiveOutlook")]`**, which is directly relevant to §9.
+
+## 8. Testing implications (no test code written)
+
+All proposed tests are MSTest + Moq + FluentAssertions, deterministic, no filesystem, no temp files,
+no live Outlook.
+
+Regression (RED before the fix, GREEN after) — `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`:
+
+1. `MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing`
+   Arrange a `Mock<IOlObjects>` whose `ArchiveRootPath` getter throws `InvalidOperationException`, a
+   `SpecialFolders` dictionary containing `"OneDrive"`, and a constructed `EfcDataModel` with a
+   non-null `MailInfo`. Act: `await MoveToFolderAsync(stem, …, moveConversation: false)`.
+   Assert: returns `false`; does not throw. Fails today with `InvalidOperationException`.
+2. `OpenOlFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns`
+   Assert: does not throw, and the injected `UserDiagnosticAction` received exactly one message that
+   does not contain the mailbox address or archive path.
+3. `OpenFsFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns` — same shape.
+
+Boundary and edge coverage:
+
+4. `MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce` — `VerifyGet(..., Times.Once)`,
+   pinning that the fix does not double-read the (COM-backed) property.
+5. `MoveToFolderAsync_WhenMailInfoIsNull_ReturnsFalseWithoutReadingArchiveRoot` — `Times.Never`,
+   pinning guard order at `:267-270`.
+6. `MoveToFolderAsync_WhenOneDriveIsMissing_ReturnsFalseWithoutReadingArchiveRoot` — `Times.Never`,
+   pinning the §5.2 ordering constraint from the production side as well as the test side.
+7. `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress` — redaction, matching
+   the discipline already tested at
+   `QuickFiler.Test/Controllers/EfcDataModelIssue614Tests.cs:48-59`.
+
+Existing tests that must keep passing without modification (treat as spec):
+- `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs:207-218` (the
+  `SpecialFoldersAccessCount == 2` assertion — see §5.2)
+- `QuickFiler.Test/Controllers/EfcHomeControllerExecuteMovesTests.cs:160-175`
+- `QuickFiler.Test/Controllers/EfcDataModelTests.cs` (all)
+- `QuickFiler.Test/Controllers/EfcDataModelIssue614Tests.cs` (all)
+- `TaskMaster.Test/AppGlobals/AppOlObjectsArchiveRootValidationTests.cs` (all — the throw contract
+  must remain intact)
+
+Fail-before evidence: test 1 is a genuine failing-run artifact, so no fail-before exception dossier
+is required for this issue.
+
+## 9. Automation Feasibility
+
+**Verdict: fully automatable. No human interaction with a third-party UI is required for the fix, its
+verification, or its regression tests.**
+
+### 9.1 Requirement-by-requirement assessment
+
+| Requirement | Needs a live third-party UI? | Resolution |
+|---|---|---|
+| Reading and verifying the trace | No | Done in this session with file reads only |
+| Implementing the guard in `EfcDataModel.cs` | No | Pure source edit |
+| Regression tests 1-7 (§8) | No | `IOlObjects.ArchiveRootPath` is an interface member (`IOlObjects.cs:15`); Moq raises the exact `InvalidOperationException` the guard produces. Verified: existing tests already construct `EfcDataModel` against `Mock<IApplicationGlobals>` with no Outlook process (`EfcDataModelTests.cs:166-171`, `:200-205`) |
+| Toolchain steps 1-4 (§7.4) | No | Command-line only |
+| Coverage evidence | No | `vstest.console.exe … /EnableCodeCoverage` |
+| The issue's literal repro steps 1-5 | **Yes** | See §9.2 |
+
+### 9.2 The one unautomatable item, and how it is removed by scope change
+
+The issue's "Steps to Reproduce" require an Outlook profile whose archive folder does not resolve to
+the default store's `Archive` folder (no `Archive` folder, an archive in a second store, or a renamed
+archive), then opening the EFC form with `InitTypeEnum.Sort` and pressing OK. That requires Outlook
+desktop plus a specially constructed mail profile. It cannot be automated in CI, and CI already
+declines to try: `.github/workflows/_mstest-coverage.yml:83` filters with
+`/TestCaseFilter:"TestCategory!=LiveOutlook"`.
+
+**This requirement is removed by scope change, not by exception.** The defect is provable at the unit
+level because the failure is injected at an interface boundary, not at a COM boundary:
+
+- The profile condition's *only* effect on the code under test is that
+  `IOlObjects.ArchiveRootPath` throws `InvalidOperationException` with one of two fixed messages
+  (`ArchiveRootPathGuard.cs:13-17`, thrown at `:44` and `:56`).
+- Both throw conditions are already unit-tested in isolation, without Outlook, at
+  `TaskMaster.Test/AppGlobals/AppOlObjectsArchiveRootValidationTests.cs:64-111`. The pure decision
+  helper was extracted for exactly this reason (`ArchiveRootPathGuard.cs:5-10`).
+- `EfcDataModel` consumes that property only through `IApplicationGlobals` / `IOlObjects` (§4.1), so
+  a Moq `SetupGet(...).Throws(...)` is behaviorally indistinguishable from the live profile at the
+  seam under test.
+
+Therefore the regression test proves the defect and the fix through the seam, and the live-profile
+repro is downgraded from a required verification step to an optional manual confirmation.
+
+### 9.3 Recommended handling of the manual step
+
+Record the live-profile walkthrough as an **optional post-merge manual confirmation**, owned by the
+maintainer, and do not make any acceptance criterion depend on it. Do not add a
+`[TestCategory("LiveOutlook")]` test for this issue: it would not run in CI, and the unit-level proof
+is strictly stronger because it is deterministic and covers both throw conditions.
+
+### 9.4 Blockers
+
+- **Automation blockers: none.**
+- **Exceptions required: none.**
+- **Halt conditions: none.**
+
+Two non-blocking items require an orchestrator decision before implementation:
+1. The `tests/` versus `<Project>.Test/` policy conflict in §4.4 (`CLAUDE.md` directs a halt-and-notify
+   on conflicting instructions).
+2. The acceptance criteria must be restated against the observed behavior in §1.5 (silent swallow,
+   hidden and undisposed form) rather than the stale "unhandled UI-thread exception" symptom, or the
+   AC will be unsatisfiable by any change.
+
+## 10. Items recommended for promotion to separate issues
+
+1. **COMException from the archive-root getter's COM calls** is not absorbed by the recommended
+   narrow catch (§5.3). `AppOlObjects.cs:260-261` dereferences `Root.FolderPath` and lazily loads
+   `ArchiveRoot` via `FolderPredictor.GetFolder` (`:272-276`).
+2. **EFC boundary sinks are log-only** (§6.2), so any unexpected exception on the OK path leaves a
+   hidden, undisposed form with no user feedback and `Cleanup()` never run.
+3. **`quality-tiers.yml` is absent** (§7.2) while `.claude/rules/quality-tiers.md` and
+   `.claude/rules/general-unit-test.md` both treat it as the source of truth for a CI gate that does
+   not exist in `.github/workflows/`.
+4. **`.claude/rules/general-unit-test.md` "Test File Location" contradicts the repository's actual
+   C# test layout** (§4.4). Note that `.claude/**` in this repository is push-down-owned from an
+   upstream repo, so the correction belongs upstream rather than here.
+
+## 11. Summary of corrections to the issue body
+
+| Issue body claim | Verified status |
+|---|---|
+| Throw site, guard conditions, three unguarded reads, both early guards | Accurate, line numbers unchanged |
+| No negative caching | Accurate |
+| `ExecuteMoves*` chain has no catch | Accurate; line numbers drifted by +1 to +3 |
+| `EfcFormController.ActionOkAsync` has no try/catch | Accurate (`:738-772`) |
+| Catch "logs and then **rethrows** at `EfcFormController.cs:441`" | **False at this head.** No rethrow exists anywhere in the file; the catch at `:471-474` calls `BoundaryErrorSink` and returns |
+| "unhandled `InvalidOperationException` on the UI thread" | **Not reproducible at this head.** The residual is a silent swallow with a hidden, undisposed form |
+| `EfcSelectionGuard.ResolveArchiveRootOrEmpty` at `EfcFormController.cs:708` | **Removed entirely.** Zero occurrences repo-wide; `EfcSelectionGuard` has only two predicates |
+| `ButtonOK_Click` at `:429-443`, wired at `:389` | Drifted to `:460`, wired at `:418` |

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md
@@ -1,0 +1,874 @@
+# 2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread (Spec)
+
+- **Issue:** #638
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-08-29T08-40
+- **Status:** Ready for Planning
+- **Version:** 1.0
+
+> Work Mode for issue #638 is `full-bug`. Per `.claude/skills/acceptance-criteria-tracking/SKILL.md`,
+> this file is the **sole** authoritative acceptance-criteria source for this issue. No
+> `user-story.md` exists or should be created for #638.
+
+## Context
+
+`QuickFiler/Controllers/EfcDataModel.cs` reads `Globals.Ol.ArchiveRootPath` at three call sites with
+no guard. When the Outlook archive root cannot be resolved, that read throws
+`InvalidOperationException`, which unwinds out of the filing operation and is absorbed by a log-only
+fault-boundary sink several frames later. The user is left with a hidden, undisposed form, no
+message, and no filed mail.
+
+All line and shape citations in this section were re-derived during spec authoring from the working
+tree of a dedicated agent worktree checked out on branch
+`bug/efc-unguarded-archive-root-read-crashes-ui-thread-638`, branched from `origin/main` at
+`ecdb1c84ba8541ab67042985919cfed4df768c01`. The branch name and that merge-base SHA are the two facts
+required to reproduce the citations; the worktree's filesystem location is not recorded here.
+
+**Throw site.** `TaskMaster/AppGlobals/AppOlObjects.cs:253-267` declares the `ArchiveRootPath`
+getter. It delegates to `ArchiveRootPathGuard.RequireResolvedArchiveRoot` at
+`TaskMaster/AppGlobals/AppOlObjects.cs:259-263`. That helper
+(`TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:32-60`) throws `InvalidOperationException`
+unconditionally on either of two conditions: `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:44` when
+either the composed or the resolved path is null, empty, or whitespace (no `Archive` folder resolves
+in the default store), and `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:56` when the two are not
+`OrdinalIgnoreCase`-equal (archive in a second store, renamed, or a delegate mailbox). Both messages
+are the redacted constants at `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:13-17`, which name the
+rule and withhold the path because it can carry a mailbox address (#602).
+
+**No negative caching.** The backing field `_archiveRootPath` at
+`TaskMaster/AppGlobals/AppOlObjects.cs:237` is assigned only from the helper's return value, inside
+`if (_archiveRootPath is null)` at `TaskMaster/AppGlobals/AppOlObjects.cs:257-264`. On throw the field
+stays null, so every subsequent read re-enters the helper and throws again. For an affected profile
+the failure is permanent and reproduces on every attempt.
+
+**Unguarded reads.** All three are `OlAncestor = Globals.Ol.ArchiveRootPath` inside an
+`EmailFilerConfig` initializer:
+
+- `QuickFiler/Controllers/EfcDataModel.cs:289` in `MoveToFolderAsync(string, bool, bool, bool, bool)`
+  (`QuickFiler/Controllers/EfcDataModel.cs:259-297`).
+- `QuickFiler/Controllers/EfcDataModel.cs:310` in `OpenOlFolderAsync(string)`
+  (`QuickFiler/Controllers/EfcDataModel.cs:299-316`).
+- `QuickFiler/Controllers/EfcDataModel.cs:328` in `OpenFsFolderAsync(string)`
+  (`QuickFiler/Controllers/EfcDataModel.cs:318-334`).
+
+`QuickFiler/Controllers/EfcDataModel.cs` contains exactly one `catch` in the whole file, at
+`QuickFiler/Controllers/EfcDataModel.cs:249`, inside `TryGetFirstInSelection`. None of the three
+reads is inside a `try`. In `MoveToFolderAsync` the read is reached unconditionally once the
+`MailInfo is null` guard at `QuickFiler/Controllers/EfcDataModel.cs:267-270` and the OneDrive
+`SpecialFolders` guard at `QuickFiler/Controllers/EfcDataModel.cs:277-281` both pass. In the two
+`Open*` methods the read is reached once the OneDrive guards at
+`QuickFiler/Controllers/EfcDataModel.cs:301-304` and
+`QuickFiler/Controllers/EfcDataModel.cs:320-323` pass; both of those degrade with a bare `return;`
+and no log.
+
+**Propagation chain, no handler until the boundary.**
+
+1. `QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:98` calls
+   `_dataModel.MoveToFolderAsync(...)` inside `EfcHomeController.MoveToFolderAsync`
+   (`QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:89-112`). No `try`.
+2. `QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:78` awaits it inside
+   `ExecuteMovesCoreAsync` (`QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:67-87`).
+   No `try`.
+3. `QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:41` awaits that inside
+   `ExecuteMovesAsync` (`QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:32-47`), which is
+   `try { ... } finally { ResetExecuteMovesState(); }` at
+   `QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:39-46` with **no catch**. The `finally`
+   releases the `Interlocked` single-move guard
+   (`QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:62-65`) and the exception continues
+   unchanged. This frame is the one most likely to be mistaken for a handler; it is not one.
+4. `QuickFiler/Controllers/EfcFormController.cs:759` awaits `ExecuteMovesAsync()` inside
+   `ActionOkAsync` (`QuickFiler/Controllers/EfcFormController.cs:738-772`). No `try`.
+5. `QuickFiler/Controllers/EfcFormController.cs:469` awaits `ActionOkAsync()` inside
+   `ButtonOkClickAsync` (`QuickFiler/Controllers/EfcFormController.cs:462-475`). **This frame
+   catches**, at `QuickFiler/Controllers/EfcFormController.cs:471-474`, and calls
+   `BoundaryErrorSink(ex.Message, ex)` at `QuickFiler/Controllers/EfcFormController.cs:473`.
+
+**Two claims in the issue body are false on this branch head; both were re-verified during spec
+authoring and are settled.**
+
+1. **There is no rethrow.** `BoundaryErrorSink` is declared at
+   `QuickFiler/Controllers/EfcFormController.cs:128-129` as
+   `internal System.Action<string, System.Exception> BoundaryErrorSink { get; set; } = (message, exception) => logger.Error(message, exception);`
+   — an injectable seam over the static log4net logger, with no rethrow. A grep for `throw` across
+   `QuickFiler/Controllers/EfcFormController.cs` returns exactly one executable throw,
+   `throw new NotImplementedException();` at `QuickFiler/Controllers/EfcFormController.cs:767`, in the
+   `ActionOkAsync` else-branch for an `_initType` that is neither `Sort` nor `Find`. There is no bare
+   `throw;` and no `throw ex;` anywhere in the file. The issue body's citation of a rethrow at
+   `:441` refers to code that does not exist here. Consequently the issue's repro step 5 ("Observe an
+   unhandled `InvalidOperationException` on the UI thread") is **not reproducible** at this head, and
+   any acceptance criterion asserting it would be unsatisfiable.
+2. **`EfcSelectionGuard.ResolveArchiveRootOrEmpty` no longer exists.** A repository-wide grep returns
+   zero occurrences in any `.cs` file; the only hits are prose in issue and feature documents.
+   `QuickFiler/Controllers/EfcSelectionGuard.cs` contains exactly two members,
+   `IsValidFilingSelection` and `IsValidCreationSelection`. The cycle-2 revert removed the method
+   itself, not merely its call site, so there is no dead helper to clean up.
+
+**The residual defect that is present.** `ActionOkAsync`
+(`QuickFiler/Controllers/EfcFormController.cs:738-772`) executes in this order on the `Sort` path:
+`_formViewer.Hide();` at `QuickFiler/Controllers/EfcFormController.cs:756`, then
+`await _homeController.ExecuteMovesAsync();` at `QuickFiler/Controllers/EfcFormController.cs:759`
+(where the exception originates), then `_formViewer.Dispose();` at
+`QuickFiler/Controllers/EfcFormController.cs:769` and `Cleanup();` at
+`QuickFiler/Controllers/EfcFormController.cs:770`. The throw skips the last two. The observable
+outcome is therefore a **silent swallow**: the form has already been hidden, the mail is not filed,
+no message box appears, the only record is a log4net `Error` entry, and the viewer is left hidden and
+undisposed with `Cleanup()` never run. The add-in keeps running, which satisfies half of the issue's
+Expected Behavior, but it produces no user-facing diagnostic and leaks form and session state.
+
+**Relationship to other issues.** This is distinct from issue #637, which covers producer-side
+normalization of rooted paths at `BreadcrumbBridgeRouter.SelectRow`. This defect is an archive-root
+*resolution failure*, not a path-rootedness problem, and it fires even for a well-formed
+archive-relative stem. It is pre-existing rather than introduced by issue #614.
+
+Environment:
+- OS/version: Windows 11 Pro 10.0.26200; .NET Framework 4.8.1 VSTO add-in (legacy non-SDK projects).
+- Command/flags used: static reachability tracing plus file reads against the worktree named above;
+  no production source file was modified during analysis.
+- Data source or fixture: repository source at
+  `ecdb1c84ba8541ab67042985919cfed4df768c01`, plus the research artifact
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/research/2026-08-29T08-05-archive-root-guard-research.md`.
+
+## Repro & Evidence
+
+The steps below describe behavior that is actually reachable on this branch head. The profile
+precondition is retained from the issue body; the observable outcome is restated as the verified
+silent swallow. Step 5 of the issue body ("unhandled `InvalidOperationException` on the UI thread")
+is superseded — see the Context section.
+
+Steps to Reproduce (manual, optional confirmation only — not a required verification step):
+1. Use an Outlook profile whose archive folder does not resolve to the default store's `Archive`
+   folder. Any of three shapes reproduces it: no `Archive` folder in the default store (throw
+   condition at `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:44`); an archive that lives in a
+   second store, for example a delegate mailbox (throw condition at
+   `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:56`); or a renamed archive folder (same condition).
+2. Open the QuickFiler email-filer form with `InitTypeEnum.Sort`.
+3. Select a valid archive-relative destination stem such as `Clients\North` — a non-rooted value that
+   `EfcSelectionGuard.IsValidFilingSelection`
+   (`QuickFiler/Controllers/EfcSelectionGuard.cs:41-51`) accepts.
+4. Press OK.
+5. Observe that the form disappears immediately and nothing further happens: no message box, no
+   filed mail, no error dialog. The window vanishes because
+   `QuickFiler/Controllers/EfcFormController.cs:756` hides it before the failure.
+6. Inspect the log4net output. It contains one `Error` entry carrying the redacted rule text from
+   `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:13-17`, written through `BoundaryErrorSink`.
+7. Repeat steps 2-5. The failure recurs on every attempt, because the null backing field at
+   `TaskMaster/AppGlobals/AppOlObjects.cs:237` is never assigned and there is no negative caching.
+
+Expected:
+An unresolvable archive root produces a clear, user-facing diagnostic, the filing operation returns a
+failure result rather than throwing, and the form is disposed and cleaned up normally. The redacted
+message text is preserved: no archive root path and no mailbox address appears in any user-visible
+string.
+
+Actual:
+`Globals.Ol.ArchiveRootPath` throws `InvalidOperationException` at
+`QuickFiler/Controllers/EfcDataModel.cs:289`. The exception unwinds through four frames that do not
+catch it and is absorbed at `QuickFiler/Controllers/EfcFormController.cs:471-474`, which logs and
+returns. The user sees the form vanish with no diagnostic;
+`QuickFiler/Controllers/EfcFormController.cs:769-770` (`Dispose()` and `Cleanup()`) never run, so the
+viewer is left hidden and undisposed and the session state is not released. The `Find` path
+(`QuickFiler/Controllers/EfcFormController.cs:763` → `OpenOlFolderAsync`) fails the same way at
+`QuickFiler/Controllers/EfcDataModel.cs:310`, as does the file-system open path at
+`QuickFiler/Controllers/EfcDataModel.cs:328`.
+
+Evidence to be captured during implementation (canonical locations per
+`.claude/skills/evidence-and-timestamp-conventions/SKILL.md`):
+- Fail-before run of the new regression tests →
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/`
+- Post-change toolchain logs →
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/`
+- Coverage baseline →
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/`
+- Coverage post-change comparison →
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/`
+
+No evidence artifact exists in this feature folder yet; the `evidence` directory has not been
+created.
+
+## Scope & Non-Goals
+
+- In scope:
+  - Guarding the three archive-root reads at `QuickFiler/Controllers/EfcDataModel.cs:289`,
+    `QuickFiler/Controllers/EfcDataModel.cs:310` and `QuickFiler/Controllers/EfcDataModel.cs:328`
+    against `InvalidOperationException`, so that `MoveToFolderAsync` returns `false` and the two
+    `Open*` methods return after reporting, instead of propagating.
+  - Adding an injectable user-diagnostic seam on `EfcDataModel` so the two `Open*` paths, which
+    return `Task` and therefore cannot report through a result, can surface a message that is
+    assertable in a unit test.
+  - New MSTest regression tests in `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`.
+  - Registering that new file in `QuickFiler.Test/QuickFiler.Test.csproj`.
+  - Updating this spec's status and the feature folder's evidence artifacts.
+
+- Out of scope / non-goals. The three items below are verified findings that must survive this
+  issue. Each warrants a **separate follow-up issue**, filed through the repository's promotion
+  lifecycle rather than left as prose in this folder.
+  - **(a) `COMException` from the live COM calls inside the `ArchiveRootPath` getter.** The getter
+    dereferences `Root.FolderPath` at `TaskMaster/AppGlobals/AppOlObjects.cs:260` and
+    `ArchiveRoot?.FolderPath` at `TaskMaster/AppGlobals/AppOlObjects.cs:261`; `ArchiveRoot`
+    (`TaskMaster/AppGlobals/AppOlObjects.cs:270`) lazily runs `LoadArchiveRoot`
+    (`TaskMaster/AppGlobals/AppOlObjects.cs:272-276`) → `FolderPredictor.GetFolder`. Those are live
+    COM calls and can raise `System.Runtime.InteropServices.COMException`, which the deliberately
+    narrow catch in this fix will not absorb. Widening the catch here is rejected; see Root Cause
+    Analysis.
+  - **(b) The generic log-only boundary-sink gap at the `async void` boundaries.** All five
+    `async void` handlers in `QuickFiler/Controllers/EfcFormController.cs` — `ButtonCancel_Click`
+    (`:442-443`), `ButtonOK_Click` (`:460`), `ButtonRefresh_Click` (`:477-478`), `ButtonCreate_Click`
+    (`:495-496`) and `ButtonDelete_Click` (`:557-558`) — delegate to an `Async` method whose catch
+    calls `BoundaryErrorSink` and returns. Any unexpected exception on the OK path therefore
+    produces a vanished form with no user feedback and with `Dispose()`/`Cleanup()` skipped,
+    independently of the archive-root cause. This is a boundary-behavior defect, not an
+    archive-root defect.
+  - **(c) The archive-root reads inside `QuickFiler/Controllers/EfcFormController.cs`.** Five exist:
+    `:529` and `:539` in `ButtonCreateClickAsync` (`:498-555`, caught at `:551-554`); `:836` and
+    `:846` in `CreateFolderAsync` (`:815-858`, which has **no local try/catch** and is reached from
+    the keyboard `'N'` binding at `:630` and `:698` via `KbdExecuteAsync` (`:894-898`, no try/catch)
+    into `KeyboardHandler.KeyboardHandler_KeyDownAsync`
+    (`QuickFiler/Controllers/KeyboardHandler.cs:133-148`), whose catch at `:141-147` logs only); and
+    `:987` in `BindBreadcrumbRowsAsync` (`:980-997`, caught at `:993-996`, logs only). These sit in a
+    different class with a different reporting surface and are excluded to keep the fix minimal per
+    the Bugfix Workflow.
+  - Note on formatting: the paths in this non-goals list are given as concrete, verified citations so
+    a later reader can re-derive them. They are **not** part of the change footprint. The change
+    footprint is exactly the four files listed under "In scope" above and repeated under
+    "Files/modules to change".
+
+- Explicitly excluded systems, integrations, or datasets:
+  - `TaskMaster/AppGlobals/AppOlObjects.cs` and `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs`: the
+    throw contract stays exactly as it is. It is pinned by
+    `TaskMaster.Test/AppGlobals/AppOlObjectsArchiveRootValidationTests.cs`, which must continue to
+    pass unmodified.
+  - `UtilitiesCS`: `IOlObjects.ArchiveRootPath` (`UtilitiesCS/Interfaces/IGlobals/IOlObjects.cs:15`)
+    is read, not changed. No interface member is added, removed, or retyped.
+  - The wider `async void` surface in the QuickFiler assembly outside
+    `QuickFiler/Controllers/EfcFormController.cs` (handlers in `QfcFormController.EventHandlers.cs`,
+    `QfcItemController.EventHandlers.cs`, `QfcItemController.EventWiring.cs`, `QfcDatamodel.cs`,
+    `KeyboardHandler.cs`, `BreadcrumbBridgeRouter.cs` and `ConversationResolver.Loading.cs`) is not
+    reached by this issue and must not be swept in.
+  - Live Outlook, live COM, network, database, and filesystem: none is touched by the fix or by any
+    test added for it.
+
+## Root Cause Analysis
+
+- Confirmed root cause:
+  `QuickFiler/Controllers/EfcDataModel.cs` treats `Globals.Ol.ArchiveRootPath` as a total function.
+  Since the #614 D6 change, the getter is a **partial** function: it throws
+  `InvalidOperationException` by contract when the archive root cannot be validated
+  (`TaskMaster/AppGlobals/AppOlObjects.cs:250-252` documents the exception;
+  `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:30-31` documents it on the helper). `EfcDataModel`
+  was never updated to honour that contract, so a documented, expected failure mode escapes as an
+  exception through a call chain that has no handler until a log-only fault boundary. The result is
+  not a crash on this head — it is a silent swallow with skipped cleanup.
+
+- Signals/evidence supporting it:
+  - The three reads are syntactically inside object initializers
+    (`QuickFiler/Controllers/EfcDataModel.cs:282-291`, `:306-312`, `:324-330`), where a `try` cannot
+    be placed without restructuring, which is why the omission is easy to miss in review.
+  - The adjacent OneDrive condition in the same method is guarded
+    (`QuickFiler/Controllers/EfcDataModel.cs:277-281`), demonstrating that the class already models
+    "a required filing root did not resolve" as a `return false`, not as an exception. The archive
+    root is the same class of condition and is the only one left unguarded.
+  - The whole of `QuickFiler/Controllers/EfcDataModel.cs` contains a single `catch`, at `:249`, in an
+    unrelated method.
+  - `TaskMaster.Test/AppGlobals/AppOlObjectsArchiveRootValidationTests.cs` already pins both throw
+    conditions in isolation, so the throwing behavior is intentional and must not be reversed at the
+    source.
+  - Every caller of `MoveToFolderAsync(string, ...)` already handles a `false` result:
+    `QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:98` returns it to `:78`, which passes
+    it to `HandleMoveResult` at `:86`, which routes `false` to `MoveFailureMessageAction` at
+    `:132-136`; and the `MAPIFolder` overload at `QuickFiler/Controllers/EfcDataModel.cs:346` shows a
+    message box at `:353-356`. No caller silently discards the bool, so returning `false` is already
+    a fully supported outcome.
+
+- Affected components/modules (paths, services, pipelines):
+  - `QuickFiler/Controllers/EfcDataModel.cs` — the defect site and the only production file changed.
+  - `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` — new regression tests.
+  - `QuickFiler.Test/QuickFiler.Test.csproj` — explicit compile registration for the new test file.
+  - Unchanged but load-bearing on the outcome: `QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs`
+    (routes a `false` result to the user) and `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs`
+    (defines the exception contract being honoured).
+
+## Proposed Fix
+
+### Design summary (what changes where):
+
+Add one private helper to `EfcDataModel` that performs the archive-root read inside a narrow
+`try`/`catch (InvalidOperationException)` and reports failure through a `bool` return, then route all
+three reads through it. Add one injectable `Action<string>` diagnostic seam so the two `Open*`
+methods, which return `Task` and cannot report through a result, can still surface a message that a
+unit test can assert. Both shapes already exist in this codebase and are reused rather than invented:
+the `return false` degrade mirrors the OneDrive guard in the same method
+(`QuickFiler/Controllers/EfcDataModel.cs:277-281`), and the injectable action mirrors
+`EfcHomeController.MoveFailureMessageAction`
+(`QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:23-24`), which is already unit-tested at
+`QuickFiler.Test/Controllers/EfcHomeControllerExecuteMovesTests.cs:160-175`.
+
+### Boundaries and invariants to preserve:
+
+- **Guard ordering (verified, load-bearing).** The archive-root guard must be placed **after** the
+  existing OneDrive `SpecialFolders` read in all three methods, never before it.
+  `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs:217` asserts
+  `probe.FileSystem.SpecialFoldersAccessCount.Should().Be(2)` in
+  `OpenFolderMethods_DelegateToDataModelWithoutExternalServices`
+  (`QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs:207-218`), after calling
+  `OpenOlFolderAsync` and `OpenFsFolderAsync` once each. The counter is incremented by the
+  `SpecialFolders` getter at `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs:414-423`.
+  Two independent breakages follow from putting the new guard first: the count would drop to 0
+  because both methods would return before the `SpecialFolders` read; and the probe's
+  `FakeApplicationGlobals.Ol` returns `null`
+  (`QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs:388`), so an earlier
+  `Globals.Ol.ArchiveRootPath` would raise `NullReferenceException`, which a
+  `catch (InvalidOperationException)` does not absorb. The probe seeds an empty
+  `ConcurrentDictionary` (`QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs:245-247`),
+  which is why the existing test never reaches the archive-root read today.
+- The `MailInfo is null` guard at `QuickFiler/Controllers/EfcDataModel.cs:267-270` must remain the
+  first check in `MoveToFolderAsync`.
+- The exception contract of `IOlObjects.ArchiveRootPath` is not changed. The archive root must never
+  be degraded to an empty or synthesized value: an empty `OlAncestor` flows into `EmailFilerConfig`
+  and downstream stem composition, which is precisely the #614 store-root-leak failure mode.
+- Public and internal signatures are unchanged:
+  `Task<bool> MoveToFolderAsync(string, bool, bool, bool, bool)`, `Task OpenOlFolderAsync(string)`,
+  `Task OpenFsFolderAsync(string)`.
+- Redaction discipline is preserved. No user-visible message may interpolate the archive root path,
+  the destination folder path, or a mailbox address, matching
+  `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:13-17` and the assertion style already used at
+  `QuickFiler.Test/Controllers/EfcDataModelIssue614Tests.cs:47-59`.
+- `QuickFiler/Controllers/EfcDataModel.cs` is currently 423 lines against the 500-line cap in the
+  General Code Change Policy. The change must not exceed the cap.
+
+### Dependencies or blocked work:
+
+- No blocking dependency. The fix is self-contained within the `QuickFiler` and `QuickFiler.Test`
+  projects.
+- Related but independent: issue #637 (producer-side rooted-path normalization) and issue #614
+  (store-root leak). Neither must land first.
+- The three non-goals above should be filed as follow-up issues; filing them does not block this fix.
+
+### Implementation strategy (what changes, not sequencing):
+
+#### Files/modules to change:
+
+- `QuickFiler/Controllers/EfcDataModel.cs` — production change.
+- `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` — new test file.
+- `QuickFiler.Test/QuickFiler.Test.csproj` — add an explicit
+  `<Compile Include="Controllers\EfcDataModelArchiveRootTests.cs" />` entry.
+- `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md` —
+  acceptance-criteria check-off and status update.
+
+#### Functions/classes/CLI commands impacted:
+
+- `EfcDataModel.MoveToFolderAsync(string, bool, bool, bool, bool)` — the read at `:289` becomes a
+  guarded assignment; an unresolvable root returns `false`.
+- `EfcDataModel.OpenOlFolderAsync(string)` — the read at `:310` becomes a guarded assignment; an
+  unresolvable root reports through the diagnostic seam and returns.
+- `EfcDataModel.OpenFsFolderAsync(string)` — same, for the read at `:328`.
+- New private helper on `EfcDataModel` (for example `TryGetArchiveRoot(out string)`), catching
+  `InvalidOperationException` only and logging through the existing static `log4net` logger declared
+  at `QuickFiler/Controllers/EfcDataModel.cs:23-25`.
+- New internal settable seam on `EfcDataModel` (for example
+  `internal System.Action<string> UserDiagnosticAction { get; set; }`) defaulting to
+  `MessageBox.Show`. `System.Windows.Forms` is already imported at
+  `QuickFiler/Controllers/EfcDataModel.cs:10` and `MessageBox.Show` is already used at
+  `QuickFiler/Controllers/EfcDataModel.cs:355`, so this adds no dependency.
+- No CLI command is affected; this project ships no CLI surface.
+
+#### Data flow and validation changes:
+
+- `EmailFilerConfig.OlAncestor` is assigned only from a value that the guard has confirmed was
+  produced without throwing. It is never assigned an empty or synthesized value.
+- The failure path short-circuits before `new EmailFiler(config)` at
+  `QuickFiler/Controllers/EfcDataModel.cs:293`, `:314` and `:332`, so no partially populated
+  `EmailFilerConfig` is ever handed to the filer.
+- Validation order inside `MoveToFolderAsync` becomes: `MailInfo` null check → OneDrive
+  `SpecialFolders` lookup → archive-root resolution. Inside each `Open*` method: OneDrive
+  `SpecialFolders` lookup → archive-root resolution.
+
+#### Error handling and logging updates:
+
+- Catch breadth is exactly `InvalidOperationException`. That is the documented contract of the
+  property (`TaskMaster/AppGlobals/AppOlObjects.cs:250-252`) and of the guard
+  (`TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:30-31`). Broader catches are rejected: a
+  `COMException` from the live COM calls in the getter must continue to propagate so it remains
+  visible for non-goal (a), and `catch (Exception)` would violate the General Code Change Policy's
+  fail-fast rule.
+- One `logger.Warn` entry is written per guarded failure, using the existing static logger at
+  `QuickFiler/Controllers/EfcDataModel.cs:23-25`. This matches the shape of the adjacent OneDrive
+  guard's `logger.Warn($"Cannot sort without OneDrive location")` at
+  `QuickFiler/Controllers/EfcDataModel.cs:279`. No `Console.WriteLine` or other ad-hoc output is
+  added.
+- On the `Sort` path the user message continues to be emitted by
+  `EfcHomeController.HandleMoveResult` → `MoveFailureMessageAction`
+  (`QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:132-136`). Its existing text,
+  "Cannot move to folderpath {selectedFolder}", is left unchanged: it already fires, it is pinned by
+  `QuickFiler.Test/Controllers/EfcHomeControllerExecuteMovesTests.cs:174`, and changing it would
+  widen the diff without changing the outcome.
+- On the two `Open*` paths the user message is emitted at the point of failure through the new
+  diagnostic seam, because those methods return `Task` and have no result channel.
+
+#### Rollback/feature-flag considerations (if applicable):
+
+- No feature flag. The change is a behavior-narrowing guard inside three methods of one class; the
+  repository has no feature-flag mechanism and adding one for this would be disproportionate.
+- Rollback is a straight revert of the commit. Because no interface, no signature, and no persisted
+  data shape changes, a revert restores the prior behavior exactly, with no migration or cleanup.
+
+### Technical specifications (interfaces/contracts):
+
+#### Inputs/outputs and formats:
+
+- Input to the guarded read: `IApplicationGlobals.Ol.ArchiveRootPath`, a `string` declared at
+  `UtilitiesCS/Interfaces/IGlobals/IOlObjects.cs:15`, which either returns a validated full Outlook
+  archive path or throws `InvalidOperationException`.
+- `MoveToFolderAsync(string, bool, bool, bool, bool)` returns `Task<bool>`; `true` means the filing
+  operation completed, `false` means it did not. The new contract clause: `false` now additionally
+  covers "the archive root could not be resolved".
+- `OpenOlFolderAsync(string)` and `OpenFsFolderAsync(string)` return `Task` (no value). Their new
+  contract clause: on an unresolvable archive root they complete normally after invoking the
+  diagnostic seam exactly once.
+- User-visible diagnostic format: a single plain-text sentence naming the rule, with no path and no
+  mailbox address interpolated.
+
+#### Required configuration keys and defaults:
+
+- None. This fix introduces no configuration key, no app setting, and no entry in `coverage.config`.
+- The one new default is the diagnostic seam's initial value, `text => MessageBox.Show(text)`, chosen
+  to match `QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:23-24` exactly. Tests replace it
+  with a capturing delegate; production never assigns it.
+
+#### Backward-compatibility expectations:
+
+- No breaking change. `EfcDataModel` is `internal`
+  (`QuickFiler/Controllers/EfcDataModel.cs:21`) and is reachable from tests only through
+  `[assembly: InternalsVisibleTo("QuickFiler.Test")]` at `QuickFiler/Properties/AssemblyInfo.cs:5`.
+  There is no external consumer.
+- Widening `OpenOlFolderAsync` or `OpenFsFolderAsync` to `Task<bool>` is explicitly rejected. All
+  five production call sites — `QuickFiler/Controllers/EfcHomeController.cs:429`,
+  `QuickFiler/Controllers/EfcHomeController.cs:434`,
+  `QuickFiler/Controllers/EfcFormController.cs:763`,
+  `QuickFiler/Controllers/EfcFormController.cs:513` and
+  `QuickFiler/Controllers/EfcFormController.cs:823` — would discard the value, which would
+  manufacture a silent-swallow problem in five places rather than remove one.
+- Callers that already branch on a `false` result keep working unchanged; no caller needs editing.
+
+#### Performance constraints (latency/throughput/memory):
+
+- The guard adds one `try` frame per call on a path that already performs Outlook COM work and disk
+  I/O through `EmailFiler`. The added cost is not measurable against that baseline.
+- The success path must read `ArchiveRootPath` exactly once per call, as it does today. The property
+  is COM-backed on first resolution (`TaskMaster/AppGlobals/AppOlObjects.cs:272-276`), so a
+  double-read would add a real round trip on the first call; this is pinned by a test.
+- The failure path is strictly cheaper than today: it returns before constructing `EmailFiler`.
+- No new allocation on the success path beyond the existing string reference.
+
+## Assumptions, Constraints, Dependencies
+
+- Assumptions (environment, data, access):
+  - `EfcDataModel.Globals` is an **injected instance**, not a static COM accessor. It is the property
+    at `QuickFiler/Controllers/EfcDataModel.cs:148-153`
+    (`public IApplicationGlobals Globals { get => _globals; protected set => _globals = value; }`),
+    assigned from a constructor parameter. The read chain is therefore
+    `IApplicationGlobals.Ol` → `IOlObjects.ArchiveRootPath`, both interface members, so no new seam
+    is required to test the failure.
+  - `IFileSystemFolderPaths.SpecialFolders` is a concrete `ConcurrentDictionary<string, string>`, so
+    seeding `"OneDrive"` in a test to let the guard at
+    `QuickFiler/Controllers/EfcDataModel.cs:277-281` pass is straightforward.
+  - A developer machine has `msbuild`, `vstest.console.exe` and the .NET Framework 4.8.1 targeting
+    pack available; `dotnet tool restore` has been run once in this worktree before the first
+    CSharpier invocation.
+  - The manual live-Outlook walkthrough in Repro & Evidence is optional confirmation owned by the
+    maintainer. No acceptance criterion depends on it.
+- Constraints (budget, performance, compatibility):
+  - `QuickFiler/Controllers/EfcDataModel.cs` must stay at or under 500 lines. It is 423 lines today;
+    the change is estimated at 30-45 added lines, landing near 455-470. Headroom is limited, so no
+    opportunistic additions to this file.
+  - Both `QuickFiler.csproj` and `QuickFiler.Test.csproj` are legacy non-SDK projects that enumerate
+    every source file. A new `.cs` file does not compile until it is registered; the existing
+    `EfcDataModel` test files are registered at `QuickFiler.Test/QuickFiler.Test.csproj:114-115`.
+  - Target framework is .NET Framework 4.8.1. Language features that require `IsExternalInit`
+    (`init` accessors, `record`, `record struct`) are unavailable.
+  - MSTest, Moq and FluentAssertions are the only permitted test libraries; no new dependency may be
+    added.
+- External dependencies (services, libraries, releases):
+  - None added. The fix uses only `System`, `System.Windows.Forms` (already imported at
+    `QuickFiler/Controllers/EfcDataModel.cs:10`) and the existing `log4net` logger.
+  - No release coordination is required; the change ships with the next add-in build.
+
+## Data / API / Config Impact
+
+- User-facing or API changes:
+  - Behavior change only. On an unresolvable archive root the user now sees a message instead of a
+    form that vanishes silently, and the form is disposed and cleaned up.
+  - No public API surface changes. `EfcDataModel` is `internal`; no interface member is added,
+    removed, or retyped.
+- Data or migration considerations:
+  - None. No persisted data, no schema, no stored settings, and no serialized shape is read or
+    written by this change. No migration is required and none is possible to require.
+- Logging/telemetry updates (if any):
+  - One additional `logger.Warn` entry per guarded failure, from
+    `QuickFiler/Controllers/EfcDataModel.cs`, using the existing static log4net logger at `:23-25`.
+  - The log4net `Error` entry currently produced by `BoundaryErrorSink` on this path disappears,
+    because the exception no longer reaches the boundary. That is the intended outcome, not a loss of
+    signal: the new `Warn` entry names the same redacted rule at the point of failure.
+  - No telemetry counter, metric, or event is added. `QuickFileMetrics_WRITE`
+    (`QuickFiler/Controllers/EfcHomeController.ExecuteMoves.cs:144`) is unchanged and continues to run
+    only on a successful move.
+- Compatibility notes (CLI flags, config schemas, versioning):
+  - No CLI flag, no config schema, no version bump. `coverage.config` is unchanged; it excludes only
+    third-party modules (`coverage.config:12-22`) and no first-party assembly.
+
+## Test Strategy
+
+- Test stack and framework (mandated by `CLAUDE.md` §§ CUT1-CUT2):
+  - **MSTest** (`Microsoft.VisualStudio.TestTools.UnitTesting`) with `[TestClass]`/`[TestMethod]`.
+  - **Moq** for the `IApplicationGlobals` / `IOlObjects` seams.
+  - **FluentAssertions** for all assertions.
+  - No other framework or assertion library may be introduced.
+
+- Test location decision (D1, recorded so it is not re-litigated):
+  New tests go in `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`, **not** in a
+  `tests/` mirror tree. Rationale: `.claude/skills/policy-compliance-order/SKILL.md` ranks
+  `CLAUDE.md` above `.claude/rules/general-unit-test.md`; the General and C# Unit Test Policies
+  embedded in `CLAUDE.md` impose no `tests/` mirroring requirement; and the General Code Change
+  Policy § 7.1 requires matching existing repository style, which for every C# test project here is a
+  sibling project named after the production project with a `.Test` suffix — `QuickFiler.Test`,
+  `TaskMaster.Test`, `UtilitiesCS.Test`, `SVGControl.Test`. The `tests/` tree in this repository
+  contains only PowerShell Pester files under `tests/scripts/vscode/`. The
+  existing `EfcDataModel` tests already live at `QuickFiler.Test/Controllers/EfcDataModelTests.cs`
+  and `QuickFiler.Test/Controllers/EfcDataModelIssue614Tests.cs`. Use namespace
+  `QuickFiler.Test.Controllers`, matching the newer of the two. The new file **must** be registered
+  as an explicit `<Compile Include="Controllers\EfcDataModelArchiveRootTests.cs" />` entry in
+  `QuickFiler.Test/QuickFiler.Test.csproj`, which is a legacy non-SDK project that enumerates every
+  source file; without that entry the tests silently do not exist.
+
+- Unit-level reproducibility of the defect (this is what makes the fix verifiable without Outlook):
+  `EfcDataModel.Globals` is an **injected `IApplicationGlobals` instance**
+  (`QuickFiler/Controllers/EfcDataModel.cs:148-153`), not a static COM accessor, and
+  `ArchiveRootPath` is an interface member
+  (`UtilitiesCS/Interfaces/IGlobals/IOlObjects.cs:15`). The defect is therefore reproducible at the
+  unit level by configuring the injected `IOlObjects.ArchiveRootPath` getter to throw
+  `InvalidOperationException` —
+  `olObjects.SetupGet(x => x.ArchiveRootPath).Throws(new InvalidOperationException(...))`. This is
+  the same seam already used to make the property *return* in
+  `TaskMaster.Test/AppGlobals/AppOlObjectsArchiveRootValidationTests.cs`. The internal class is
+  reachable through `[assembly: InternalsVisibleTo("QuickFiler.Test")]`
+  (`QuickFiler/Properties/AssemblyInfo.cs:5`), and
+  `QuickFiler.Test/Controllers/EfcDataModelTests.cs:220-228` already builds a strict
+  `Mock<IApplicationGlobals>` over a strict `Mock<IOlObjects>` and constructs a real `EfcDataModel`
+  through the public constructor with no Outlook process
+  (`QuickFiler.Test/Controllers/EfcDataModelTests.cs:166-171` and `:200-205`).
+
+- **No `[TestCategory("LiveOutlook")]` test may be added for this issue.** CI filters that category
+  out: `.github/workflows/_mstest-coverage.yml:83` runs
+  `vstest.console.exe $testAssemblies /EnableCodeCoverage /InIsolation /Logger:trx /TestCaseFilter:"TestCategory!=LiveOutlook"`.
+  A `LiveOutlook` test would never execute in CI and would create the appearance of coverage without
+  the substance. The unit-level proof above is strictly stronger: it is deterministic and it covers
+  both throw conditions.
+
+- Regression tests to add or update (all new, in
+  `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`; each must fail before the fix and
+  pass after):
+  1. `MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing` — arrange a
+     `Mock<IOlObjects>` whose `ArchiveRootPath` getter throws `InvalidOperationException`, a
+     `SpecialFolders` dictionary containing `"OneDrive"`, and an `EfcDataModel` with a non-null
+     `MailInfo`; act with `moveConversation: false`; assert the result is `false` and nothing is
+     thrown. Fails today with `InvalidOperationException`.
+  2. `OpenOlFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns` — assert the method
+     completes without throwing and the injected diagnostic seam received exactly one message.
+  3. `OpenFsFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns` — same shape for the
+     file-system open path.
+
+- Unit tests (MSTest) for the fixed behavior and boundaries:
+  4. `MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce` — `VerifyGet(..., Times.Once())`,
+     pinning that the guard does not introduce a second read of the COM-backed property.
+  5. `MoveToFolderAsync_WhenMailInfoIsNull_ReturnsFalseWithoutReadingArchiveRoot` —
+     `VerifyGet(..., Times.Never())`, pinning the guard at
+     `QuickFiler/Controllers/EfcDataModel.cs:267-270` as still first.
+  6. `MoveToFolderAsync_WhenOneDriveIsMissing_ReturnsFalseWithoutReadingArchiveRoot` —
+     `VerifyGet(..., Times.Never())`, pinning the ordering constraint from the production side.
+
+- Edge cases and negative scenarios (invalid inputs, missing data, boundary values):
+  7. `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates` — configure the getter to
+     throw `System.Runtime.InteropServices.COMException` and assert it is **not** absorbed, proving
+     the catch is narrow and that non-goal (a) remains visible rather than silently swallowed.
+  8. Both throw conditions are exercised, not just one: the unresolvable-root message
+     (`TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:44`, constant at `:13-14`) and the
+     cross-store/renamed message (`:56`, constant at `:16-17`).
+  9. `OpenOlFolderAsync` and `OpenFsFolderAsync` with a missing `"OneDrive"` key still return early
+     without reading the archive root.
+
+- Error handling and logging verification:
+  10. `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress` — assert the
+      captured diagnostic string contains neither a mailbox address (for example
+      `mailbox@example.com`) nor the archive root path, matching the redaction assertion style at
+      `QuickFiler.Test/Controllers/EfcDataModelIssue614Tests.cs:47-59`.
+  11. The diagnostic seam is asserted to be invoked exactly once per failing `Open*` call, so a
+      future refactor cannot produce duplicate message boxes.
+
+- Existing tests that must keep passing **without modification** (treat as part of the spec):
+  - `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs` — in particular
+    `OpenFolderMethods_DelegateToDataModelWithoutExternalServices` (`:207-218`) and its
+    `SpecialFoldersAccessCount == 2` assertion at `:217`.
+  - `QuickFiler.Test/Controllers/EfcHomeControllerExecuteMovesTests.cs` — in particular
+    `HandleMoveResult_WhenMoveFails_RoutesMessageThroughInjectedAction` (`:160-175`).
+  - `QuickFiler.Test/Controllers/EfcDataModelTests.cs` (all).
+  - `QuickFiler.Test/Controllers/EfcDataModelIssue614Tests.cs` (all).
+  - `QuickFiler.Test/Controllers/EfcFormControllerTests.cs` (all).
+  - `TaskMaster.Test/AppGlobals/AppOlObjectsArchiveRootValidationTests.cs` (all — the throw contract
+    must remain intact).
+
+- Policy conformance of the new tests: independent, isolated, fast, deterministic; Arrange-Act-Assert
+  with a summary comment on each test; no external service, no network, no database, no live Outlook,
+  no temporary file, no `Thread.Sleep` or `Task.Delay`, no mutable global state.
+
+- Coverage impact and targets for changed lines/modules:
+  - `QuickFiler/Controllers/EfcDataModel.cs` carries no `[ExcludeFromCodeCoverage]` attribute and
+    `QuickFiler` is not excluded by `coverage.config` (`coverage.config:12-22` excludes only
+    third-party modules). The `CLAUDE.md` § UT2 COM/VSTO/WinForms exemption does not apply:
+    `EfcDataModel` is not form-derived, is not Designer-generated, is not a VSTO lifecycle class, and
+    takes its Outlook dependency through the injectable `IApplicationGlobals` seam, which
+    `CLAUDE.md` names as the disqualifier ("without an injectable seam"). The changed lines are
+    therefore in the measured denominator and must be covered.
+  - Target: **>= 90%** line coverage on the new helper, the new seam, and every changed line, per
+    `CLAUDE.md` § UT2 ("any new modules, classes, or methods added must target >= 90% coverage").
+  - No regression on changed lines relative to the merge-base baseline.
+  - Repository-wide line coverage against the testable denominator (`CLAUDE.md` § UT2, with the
+    COM/VSTO/WinForms/Outlook-Interop exemptions applied) is a **record-and-report** obligation, not
+    a blocking gate for this change. No baseline coverage evidence exists in this feature folder
+    yet, so no repo-wide figure can be asserted in advance; the implementer must capture the
+    merge-base baseline first and report both figures, and must show the change does not lower them.
+  - Evidence interpretation note: an exempt member emits no `<method>` element in the Cobertura
+    output at all, so absence is the exemption signal, not a zero rate.
+
+- Toolchain commands to run (format → lint → type-check → test). Quoted verbatim from `CLAUDE.md`
+  § "C# Toolchain (run in this exact order)"; run `dotnet tool restore` once per worktree before the
+  first CSharpier invocation, and restart from step 1 if any step fails or changes files:
+  1. `dotnet tool run csharpier format .` (verify: `dotnet tool run csharpier check .`; always via `dotnet tool run`, never a global install)
+  2. `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
+  3. `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:TreatWarningsAsErrors=true`
+  4. `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage`
+
+  Notes on running steps 2-4 honestly. Do **not** add `/p:Nullable=enable` to step 3 and do **not**
+  substitute `/t:Build` for `/t:Rebuild` in steps 2 or 3; `CLAUDE.md` §§ C#1.2-C#1.3 document both as
+  load-bearing, because MSBuild's up-to-date check does not invalidate on a command-line `/p:`
+  change and a warm `/t:Build` returns exit 0 having skipped `CoreCompile` on every project. Prove
+  non-vacuity by confirming the build log contains zero occurrences of
+  `Skipping target "CoreCompile"`, and read the error count from MSBuild's own `N Error(s)` line
+  rather than by grepping for `error CS`. For step 4, match CI by adding `/InIsolation` and
+  `/TestCaseFilter:"TestCategory!=LiveOutlook"`, and exclude any test assembly under
+  `.claude/worktrees` from the discovered set.
+
+- Manual validation steps (if required):
+  - **Not required.** No acceptance criterion depends on a live-Outlook step. The live-profile
+    walkthrough in Repro & Evidence is recorded as an optional post-merge confirmation owned by the
+    maintainer, because the profile condition's only effect on the code under test is that
+    `IOlObjects.ArchiveRootPath` throws `InvalidOperationException` with one of two fixed messages,
+    and that is injected directly at the interface seam in the unit tests.
+
+## Acceptance Criteria
+
+Every criterion below is independently checkable by the named MSTest test or the named toolchain
+command. None depends on a live-Outlook manual step. All tests named as new live in
+`QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` unless stated otherwise.
+
+- [ ] AC1 — `MoveToFolderAsync(string, bool, bool, bool, bool)` returns `false` instead of
+  propagating when the injected `IOlObjects.ArchiveRootPath` getter throws
+  `InvalidOperationException`. Verified by `MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing`.
+- [ ] AC2 — `OpenOlFolderAsync(string)` completes without throwing and invokes the injected
+  user-diagnostic seam exactly once when the archive root is unresolvable. Verified by
+  `OpenOlFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns`.
+- [ ] AC3 — `OpenFsFolderAsync(string)` completes without throwing and invokes the injected
+  user-diagnostic seam exactly once when the archive root is unresolvable. Verified by
+  `OpenFsFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns`.
+- [ ] AC4 — The user-visible diagnostic contains neither a mailbox address nor the archive root
+  path. Verified by `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress`.
+- [ ] AC5 — The archive-root guard sits **after** the OneDrive `SpecialFolders` read in all three
+  methods: `ArchiveRootPath` is never read when the `"OneDrive"` key is absent. Verified by
+  `MoveToFolderAsync_WhenOneDriveIsMissing_ReturnsFalseWithoutReadingArchiveRoot`
+  (`VerifyGet(..., Times.Never())`) **and** by
+  `OpenFolderMethods_DelegateToDataModelWithoutExternalServices` in
+  `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs` still passing unmodified with its
+  `SpecialFoldersAccessCount == 2` assertion at `:217`.
+- [ ] AC6 — The `MailInfo is null` guard remains the first check in `MoveToFolderAsync`:
+  `ArchiveRootPath` is not read when `MailInfo` is null. Verified by
+  `MoveToFolderAsync_WhenMailInfoIsNull_ReturnsFalseWithoutReadingArchiveRoot`
+  (`VerifyGet(..., Times.Never())`).
+- [ ] AC7 — The success path reads `ArchiveRootPath` exactly once per call; the guard introduces no
+  second COM-backed read. Verified by `MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce`
+  (`VerifyGet(..., Times.Once())`).
+- [ ] AC8 — The catch is narrowed to `InvalidOperationException`: a
+  `System.Runtime.InteropServices.COMException` raised by the same getter still propagates and is not
+  absorbed. Verified by `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates`.
+- [ ] AC9 — Both documented throw conditions are covered, not only one: a test exercises the
+  unresolvable-root message and a test exercises the cross-store/renamed message, matching the
+  constants at `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:13-17`.
+- [ ] AC10 — Public and internal signatures are unchanged:
+  `Task<bool> MoveToFolderAsync(string, bool, bool, bool, bool)`, `Task OpenOlFolderAsync(string)`,
+  `Task OpenFsFolderAsync(string)`. Verified by
+  `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs`,
+  `QuickFiler.Test/Controllers/EfcHomeControllerExecuteMovesTests.cs`,
+  `QuickFiler.Test/Controllers/EfcDataModelTests.cs`,
+  `QuickFiler.Test/Controllers/EfcDataModelIssue614Tests.cs`,
+  `QuickFiler.Test/Controllers/EfcFormControllerTests.cs` and
+  `TaskMaster.Test/AppGlobals/AppOlObjectsArchiveRootValidationTests.cs` all compiling and passing
+  with **zero** edits.
+- [ ] AC11 — `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` is registered as an
+  explicit `<Compile Include="Controllers\EfcDataModelArchiveRootTests.cs" />` entry in
+  `QuickFiler.Test/QuickFiler.Test.csproj`, and the new tests appear in the executed test list of the
+  step-4 `vstest.console.exe` run.
+- [ ] AC12 — Fail-before / pass-after evidence exists for the three regression tests (AC1-AC3): a
+  captured run showing them failing against unmodified production code, and a captured run showing
+  them passing after the fix, both written under
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/`.
+- [ ] AC13 — Format gate: `dotnet tool run csharpier check .` reports no unformatted files, run
+  through `dotnet tool run` against the manifest-pinned version.
+- [ ] AC14 — Analyzer gate:
+  `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
+  completes with `0 Error(s)` on MSBuild's own summary line, and the log contains zero occurrences of
+  `Skipping target "CoreCompile"`.
+- [ ] AC15 — Type-check gate:
+  `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:TreatWarningsAsErrors=true`
+  completes with `0 Error(s)` on MSBuild's own summary line, with zero occurrences of
+  `Skipping target "CoreCompile"`, and without `/p:Nullable=enable` and without substituting
+  `/t:Build`.
+- [ ] AC16 — Test gate: `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage` (with CI's
+  `/InIsolation` and `/TestCaseFilter:"TestCategory!=LiveOutlook"`, excluding assemblies under
+  `.claude/worktrees`) reports zero failed tests across `QuickFiler.Test` and `TaskMaster.Test`. No
+  test in the change carries `[TestCategory("LiveOutlook")]`.
+- [ ] AC17 — Coverage: the new helper, the new diagnostic seam, and every changed line in
+  `QuickFiler/Controllers/EfcDataModel.cs` reach **>= 90%** line coverage, and coverage on changed
+  lines does not regress against the merge-base baseline. The repository-wide figure against the
+  testable denominator is captured and reported for the baseline run under
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/`
+  and for the post-change run under
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/`,
+  and the change is shown not to lower it; the repo-wide figure itself is recorded, not used as a
+  blocking threshold, because no baseline evidence existed when this spec was written.
+- [ ] AC18 — Change footprint is exactly `QuickFiler/Controllers/EfcDataModel.cs`,
+  `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`,
+  `QuickFiler.Test/QuickFiler.Test.csproj`, and this feature folder's documents and evidence. No
+  other production file is modified; in particular
+  `QuickFiler/Controllers/EfcFormController.cs`, `TaskMaster/AppGlobals/AppOlObjects.cs`,
+  `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs` and
+  `UtilitiesCS/Interfaces/IGlobals/IOlObjects.cs` are untouched. Verified by `git diff --name-only`
+  against the merge base.
+- [ ] AC19 — `QuickFiler/Controllers/EfcDataModel.cs` remains at or under 500 lines after the change
+  (423 lines before). Verified by a line count of the file.
+- [ ] AC20 — The three non-goals in Scope & Non-Goals — (a) `COMException` from the archive-root
+  getter's COM calls, (b) the log-only `async void` boundary sinks in
+  `QuickFiler/Controllers/EfcFormController.cs`, and (c) the five archive-root reads inside
+  `QuickFiler/Controllers/EfcFormController.cs` — are each filed as a separate follow-up issue
+  through the repository's promotion lifecycle, with the issue numbers recorded in the Rollout &
+  Follow-up section of this file.
+
+## Risks & Mitigations
+
+- Technical or operational risks:
+  - **Guard placed before the OneDrive read.** This is the single highest-probability implementation
+    error, because "check the archive root first" reads as the natural ordering. It breaks
+    `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs:217` in two ways at once (count
+    drops to 0; `FakeApplicationGlobals.Ol` is null at `:388`, giving a `NullReferenceException` that
+    the narrow catch does not absorb).
+  - **Catch widened to `Exception` or to `COMException`.** This would silently absorb non-goal (a)
+    and would violate the General Code Change Policy's fail-fast rule, converting a visible COM
+    failure into an invisible one.
+  - **Degrading to an empty archive root instead of returning early.** An empty `OlAncestor` flows
+    into `EmailFilerConfig` and downstream stem composition, which reintroduces the #614
+    store-root-leak failure mode.
+  - **New test file not registered in the legacy `.csproj`.** The tests would silently not exist, and
+    a green run would prove nothing.
+  - **Behavior change surprises a user who relied on the current silence.** Low: the current
+    behavior is a vanished window with no message, which is not a behavior anyone can rely on.
+  - **File-size cap.** `QuickFiler/Controllers/EfcDataModel.cs` has roughly 77 lines of headroom
+    before the 500-line cap.
+
+- Mitigations and rollbacks:
+  - The ordering risk is mitigated by AC5, which pins it from both sides — a new `Times.Never()`
+    assertion on the production side and the existing, unmodified `SpecialFoldersAccessCount == 2`
+    assertion on the test side.
+  - The catch-breadth risk is mitigated by AC8, which asserts a `COMException` still propagates.
+  - The empty-root risk is mitigated by the invariant in Boundaries and by AC1-AC3, which assert an
+    early `false`/return rather than a filing attempt with a degraded root.
+  - The registration risk is mitigated by AC11, which requires the new tests to appear in the
+    executed test list, not merely to exist on disk.
+  - The file-size risk is mitigated by AC19 and by the constraint prohibiting opportunistic additions
+    to this file.
+  - Rollback: revert the single commit. No interface, signature, persisted data shape, or
+    configuration key changes, so a revert is complete and requires no migration or cleanup.
+
+## Rollout & Follow-up
+
+- Release/rollout steps:
+  1. Land the change on `bug/efc-unguarded-archive-root-read-crashes-ui-thread-638` with the full
+     four-step toolchain green in a single pass (AC13-AC16) and all evidence committed.
+  2. Open a pull request to `main` with the change description, the fail-before/pass-after regression
+     evidence, and the coverage comparison.
+  3. Ship with the next add-in build. No staged rollout, no feature flag, and no configuration change
+     is required, because the change is a behavior-narrowing guard inside one internal class.
+
+- Post-fix monitoring or clean-up tasks:
+  - After merge, the maintainer may optionally run the live-profile walkthrough in Repro & Evidence
+    on a profile whose archive folder does not resolve, and confirm that a message appears and the
+    form closes cleanly. This is confirmation only; no acceptance criterion depends on it.
+  - Watch the log4net output for the new `Warn` entry from `QuickFiler/Controllers/EfcDataModel.cs`.
+    A sustained rate of that entry indicates profiles in the field whose archive root does not
+    resolve, which is useful input for non-goal (a).
+  - File the three follow-up issues required by AC20 and record their numbers here.
+  - No temporary scaffolding, feature flag, or migration needs removing afterwards.
+
+- Links: issue, PRs, related docs
+  - Issue: #638 — https://github.com/drmoisan/TaskMaster/issues/638
+  - Feature folder:
+    `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638`
+  - Promoted issue body:
+    `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/issue.md`
+    (two of its claims are corrected in the Context section above)
+  - Research artifact (authoritative where it contradicts the issue body, because it was verified
+    against this branch head):
+    `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/research/2026-08-29T08-05-archive-root-guard-research.md`
+  - Plan:
+    `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/plan.2026-08-29T07-41.md`
+  - Related issues: #614 (store-root leak; introduced the throwing contract this fix honours), #637
+    (producer-side rooted-path normalization), #602 (redaction of mailbox addresses in diagnostics).
+  - PRs: to be recorded when opened.
+  - Follow-up issues for the three non-goals: to be recorded when filed (AC20).
+
+## Correction Log
+
+- **2026-08-29T08-40 — acceptance criteria and repro restated against verified head behavior.**
+  The template's eight generic placeholder criteria were replaced with 20 concrete, individually
+  verifiable criteria (D2). The originals were: "Repro steps now produce the expected behavior in all
+  documented environments", "Regression test(s) added and passing (list file path and test name)",
+  "Edge cases and invalid inputs are handled with correct errors or fallbacks", "No unintended
+  behavior changes outside the defined scope", "Required logs/telemetry updated and validated (if
+  applicable)", "Performance constraints met or explicitly waived with rationale", "Full toolchain
+  pass completed (format → lint → type-check → test)", and "Docs/config references updated to match
+  the new behavior". The first of those was unsatisfiable as written, because the issue body's repro
+  step 5 asserts an unhandled UI-thread exception that cannot occur on this branch head. Repro &
+  Evidence was rewritten so its steps and its Expected/Actual describe the verified silent-swallow
+  symptom instead.
+- **2026-08-29T08-40 — repo-wide coverage floor demoted from a blocking gate to a
+  record-and-report obligation (AC17).** No baseline coverage evidence exists in this feature folder,
+  so a repo-wide threshold could not be shown to be satisfiable in advance. The blocking conditions
+  are change-scoped: >= 90% on the new and changed lines, and no regression on changed lines.
+- **2026-08-29T10-05 — non-canonical coverage evidence sub-path replaced.** The Repro & Evidence
+  section and AC17 both named a `coverage` sub-directory beneath this feature folder's `evidence`
+  directory. The literal spelling of that removed sub-path is not repeated in this entry, because a
+  verification step greps the spec for it and expects zero matches.
+  That sub-path is not among the canonical evidence sub-paths enumerated by
+  `.claude/skills/evidence-and-timestamp-conventions/SKILL.md`, which is the single source of truth
+  for evidence locations and is non-overridable. Both references were replaced: the baseline coverage
+  figure is recorded under
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/baseline/`
+  and the post-change coverage figure under
+  `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/`.
+  The substitution changes only the location at which AC17's evidence is written; the measurement
+  obligations AC17 states are unchanged. Authority:
+  `.claude/skills/evidence-and-timestamp-conventions/SKILL.md`.
+- **2026-08-29T11-20 — absolute host path removed from the Context section.** The provenance sentence
+  that opens the Context section's citation note identified the worktree in which the citations were
+  re-derived by its full filesystem location, which carried the account name of the machine that ran
+  the authoring session. That sentence now identifies the worktree by its branch name and the
+  `origin/main` merge-base SHA alone, which are the two facts a reader needs in order to reproduce the
+  citations. The removed text is not quoted in this entry, because a verification step greps this file
+  for its leading segment and expects zero matches. No criterion text changed, no evidence location
+  changed, and no citation changed.

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md
@@ -3,8 +3,8 @@
 - **Issue:** #638
 - **Parent (optional):** none
 - **Owner:** drmoisan
-- **Last Updated:** 2026-08-29T08-40
-- **Status:** Ready for Planning
+- **Last Updated:** 2026-08-29T12-47
+- **Status:** Implemented
 - **Version:** 1.0
 
 > Work Mode for issue #638 is `full-bug`. Per `.claude/skills/acceptance-criteria-tracking/SKILL.md`,
@@ -670,38 +670,38 @@ Every criterion below is independently checkable by the named MSTest test or the
 command. None depends on a live-Outlook manual step. All tests named as new live in
 `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` unless stated otherwise.
 
-- [ ] AC1 — `MoveToFolderAsync(string, bool, bool, bool, bool)` returns `false` instead of
+- [x] AC1 — `MoveToFolderAsync(string, bool, bool, bool, bool)` returns `false` instead of
   propagating when the injected `IOlObjects.ArchiveRootPath` getter throws
   `InvalidOperationException`. Verified by `MoveToFolderAsync_WhenArchiveRootIsUnresolvable_ReturnsFalseInsteadOfThrowing`.
-- [ ] AC2 — `OpenOlFolderAsync(string)` completes without throwing and invokes the injected
+- [x] AC2 — `OpenOlFolderAsync(string)` completes without throwing and invokes the injected
   user-diagnostic seam exactly once when the archive root is unresolvable. Verified by
   `OpenOlFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns`.
-- [ ] AC3 — `OpenFsFolderAsync(string)` completes without throwing and invokes the injected
+- [x] AC3 — `OpenFsFolderAsync(string)` completes without throwing and invokes the injected
   user-diagnostic seam exactly once when the archive root is unresolvable. Verified by
   `OpenFsFolderAsync_WhenArchiveRootIsUnresolvable_ReportsAndReturns`.
-- [ ] AC4 — The user-visible diagnostic contains neither a mailbox address nor the archive root
+- [x] AC4 — The user-visible diagnostic contains neither a mailbox address nor the archive root
   path. Verified by `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress`.
-- [ ] AC5 — The archive-root guard sits **after** the OneDrive `SpecialFolders` read in all three
+- [x] AC5 — The archive-root guard sits **after** the OneDrive `SpecialFolders` read in all three
   methods: `ArchiveRootPath` is never read when the `"OneDrive"` key is absent. Verified by
   `MoveToFolderAsync_WhenOneDriveIsMissing_ReturnsFalseWithoutReadingArchiveRoot`
   (`VerifyGet(..., Times.Never())`) **and** by
   `OpenFolderMethods_DelegateToDataModelWithoutExternalServices` in
   `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs` still passing unmodified with its
   `SpecialFoldersAccessCount == 2` assertion at `:217`.
-- [ ] AC6 — The `MailInfo is null` guard remains the first check in `MoveToFolderAsync`:
+- [x] AC6 — The `MailInfo is null` guard remains the first check in `MoveToFolderAsync`:
   `ArchiveRootPath` is not read when `MailInfo` is null. Verified by
   `MoveToFolderAsync_WhenMailInfoIsNull_ReturnsFalseWithoutReadingArchiveRoot`
   (`VerifyGet(..., Times.Never())`).
-- [ ] AC7 — The success path reads `ArchiveRootPath` exactly once per call; the guard introduces no
+- [x] AC7 — The success path reads `ArchiveRootPath` exactly once per call; the guard introduces no
   second COM-backed read. Verified by `MoveToFolderAsync_WhenArchiveRootResolves_StillReadsItOnce`
   (`VerifyGet(..., Times.Once())`).
-- [ ] AC8 — The catch is narrowed to `InvalidOperationException`: a
+- [x] AC8 — The catch is narrowed to `InvalidOperationException`: a
   `System.Runtime.InteropServices.COMException` raised by the same getter still propagates and is not
   absorbed. Verified by `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates`.
-- [ ] AC9 — Both documented throw conditions are covered, not only one: a test exercises the
+- [x] AC9 — Both documented throw conditions are covered, not only one: a test exercises the
   unresolvable-root message and a test exercises the cross-store/renamed message, matching the
   constants at `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs:13-17`.
-- [ ] AC10 — Public and internal signatures are unchanged:
+- [x] AC10 — Public and internal signatures are unchanged:
   `Task<bool> MoveToFolderAsync(string, bool, bool, bool, bool)`, `Task OpenOlFolderAsync(string)`,
   `Task OpenFsFolderAsync(string)`. Verified by
   `QuickFiler.Test/Controllers/EfcHomeControllerLifecycleTests.cs`,
@@ -711,26 +711,26 @@ command. None depends on a live-Outlook manual step. All tests named as new live
   `QuickFiler.Test/Controllers/EfcFormControllerTests.cs` and
   `TaskMaster.Test/AppGlobals/AppOlObjectsArchiveRootValidationTests.cs` all compiling and passing
   with **zero** edits.
-- [ ] AC11 — `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` is registered as an
+- [x] AC11 — `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` is registered as an
   explicit `<Compile Include="Controllers\EfcDataModelArchiveRootTests.cs" />` entry in
   `QuickFiler.Test/QuickFiler.Test.csproj`, and the new tests appear in the executed test list of the
   step-4 `vstest.console.exe` run.
-- [ ] AC12 — Fail-before / pass-after evidence exists for the three regression tests (AC1-AC3): a
+- [x] AC12 — Fail-before / pass-after evidence exists for the three regression tests (AC1-AC3): a
   captured run showing them failing against unmodified production code, and a captured run showing
   them passing after the fix, both written under
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/regression-testing/`.
-- [ ] AC13 — Format gate: `dotnet tool run csharpier check .` reports no unformatted files, run
+- [x] AC13 — Format gate: `dotnet tool run csharpier check .` reports no unformatted files, run
   through `dotnet tool run` against the manifest-pinned version.
-- [ ] AC14 — Analyzer gate:
+- [x] AC14 — Analyzer gate:
   `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
   completes with `0 Error(s)` on MSBuild's own summary line, and the log contains zero occurrences of
   `Skipping target "CoreCompile"`.
-- [ ] AC15 — Type-check gate:
+- [x] AC15 — Type-check gate:
   `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:TreatWarningsAsErrors=true`
   completes with `0 Error(s)` on MSBuild's own summary line, with zero occurrences of
   `Skipping target "CoreCompile"`, and without `/p:Nullable=enable` and without substituting
   `/t:Build`.
-- [ ] AC16 — Test gate: `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage` (with CI's
+- [x] AC16 — Test gate: `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage` (with CI's
   `/InIsolation` and `/TestCaseFilter:"TestCategory!=LiveOutlook"`, excluding assemblies under
   `.claude/worktrees`) reports zero failed tests across `QuickFiler.Test` and `TaskMaster.Test`. No
   test in the change carries `[TestCategory("LiveOutlook")]`.
@@ -743,7 +743,7 @@ command. None depends on a live-Outlook manual step. All tests named as new live
   `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/evidence/qa-gates/`,
   and the change is shown not to lower it; the repo-wide figure itself is recorded, not used as a
   blocking threshold, because no baseline evidence existed when this spec was written.
-- [ ] AC18 — Change footprint is exactly `QuickFiler/Controllers/EfcDataModel.cs`,
+- [x] AC18 — Change footprint is exactly `QuickFiler/Controllers/EfcDataModel.cs`,
   `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs`,
   `QuickFiler.Test/QuickFiler.Test.csproj`, and this feature folder's documents and evidence. No
   other production file is modified; in particular
@@ -751,7 +751,7 @@ command. None depends on a live-Outlook manual step. All tests named as new live
   `TaskMaster/AppGlobals/ArchiveRootPathGuard.cs` and
   `UtilitiesCS/Interfaces/IGlobals/IOlObjects.cs` are untouched. Verified by `git diff --name-only`
   against the merge base.
-- [ ] AC19 — `QuickFiler/Controllers/EfcDataModel.cs` remains at or under 500 lines after the change
+- [x] AC19 — `QuickFiler/Controllers/EfcDataModel.cs` remains at or under 500 lines after the change
   (423 lines before). Verified by a line count of the file.
 - [ ] AC20 — The three non-goals in Scope & Non-Goals — (a) `COMException` from the archive-root
   getter's COM calls, (b) the log-only `async void` boundary sinks in

--- a/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md
+++ b/docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md
@@ -734,7 +734,7 @@ command. None depends on a live-Outlook manual step. All tests named as new live
   `/InIsolation` and `/TestCaseFilter:"TestCategory!=LiveOutlook"`, excluding assemblies under
   `.claude/worktrees`) reports zero failed tests across `QuickFiler.Test` and `TaskMaster.Test`. No
   test in the change carries `[TestCategory("LiveOutlook")]`.
-- [ ] AC17 — Coverage: the new helper, the new diagnostic seam, and every changed line in
+- [x] AC17 — Coverage: the new helper, the new diagnostic seam, and every changed line in
   `QuickFiler/Controllers/EfcDataModel.cs` reach **>= 90%** line coverage, and coverage on changed
   lines does not regress against the merge-base baseline. The repository-wide figure against the
   testable denominator is captured and reported for the baseline run under
@@ -753,7 +753,7 @@ command. None depends on a live-Outlook manual step. All tests named as new live
   against the merge base.
 - [x] AC19 — `QuickFiler/Controllers/EfcDataModel.cs` remains at or under 500 lines after the change
   (423 lines before). Verified by a line count of the file.
-- [ ] AC20 — The three non-goals in Scope & Non-Goals — (a) `COMException` from the archive-root
+- [x] AC20 — The three non-goals in Scope & Non-Goals — (a) `COMException` from the archive-root
   getter's COM calls, (b) the log-only `async void` boundary sinks in
   `QuickFiler/Controllers/EfcFormController.cs`, and (c) the five archive-root reads inside
   `QuickFiler/Controllers/EfcFormController.cs` — are each filed as a separate follow-up issue
@@ -812,7 +812,7 @@ command. None depends on a live-Outlook manual step. All tests named as new live
   - Watch the log4net output for the new `Warn` entry from `QuickFiler/Controllers/EfcDataModel.cs`.
     A sustained rate of that entry indicates profiles in the field whose archive root does not
     resolve, which is useful input for non-goal (a).
-  - File the three follow-up issues required by AC20 and record their numbers here.
+  - Filed the three follow-up issues required by AC20 on 2026-08-29: #696, #697 and #698. Their numbers are recorded under Links below.
   - No temporary scaffolding, feature flag, or migration needs removing afterwards.
 
 - Links: issue, PRs, related docs
@@ -830,7 +830,14 @@ command. None depends on a live-Outlook manual step. All tests named as new live
   - Related issues: #614 (store-root leak; introduced the throwing contract this fix honours), #637
     (producer-side rooted-path normalization), #602 (redaction of mailbox addresses in diagnostics).
   - PRs: to be recorded when opened.
-  - Follow-up issues for the three non-goals: to be recorded when filed (AC20).
+  - Follow-up issues for the three non-goals (AC20), filed 2026-08-29 through the
+    promotion lifecycle in `.claude/skills/feature-promotion-lifecycle/SKILL.md`:
+    - Non-goal (a), `COMException` from the archive-root getter's COM calls: #696 —
+      https://github.com/drmoisan/TaskMaster/issues/696
+    - Non-goal (b), the log-only `async void` boundary sinks in `EfcFormController`: #697 —
+      https://github.com/drmoisan/TaskMaster/issues/697
+    - Non-goal (c), the five archive-root reads inside `EfcFormController`: #698 —
+      https://github.com/drmoisan/TaskMaster/issues/698
 
 ## Correction Log
 


### PR DESCRIPTION
# Guard the three unguarded archive-root reads in `EfcDataModel` (#638)

## Summary

- `QuickFiler/Controllers/EfcDataModel.cs` read `Globals.Ol.ArchiveRootPath` at three call sites with no guard. When the Outlook archive root cannot be resolved that read throws `InvalidOperationException`, which unwound out of the filing operation and was absorbed by a log-only fault-boundary sink several frames later. The user was left with a hidden, undisposed form, no message, and no filed mail.
- All three reads now go through one private `TryGetArchiveRoot(out string archiveRoot)` helper that reads the value once inside a narrow `try`, logs a redacted warning on failure, and returns `false`.
- `MoveToFolderAsync` degrades to `return false`, matching the OneDrive guard already in the same method. `OpenOlFolderAsync` and `OpenFsFolderAsync` return `Task` and cannot report through a result, so they surface a redacted message through a new injectable `Action<string>` diagnostic seam.
- The catch is narrowed to `InvalidOperationException` only. A `COMException` from the same getter still propagates, pinned by a test, and is filed as a separate follow-up rather than silently absorbed.
- 11 new MSTest tests, fail-before and pass-after evidence recorded. Changed-line coverage is 93.10%; repository-wide line coverage moves from 85.26% to 85.33%.

## Why

`AppOlObjects.ArchiveRootPath` is a lazily computed property whose validator raises `InvalidOperationException` for an unresolvable root and for a cross-store or renamed root. That throwing contract was introduced deliberately by #614. `EfcDataModel` never adopted it, so every profile whose archive folder does not resolve hit an unhandled exception on the UI thread.

The failure is silent rather than loud because the exception is caught by a log-only boundary sink well past the code that raised it, so the button appears to do nothing. Fixing it at the read sites, rather than at the boundary, keeps the change inside one internal class and lets each call site choose the degrade shape its return type allows.

Both shapes used here already exist in this codebase and are reused rather than invented: the `return false` degrade mirrors the OneDrive `SpecialFolders` guard in the same method, and the injectable action mirrors `EfcHomeController.MoveFailureMessageAction`.

## What Changed

**Core logic (3 files, +455 / -3)**

- `QuickFiler/Controllers/EfcDataModel.cs` (423 to 485 lines)
  - New private `TryGetArchiveRoot(out string archiveRoot)` helper; single read inside `try`, one `logger.Warn` on failure interpolating no path and no mailbox address, `catch (InvalidOperationException)` only.
  - New `internal Action<string> UserDiagnosticAction { get; set; }` seam, defaulting to `MessageBox.Show`. Production never assigns it; tests replace it with a capturing delegate.
  - All three `OlAncestor = Globals.Ol.ArchiveRootPath,` initializer members replaced with `OlAncestor = olAncestor,` fed from the helper.
- `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` (new, 389 lines, 11 tests)
- `QuickFiler.Test/QuickFiler.Test.csproj` — one `Compile Include` registration. This is a legacy non-SDK project, so new files need an explicit entry.

**Docs and evidence**

The remainder of the diff is the feature folder: spec, plan, research, the three review artifacts, and 33 evidence artifacts covering baseline capture, fail-before/pass-after regression runs, the four toolchain gates, and coverage measurement.

No other production file is modified. In particular `EfcFormController.cs`, `AppOlObjects.cs`, `ArchiveRootPathGuard.cs` and `IOlObjects.cs` are untouched.

## Architecture / How It Fits Together

`EfcDataModel` sits between the QuickFiler Email Filer Combined UI and the filing pipeline. Three of its methods build an `EmailFilerConfig` whose `OlAncestor` member is the archive root.

Guard order inside each of the three methods is load-bearing and is now, top to bottom:

1. `MailInfo is null` guard (`MoveToFolderAsync` only) — returns before any COM read.
2. OneDrive `SpecialFolders` guard — returns before any COM read.
3. The new `TryGetArchiveRoot` guard.

The archive-root guard is placed strictly **after** the OneDrive read on purpose. Placing it first would drop `EfcHomeControllerLifecycleTests.cs:217`'s `SpecialFoldersAccessCount == 2` assertion to 0 and would additionally raise `NullReferenceException` from that probe's null `Ol`, which a `catch (InvalidOperationException)` does not absorb. Two tests pin this ordering from the production side using `VerifyGet(..., Times.Never())`.

## Verification

**Completed**

| Gate | Command | Result |
|---|---|---|
| Format | `dotnet tool run csharpier check .` | exit 0, no unformatted files |
| Analyzers | `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true` | `0 Error(s)`, zero `Skipping target "CoreCompile"` |
| Nullable | `msbuild TaskMaster.sln /t:Rebuild /m /p:Configuration=Debug "/p:Platform=Any CPU" /p:TreatWarningsAsErrors=true` | `0 Error(s)`, zero `Skipping target "CoreCompile"` |
| Tests | `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage /InIsolation /TestCaseFilter:"TestCategory!=LiveOutlook"` | 6870 of 6870 passed, 9 assemblies, 0 executed `LiveOutlook` tests |

The analyzer and nullable gates use `/t:Rebuild` rather than `/t:Build`, and the tee'd logs are asserted to contain zero `Skipping target "CoreCompile"` occurrences. A warm `/t:Build` exits 0 with `CoreCompile` skipped on every project and runs no analyzers, so it cannot fail.

**Regression evidence**

- Fail-before: 11 tests, 5 failed, 6 passed. Each of the five failures names `InvalidOperationException`. The run is a genuine runtime failure, not a build failure: the diagnostic seam was declared in a separate earlier phase with no call site so the tests would compile against unfixed production code.
- Pass-after: 11 of 11 passed.
- Ordering sentinels `OpenFolderMethods_DelegateToDataModelWithoutExternalServices` and `HandleMoveResult_WhenMoveFails_RoutesMessageThroughInjectedAction` both still pass, unmodified.

**Coverage**

| Measure | Baseline (merge base) | After | Delta |
|---|---|---|---|
| Changed lines in `EfcDataModel.cs` | n/a | **93.10%** (27 of 29) | — |
| Repository-wide line | 85.26% | 85.33% | +0.07 |
| Repository-wide branch | 79.24% | 79.31% | +0.07 |

Both repository-wide figures are measured over the same post-processed first-party denominator (9 packages). The first baseline attempt produced a raw denominator because a pre-existing flaky wall-clock test terminated the harness before its post-processing step; it was re-measured at the merge base in an isolated worktree with an identical analyzer set and SDK, and that re-measurement is recorded under `evidence/remediation-baseline/`.

The two uncovered changed lines are the `OlAncestor = olAncestor,` initializer members on the success branch of the two `Open*` methods; reaching them requires a live Outlook folder.

**Recommended**

Optionally, on a profile whose archive folder does not resolve, confirm a message appears and the form closes cleanly. No acceptance criterion depends on this.

## Backward Compatibility / Migration Notes

None. No public or internal signature changes: `Task<bool> MoveToFolderAsync(string, bool, bool, bool, bool)`, `Task OpenOlFolderAsync(string)` and `Task OpenFsFolderAsync(string)` are unchanged. No configuration change, no feature flag, no staged rollout. The only behavior change is that an unresolvable archive root now degrades instead of throwing.

## Risks and Mitigations

- **A caller relied on the exception propagating.** Mitigated by the narrow catch: only `InvalidOperationException` from the archive-root read is absorbed, and only at these three sites. `COMException` still propagates, pinned by `MoveToFolderAsync_WhenArchiveRootThrowsComException_StillPropagates`.
- **The guard could mask the OneDrive precondition.** Mitigated by placing it after the OneDrive read and pinning that order from both sides: two new `Times.Never()` tests, plus the untouched `SpecialFoldersAccessCount == 2` sentinel.
- **A redacted diagnostic could leak the mailbox address.** Mitigated by `ArchiveRootFailureDiagnostic_DoesNotContainTheArchivePathOrMailboxAddress`, which asserts the captured message contains neither the mailbox address nor the archive path.
- **Rollback** is a straight revert of the three code files; nothing else depends on the new helper or seam.

## Review Guide

1. `QuickFiler/Controllers/EfcDataModel.cs` — the whole change is here. Read `TryGetArchiveRoot` first, then the three call sites, checking that the OneDrive guard precedes the new guard in each.
2. `QuickFiler.Test/Controllers/EfcDataModelArchiveRootTests.cs` — the `TestableEfcDataModel` fixture is the only arrangement that yields a non-null `MailInfo` without an Outlook COM fixture; its XML doc explains why.
3. `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/spec.md` — 20 acceptance criteria, all checked and independently verified during review.
4. `docs/features/active/2026-08-26-efc-unguarded-archive-root-read-crashes-ui-thread-638/code-review.2026-08-29T13-06.md`, `policy-audit.2026-08-29T13-06.md` and `feature-audit.2026-08-29T13-06.md` — all PASS, zero blocking findings.
5. The remaining evidence files are mechanical gate records; skim rather than read.

## Follow-ups

Filed through the promotion lifecycle. None is a prerequisite for this change.

- #696 — the archive-root getter makes two live COM reads and raises `COMException`, which this change deliberately leaves propagating; decide the handling at the `AppOlObjects` boundary rather than per call site.
- #697 — the five `async void` boundary sinks in `EfcFormController` are log-only, so a failed button press is indistinguishable from a no-op.
- #698 — five equivalent unguarded archive-root reads remain in `EfcFormController` and should adopt the same helper shape.
- #699 — from this change's own code review: the success-path test terminates on an incidental collaborator crash rather than a deliberate stopping point, which would misdirect a future maintainer.

Related context, not acted on here: #614 introduced the throwing contract this change honours, #637 covers producer-side rooted-path normalization, and #602 covers redaction of mailbox addresses in diagnostics.

## GitHub Auto-close

- Closes #638
