### PR TITLE
chore(blast-radius): exclude scripts/vscode/** from write-path derivation

### DIFF
--- a/config/blast-radius.json
+++ b/config/blast-radius.json
@@ -19,7 +19,8 @@
     ".claude/skills/acceptance-criteria-tracking/SKILL.md",
     ".claude/skills/policy-compliance-order/SKILL.md",
     ".claude/agent-memory/**",
-    ".agents/skills/**"
+    ".agents/skills/**",
+    "scripts/vscode/**"
   ],
   "modules": {
     "QuickFiler": [


### PR DESCRIPTION
## Suggested title
chore(blast-radius): exclude scripts/vscode/** from write-path derivation

## Summary
- Adds `"scripts/vscode/**"` to `mandate_reads` in `config/blast-radius.json`.
- Fixes a false-contention source in the parallel-orchestration surface's blast-radius derivation: the toolchain wrapper scripts under `scripts/vscode/` were being counted as write-path citations instead of run-path citations.
- Local stopgap only; `config/blast-radius.json` is push-down-owned from `drm-copilot` and will be overwritten by the next push-down cycle. The equivalent fix has separately been requested upstream.

## Why
Every C# atomic plan in this repository cites the toolchain wrapper scripts under `scripts/vscode/` (`Invoke-MSTestWithCoverage.ps1`, `Invoke-Restore.ps1`, `Install-RepoDotNetSdk.ps1`, etc.) as commands it **runs**, not files it writes. `mandate_reads` already excludes this exact shape of citation for `.claude/rules/**` and `quality-tiers.yml` (see `.claude/rules/parallel-orchestration.md`, "Read-by-mandate classification"), but `scripts/vscode/**` was missing from that list.

Without the exclusion, blast-radius derivation treated every such citation as a genuine write-path overlap, manufacturing a spurious `path_overlap` conflict edge between every pair of C# parallel items that cite the standard toolchain — which is effectively all of them.

## What Changed
**Config**
- `config/blast-radius.json`: one entry added to the `mandate_reads` array.

## Architecture / How It Fits Together
`mandate_reads` is consumed by `Get-BlastRadius`/`derive_blast_radius` to strip citations of mandated-reading paths out of a plan's harvested path list before conflict-edge computation, per the doctrine documented in `.claude/rules/parallel-orchestration.md` ("Blast-Radius Contention Doctrine"). This change extends that exclusion set by one glob; no other logic changes.

## Verification
**Completed**
- JSON syntax validated (`python -m json.tool`).
- Diff reviewed and confirmed as a single isolated addition to `mandate_reads`; no other keys touched.

**Recommended**
- Not verified in this PR: none of the C# toolchain gates (CSharpier, analyzers, nullable, MSTest) exercise this config path, so there is no applicable command beyond CI's standard checks, included for completeness.

## Backward Compatibility / Migration Notes
None. This only narrows what counts as a *citation-based* conflict signal; it does not change scheduling for any item that genuinely writes a file under `scripts/vscode/` — the planner remains obligated to declare such a write explicitly, per the existing mandate-read doctrine's constraint 1.

## Risks and Mitigations
- **Risk:** an item that actually modifies a file under `scripts/vscode/` could under-report its radius if the planner relies on the exclusion instead of declaring the write.
  **Mitigation:** the existing mandate-read doctrine already requires the planner to append a genuine write explicitly regardless of this exclusion (unchanged behavior), and drift detection compares the declared radius against paths actually touched, catching a real write against observed evidence.
- **Rollback:** revert this single-line change.

## Review Guide
Single-file, single-line diff. No suggested review order beyond the diff itself.

## Follow-ups
- The equivalent change has been requested upstream in `drm-copilot`, in both the self-hosted `config/blast-radius.json` and the bundled `extensions/drm-copilot/resources/claude-customizations/config/blast-radius.json`, kept byte-equal per the parity contract, so it survives the next push-down cycle instead of being silently reverted by it.

## GitHub Auto-close
None
